### PR TITLE
feat: harden foundation contracts and seed tooling

### DIFF
--- a/app/agent/invitations/page.tsx
+++ b/app/agent/invitations/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useState, useEffect } from "react";
 import { apiFetch } from "@/lib/api";
+import { readApiData, readApiError } from "@/lib/api-contract";
 import { useToast } from "@/lib/toast";
 
 interface Invitation {
@@ -28,11 +29,18 @@ export default function InvitationsPage() {
   useEffect(() => {
     apiFetch("/api/v1/invitations")
       .then(async (res) => {
-        if (!res.ok) throw new Error("Failed to load");
-        const data = await res.json();
-        setInvitations(data ?? []);
+        if (!res.ok) {
+          throw new Error(await readApiError(res, "Failed to load invitations"));
+        }
+        const data = await readApiData<Invitation[]>(res);
+        setInvitations(data);
       })
-      .catch(() => addToast("Failed to load invitations", "error" as never))
+      .catch((error: unknown) =>
+        addToast(
+          error instanceof Error ? error.message : "Failed to load invitations",
+          "error" as never,
+        ),
+      )
       .finally(() => setLoading(false));
   }, [addToast]);
 

--- a/app/agent/layout.tsx
+++ b/app/agent/layout.tsx
@@ -6,6 +6,7 @@ import AppShell from "@/components/AppShell";
 import Sidebar from "@/components/Sidebar";
 import { ToastProvider } from "@/lib/toast";
 import Copilot from "@/components/Copilot";
+import { isAdminRole, primarySchemeId } from "@/lib/session";
 
 export default function AgentLayout({
   children,
@@ -19,12 +20,12 @@ export default function AgentLayout({
     if (loading) return;
     if (user === null) {
       router.replace("/auth/login");
-    } else if (user.role !== "admin") {
-      router.replace(`/app/${user.scheme_memberships[0]?.scheme_id ?? ""}`);
+    } else if (!isAdminRole(user.role)) {
+      router.replace(`/app/${primarySchemeId(user) ?? ""}`);
     }
   }, [user, loading, router]);
 
-  if (loading || !user || user.role !== "admin") return null;
+  if (loading || !user || !isAdminRole(user.role)) return null;
 
   return (
     <ToastProvider>

--- a/app/app/[schemeId]/layout.tsx
+++ b/app/app/[schemeId]/layout.tsx
@@ -6,6 +6,7 @@ import AppShell from '@/components/AppShell'
 import Sidebar, { type SidebarRole } from '@/components/Sidebar'
 import { ToastProvider } from '@/lib/toast'
 import Copilot from '@/components/Copilot'
+import { hasSchemeMembership, isAdminRole, isResidentRole, primarySchemeId } from '@/lib/session'
 
 export default function SchemeLayout({ children }: { children: React.ReactNode }) {
   const { user, loading } = useAuth()
@@ -18,23 +19,23 @@ export default function SchemeLayout({ children }: { children: React.ReactNode }
     if (!user) { router.replace('/auth/login'); return }
 
     // Admins can access any scheme; trustee/resident must be a member of this specific scheme
-    if (user.role !== 'admin') {
-      const isMember = user.scheme_memberships.some(m => m.scheme_id === schemeId)
+    if (!isAdminRole(user.role)) {
+      const isMember = hasSchemeMembership(user, schemeId)
       if (!isMember) {
-        router.replace(`/app/${user.scheme_memberships[0]?.scheme_id ?? ''}`)
+        router.replace(`/app/${primarySchemeId(user) ?? ''}`)
       }
     }
   }, [user, loading, router, schemeId])
 
   if (loading || !user) return null
 
-  const currentScheme = user.role === 'admin'
+  const currentScheme = isAdminRole(user.role)
     ? user.scheme_memberships.find(m => m.scheme_id === schemeId) ?? user.scheme_memberships[0]
     : user.scheme_memberships.find(m => m.scheme_id === schemeId)
 
   const sidebarRole: SidebarRole =
-    user.role === 'admin' ? 'agent-scheme' :
-    user.role === 'trustee' ? 'trustee' : 'resident'
+    isAdminRole(user.role) ? 'agent-scheme' :
+    isResidentRole(user.role) ? 'resident' : 'trustee'
 
   const headerLabel = currentScheme?.scheme_name ?? schemeId
 

--- a/app/auth/invite/[token]/page.tsx
+++ b/app/auth/invite/[token]/page.tsx
@@ -6,6 +6,8 @@ import Link from 'next/link'
 import LogoIcon from '@/components/LogoIcon'
 import { acceptInviteAction } from '@/lib/auth-actions'
 import { setSessionCookie } from '@/lib/auth'
+import { readApiData, readApiError } from '@/lib/api-contract'
+import { postLoginPath } from '@/lib/session'
 
 interface InviteInfo {
   email: string
@@ -28,10 +30,10 @@ export default function AcceptInvitePage() {
     fetch(`${apiUrl}/api/v1/invitations/${token}`)
       .then(async res => {
         if (!res.ok) {
-          setFetchError('This invite link is invalid or has expired.')
+          setFetchError(await readApiError(res, 'This invite link is invalid or has expired.'))
           return
         }
-        const data = await res.json()
+        const data = await readApiData<InviteInfo>(res)
         setInvite(data)
       })
       .catch(() => setFetchError('Something went wrong — please try again.'))
@@ -50,8 +52,7 @@ export default function AcceptInvitePage() {
     }
 
     setSessionCookie(result.user)
-    const schemeId = result.user.scheme_memberships[0]?.scheme_id ?? ''
-    window.location.replace(`/app/${schemeId}`)
+    window.location.replace(postLoginPath(result.user))
   }
 
   const ROLE_LABELS: Record<string, string> = {

--- a/app/auth/login/page.tsx
+++ b/app/auth/login/page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import LogoIcon from "@/components/LogoIcon";
 import { loginAction } from "@/lib/auth-actions";
 import { setSessionCookie } from "@/lib/auth";
+import { postLoginPath } from "@/lib/session";
 
 export default function LoginPage() {
   const [email, setEmail] = useState("");
@@ -26,13 +27,7 @@ export default function LoginPage() {
 
     const { user } = result;
     setSessionCookie(user);
-    if (user.role === "admin" && !user.wizard_complete) {
-      window.location.replace("/agent/setup");
-    } else if (user.role === "admin") {
-      window.location.replace("/agent");
-    } else {
-      window.location.replace(`/app/${user.scheme_memberships[0]?.scheme_id ?? ""}`);
-    }
+    window.location.replace(postLoginPath(user));
   }
 
   return (

--- a/backend/README.md
+++ b/backend/README.md
@@ -48,6 +48,9 @@ make migrate-up
 # Generate sqlc code
 make generate
 
+# Seed demo users + a scheme
+make seed
+
 # Start the server
 make run
 ```
@@ -131,6 +134,10 @@ backend/
 6. Add tests next to your code (`*_test.go`) and in `tests/integration/`
 
 ## API
+
+## Demo Seed Data
+
+Running `make seed` creates one managing-agent admin, one trustee, one resident, and a demo scheme with representative units. The command is idempotent and prints the login credentials after seeding.
 
 All API routes are prefixed with `/api/v1`.
 

--- a/backend/cmd/seed/main.go
+++ b/backend/cmd/seed/main.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+
+	"github.com/joho/godotenv"
+
+	"github.com/stratahq/backend/internal/config"
+	"github.com/stratahq/backend/internal/platform/database"
+	"github.com/stratahq/backend/internal/seed"
+)
+
+func main() {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+
+	_ = godotenv.Load()
+
+	cfg, err := config.Load()
+	if err != nil {
+		logger.Error("failed to load config", "error", err)
+		os.Exit(1)
+	}
+
+	ctx := context.Background()
+	db, err := database.New(ctx, cfg.DatabaseURL)
+	if err != nil {
+		logger.Error("failed to connect to database", "error", err)
+		os.Exit(1)
+	}
+	defer db.Close()
+
+	result, err := seed.NewService(db).SeedDemo(ctx)
+	if err != nil {
+		logger.Error("failed to seed demo data", "error", err)
+		os.Exit(1)
+	}
+
+	state := "created"
+	if result.AlreadyExisted {
+		state = "already present"
+	}
+
+	fmt.Printf("Demo seed %s\n", state)
+	fmt.Printf("Org: %s (%s)\n", result.OrgName, result.OrgID)
+	fmt.Printf("Scheme: %s (%s)\n", result.SchemeName, result.SchemeID)
+	fmt.Printf("Units seeded: %d\n", result.UnitsSeeded)
+	fmt.Printf("Admin login: %s / %s\n", result.AdminEmail, result.Password)
+	fmt.Printf("Trustee login: %s / %s\n", result.TrusteeEmail, result.Password)
+	fmt.Printf("Resident login: %s / %s\n", result.ResidentEmail, result.Password)
+}

--- a/backend/internal/auth/context.go
+++ b/backend/internal/auth/context.go
@@ -1,0 +1,50 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+)
+
+type Identity struct {
+	UserID string
+	OrgID  string
+	Role   string
+}
+
+func ContextWithIdentity(ctx context.Context, userID, orgID, role string) context.Context {
+	ctx = context.WithValue(ctx, UserIDKey, userID)
+	ctx = context.WithValue(ctx, OrgIDKey, orgID)
+	ctx = context.WithValue(ctx, RoleKey, role)
+	return ctx
+}
+
+func ContextWithClaims(ctx context.Context, claims *Claims) context.Context {
+	if claims == nil {
+		return ctx
+	}
+	return ContextWithIdentity(ctx, claims.Subject, claims.OrgID, claims.Role)
+}
+
+func IdentityFromContext(ctx context.Context) (Identity, bool) {
+	identity := Identity{
+		UserID: valueFromContext(ctx, UserIDKey),
+		OrgID:  valueFromContext(ctx, OrgIDKey),
+		Role:   valueFromContext(ctx, RoleKey),
+	}
+	if identity.UserID == "" || identity.OrgID == "" || identity.Role == "" {
+		return Identity{}, false
+	}
+	return identity, true
+}
+
+func IdentityFromRequest(r *http.Request) (Identity, bool) {
+	if r == nil {
+		return Identity{}, false
+	}
+	return IdentityFromContext(r.Context())
+}
+
+func valueFromContext(ctx context.Context, key ContextKey) string {
+	value, _ := ctx.Value(key).(string)
+	return value
+}

--- a/backend/internal/auth/handler.go
+++ b/backend/internal/auth/handler.go
@@ -37,20 +37,20 @@ type logoutRequest struct {
 func (h *Handler) Register(w http.ResponseWriter, r *http.Request) {
 	var req registerRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		response.Error(w, http.StatusBadRequest, "BAD_REQUEST", "invalid request body")
+		response.Error(w, http.StatusBadRequest, response.CodeBadRequest, "invalid request body")
 		return
 	}
 	if req.Email == "" || req.Password == "" || req.FullName == "" {
-		response.Error(w, http.StatusBadRequest, "BAD_REQUEST", "email, password, and full_name are required")
+		response.Error(w, http.StatusBadRequest, response.CodeBadRequest, "email, password, and full_name are required")
 		return
 	}
 	res, err := h.service.Register(r.Context(), req.Email, req.Password, req.FullName)
 	if err != nil {
 		if err == ErrEmailExists {
-			response.Error(w, http.StatusConflict, "CONFLICT", "email already registered")
+			response.Error(w, http.StatusConflict, response.CodeConflict, "email already registered")
 			return
 		}
-		response.Error(w, http.StatusInternalServerError, "INTERNAL_ERROR", "registration failed")
+		response.Error(w, http.StatusInternalServerError, response.CodeInternalError, "registration failed")
 		return
 	}
 	response.JSON(w, http.StatusCreated, res)
@@ -65,24 +65,27 @@ type setupRequest struct {
 }
 
 func (h *Handler) Setup(w http.ResponseWriter, r *http.Request) {
-	role, _ := r.Context().Value(RoleKey).(string)
-	if role != "admin" {
-		response.Error(w, http.StatusForbidden, "FORBIDDEN", "only org admins can complete onboarding")
+	identity, ok := IdentityFromRequest(r)
+	if !ok {
+		response.Error(w, http.StatusUnauthorized, response.CodeUnauthorized, "missing auth context")
+		return
+	}
+	if !IsAdminRole(identity.Role) {
+		response.Error(w, http.StatusForbidden, response.CodeForbidden, "only org admins can complete onboarding")
 		return
 	}
 	var req setupRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		response.Error(w, http.StatusBadRequest, "BAD_REQUEST", "invalid request body")
+		response.Error(w, http.StatusBadRequest, response.CodeBadRequest, "invalid request body")
 		return
 	}
 	if req.OrgName == "" || req.ContactEmail == "" || req.SchemeName == "" || req.SchemeAddress == "" || req.UnitCount <= 0 {
-		response.Error(w, http.StatusBadRequest, "BAD_REQUEST", "org_name, contact_email, scheme_name, scheme_address, and unit_count are required")
+		response.Error(w, http.StatusBadRequest, response.CodeBadRequest, "org_name, contact_email, scheme_name, scheme_address, and unit_count are required")
 		return
 	}
-	orgID, _ := r.Context().Value(OrgIDKey).(string)
-	res, err := h.service.Setup(r.Context(), orgID, req.OrgName, req.ContactEmail, req.SchemeName, req.SchemeAddress, req.UnitCount)
+	res, err := h.service.Setup(r.Context(), identity.OrgID, req.OrgName, req.ContactEmail, req.SchemeName, req.SchemeAddress, req.UnitCount)
 	if err != nil {
-		response.Error(w, http.StatusInternalServerError, "INTERNAL_ERROR", "onboarding failed")
+		response.Error(w, http.StatusInternalServerError, response.CodeInternalError, "onboarding failed")
 		return
 	}
 	response.JSON(w, http.StatusCreated, res)
@@ -105,42 +108,42 @@ func (h *Handler) ResetPassword(w http.ResponseWriter, r *http.Request) {
 		Password string `json:"password"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		response.Error(w, http.StatusBadRequest, "BAD_REQUEST", "invalid request body")
+		response.Error(w, http.StatusBadRequest, response.CodeBadRequest, "invalid request body")
 		return
 	}
 	if req.Token == "" || req.Password == "" {
-		response.Error(w, http.StatusBadRequest, "BAD_REQUEST", "token and password are required")
+		response.Error(w, http.StatusBadRequest, response.CodeBadRequest, "token and password are required")
 		return
 	}
 	if err := h.service.ResetPassword(r.Context(), req.Token, req.Password); err != nil {
 		if err == ErrInvalidToken {
-			response.Error(w, http.StatusUnauthorized, "UNAUTHORIZED", "invalid or expired reset token")
+			response.Error(w, http.StatusUnauthorized, response.CodeUnauthorized, "invalid or expired reset token")
 			return
 		}
-		response.Error(w, http.StatusInternalServerError, "INTERNAL_ERROR", "password reset failed")
+		response.Error(w, http.StatusInternalServerError, response.CodeInternalError, "password reset failed")
 		return
 	}
-	w.WriteHeader(http.StatusNoContent)
+	response.NoContent(w)
 }
 
 func (h *Handler) Login(w http.ResponseWriter, r *http.Request) {
 	var req loginRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		response.Error(w, http.StatusBadRequest, "BAD_REQUEST", "invalid request body")
+		response.Error(w, http.StatusBadRequest, response.CodeBadRequest, "invalid request body")
 		return
 	}
 	if req.Email == "" || req.Password == "" {
-		response.Error(w, http.StatusBadRequest, "BAD_REQUEST", "email and password are required")
+		response.Error(w, http.StatusBadRequest, response.CodeBadRequest, "email and password are required")
 		return
 	}
 
 	res, err := h.service.Login(r.Context(), req.Email, req.Password)
 	if err != nil {
 		if err == ErrInvalidCredentials {
-			response.Error(w, http.StatusUnauthorized, "UNAUTHORIZED", "invalid credentials")
+			response.Error(w, http.StatusUnauthorized, response.CodeUnauthorized, "invalid credentials")
 			return
 		}
-		response.Error(w, http.StatusInternalServerError, "INTERNAL_ERROR", "login failed")
+		response.Error(w, http.StatusInternalServerError, response.CodeInternalError, "login failed")
 		return
 	}
 	response.JSON(w, http.StatusOK, res)
@@ -149,21 +152,21 @@ func (h *Handler) Login(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) Refresh(w http.ResponseWriter, r *http.Request) {
 	var req refreshRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		response.Error(w, http.StatusBadRequest, "BAD_REQUEST", "invalid request body")
+		response.Error(w, http.StatusBadRequest, response.CodeBadRequest, "invalid request body")
 		return
 	}
 	if req.RefreshToken == "" {
-		response.Error(w, http.StatusBadRequest, "BAD_REQUEST", "refresh_token is required")
+		response.Error(w, http.StatusBadRequest, response.CodeBadRequest, "refresh_token is required")
 		return
 	}
 
 	res, err := h.service.Refresh(r.Context(), req.RefreshToken)
 	if err != nil {
 		if err == ErrInvalidToken {
-			response.Error(w, http.StatusUnauthorized, "UNAUTHORIZED", "invalid or expired token")
+			response.Error(w, http.StatusUnauthorized, response.CodeUnauthorized, "invalid or expired token")
 			return
 		}
-		response.Error(w, http.StatusInternalServerError, "INTERNAL_ERROR", "token refresh failed")
+		response.Error(w, http.StatusInternalServerError, response.CodeInternalError, "token refresh failed")
 		return
 	}
 	response.JSON(w, http.StatusOK, res)
@@ -172,29 +175,28 @@ func (h *Handler) Refresh(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) Logout(w http.ResponseWriter, r *http.Request) {
 	var req logoutRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		response.Error(w, http.StatusBadRequest, "BAD_REQUEST", "invalid request body")
+		response.Error(w, http.StatusBadRequest, response.CodeBadRequest, "invalid request body")
 		return
 	}
 	if req.RefreshToken == "" {
-		response.Error(w, http.StatusBadRequest, "BAD_REQUEST", "refresh_token is required")
+		response.Error(w, http.StatusBadRequest, response.CodeBadRequest, "refresh_token is required")
 		return
 	}
 	// Idempotent — ignore service errors (token may already be revoked)
 	_ = h.service.Logout(r.Context(), req.RefreshToken)
-	w.WriteHeader(http.StatusNoContent)
+	response.NoContent(w)
 }
 
 func (h *Handler) Me(w http.ResponseWriter, r *http.Request) {
-	userID, _ := r.Context().Value(UserIDKey).(string)
-	orgID, _ := r.Context().Value(OrgIDKey).(string)
-	if userID == "" || orgID == "" {
-		response.Error(w, http.StatusUnauthorized, "UNAUTHORIZED", "missing auth context")
+	identity, ok := IdentityFromRequest(r)
+	if !ok {
+		response.Error(w, http.StatusUnauthorized, response.CodeUnauthorized, "missing auth context")
 		return
 	}
 
-	res, err := h.service.Me(r.Context(), userID, orgID)
+	res, err := h.service.Me(r.Context(), identity.UserID, identity.OrgID)
 	if err != nil {
-		response.Error(w, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to fetch user")
+		response.Error(w, http.StatusInternalServerError, response.CodeInternalError, "failed to fetch user")
 		return
 	}
 	response.JSON(w, http.StatusOK, res)

--- a/backend/internal/auth/handler_test.go
+++ b/backend/internal/auth/handler_test.go
@@ -12,27 +12,63 @@ import (
 
 // mockService is a test double for Servicer.
 type mockService struct {
-	registerFn func(ctx context.Context, email, password, fullName, orgName string) (*AuthResponse, error)
+	registerFn func(ctx context.Context, email, password, fullName string) (*AuthResponse, error)
 	loginFn    func(ctx context.Context, email, password string) (*AuthResponse, error)
 	refreshFn  func(ctx context.Context, refreshToken string) (*RefreshResponse, error)
 	logoutFn   func(ctx context.Context, refreshToken string) error
 	meFn       func(ctx context.Context, userID, orgID string) (*MeResponse, error)
+	setupFn    func(ctx context.Context, orgID, orgName, contactEmail, schemeName, schemeAddress string, unitCount int32) (*SetupResponse, error)
+	forgotFn   func(ctx context.Context, email string) error
+	resetFn    func(ctx context.Context, token, password string) error
 }
 
-func (m *mockService) Register(ctx context.Context, email, password, fullName, orgName string) (*AuthResponse, error) {
-	return m.registerFn(ctx, email, password, fullName, orgName)
+func (m *mockService) Register(ctx context.Context, email, password, fullName string) (*AuthResponse, error) {
+	if m.registerFn == nil {
+		return nil, nil
+	}
+	return m.registerFn(ctx, email, password, fullName)
 }
 func (m *mockService) Login(ctx context.Context, email, password string) (*AuthResponse, error) {
+	if m.loginFn == nil {
+		return nil, nil
+	}
 	return m.loginFn(ctx, email, password)
 }
 func (m *mockService) Refresh(ctx context.Context, refreshToken string) (*RefreshResponse, error) {
+	if m.refreshFn == nil {
+		return nil, nil
+	}
 	return m.refreshFn(ctx, refreshToken)
 }
 func (m *mockService) Logout(ctx context.Context, refreshToken string) error {
+	if m.logoutFn == nil {
+		return nil
+	}
 	return m.logoutFn(ctx, refreshToken)
 }
 func (m *mockService) Me(ctx context.Context, userID, orgID string) (*MeResponse, error) {
+	if m.meFn == nil {
+		return nil, nil
+	}
 	return m.meFn(ctx, userID, orgID)
+}
+func (m *mockService) Setup(ctx context.Context, orgID, orgName, contactEmail, schemeName, schemeAddress string, unitCount int32) (*SetupResponse, error) {
+	if m.setupFn == nil {
+		return nil, nil
+	}
+	return m.setupFn(ctx, orgID, orgName, contactEmail, schemeName, schemeAddress, unitCount)
+}
+func (m *mockService) ForgotPassword(ctx context.Context, email string) error {
+	if m.forgotFn == nil {
+		return nil
+	}
+	return m.forgotFn(ctx, email)
+}
+func (m *mockService) ResetPassword(ctx context.Context, token, password string) error {
+	if m.resetFn == nil {
+		return nil
+	}
+	return m.resetFn(ctx, token, password)
 }
 
 // helpers
@@ -67,7 +103,7 @@ func TestRegister_MissingFields(t *testing.T) {
 
 func TestRegister_DuplicateEmail(t *testing.T) {
 	svc := &mockService{
-		registerFn: func(_ context.Context, _, _, _, _ string) (*AuthResponse, error) {
+		registerFn: func(_ context.Context, _, _, _ string) (*AuthResponse, error) {
 			return nil, ErrEmailExists
 		},
 	}
@@ -83,7 +119,7 @@ func TestRegister_DuplicateEmail(t *testing.T) {
 
 func TestRegister_Success(t *testing.T) {
 	svc := &mockService{
-		registerFn: func(_ context.Context, _, _, _, _ string) (*AuthResponse, error) {
+		registerFn: func(_ context.Context, _, _, _ string) (*AuthResponse, error) {
 			return &AuthResponse{
 				AccessToken: "access", RefreshToken: "refresh", ExpiresIn: 900,
 				User: UserInfo{ID: "u1", Email: "a@b.com", FullName: "A B"},
@@ -242,9 +278,7 @@ func TestMe_Success(t *testing.T) {
 		},
 	}
 	req := httptest.NewRequest(http.MethodGet, "/me", nil)
-	ctx := context.WithValue(req.Context(), UserIDKey, "u1")
-	ctx = context.WithValue(ctx, OrgIDKey, "o1")
-	req = req.WithContext(ctx)
+	req = req.WithContext(ContextWithIdentity(req.Context(), "u1", "o1", string(RoleAdmin)))
 	w := httptest.NewRecorder()
 	NewHandler(svc).Me(w, req)
 	if w.Code != http.StatusOK {

--- a/backend/internal/auth/roles.go
+++ b/backend/internal/auth/roles.go
@@ -1,0 +1,32 @@
+package auth
+
+type Role string
+
+const (
+	RoleAdmin    Role = "admin"
+	RoleAgent    Role = "agent"
+	RoleTrustee  Role = "trustee"
+	RoleResident Role = "resident"
+	RoleOwner    Role = "owner"
+)
+
+func IsAdminRole(role string) bool {
+	return role == string(RoleAdmin)
+}
+
+func IsResidentRole(role string) bool {
+	return role == string(RoleResident)
+}
+
+func IsInvitableRole(role string) bool {
+	return role == string(RoleTrustee) || role == string(RoleResident)
+}
+
+func IsSchemeRole(role string) bool {
+	switch role {
+	case string(RoleOwner), string(RoleTrustee), string(RoleResident), string(RoleAdmin):
+		return true
+	default:
+		return false
+	}
+}

--- a/backend/internal/auth/roles_test.go
+++ b/backend/internal/auth/roles_test.go
@@ -1,0 +1,25 @@
+package auth
+
+import "testing"
+
+func TestIsAdminRole(t *testing.T) {
+	if !IsAdminRole("admin") {
+		t.Fatal("expected admin to be recognized as admin role")
+	}
+	if IsAdminRole("trustee") {
+		t.Fatal("did not expect trustee to be recognized as admin role")
+	}
+}
+
+func TestIsInvitableRole(t *testing.T) {
+	for _, role := range []string{"trustee", "resident"} {
+		if !IsInvitableRole(role) {
+			t.Fatalf("expected %q to be invitable", role)
+		}
+	}
+	for _, role := range []string{"admin", "agent", "owner", ""} {
+		if IsInvitableRole(role) {
+			t.Fatalf("did not expect %q to be invitable", role)
+		}
+	}
+}

--- a/backend/internal/invitation/handler.go
+++ b/backend/internal/invitation/handler.go
@@ -20,10 +20,13 @@ func NewHandler(service Servicer, appBaseURL string) *Handler {
 }
 
 func (h *Handler) Create(w http.ResponseWriter, r *http.Request) {
-	orgID, _ := r.Context().Value(auth.OrgIDKey).(string)
-	role, _ := r.Context().Value(auth.RoleKey).(string)
-	if role != "admin" {
-		response.Error(w, http.StatusForbidden, "FORBIDDEN", "only org admins can send invitations")
+	identity, ok := auth.IdentityFromRequest(r)
+	if !ok {
+		response.Error(w, http.StatusUnauthorized, response.CodeUnauthorized, "missing auth context")
+		return
+	}
+	if !auth.IsAdminRole(identity.Role) {
+		response.Error(w, http.StatusForbidden, response.CodeForbidden, "only org admins can send invitations")
 		return
 	}
 
@@ -35,19 +38,23 @@ func (h *Handler) Create(w http.ResponseWriter, r *http.Request) {
 		UnitID   string `json:"unit_id"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		response.Error(w, http.StatusBadRequest, "BAD_REQUEST", "invalid request body")
+		response.Error(w, http.StatusBadRequest, response.CodeBadRequest, "invalid request body")
 		return
 	}
 	if req.Email == "" || req.FullName == "" || req.Role == "" || req.SchemeID == "" {
-		response.Error(w, http.StatusBadRequest, "BAD_REQUEST", "email, full_name, role, and scheme_id are required")
+		response.Error(w, http.StatusBadRequest, response.CodeBadRequest, "email, full_name, role, and scheme_id are required")
+		return
+	}
+	if !auth.IsInvitableRole(req.Role) {
+		response.Error(w, http.StatusBadRequest, response.CodeBadRequest, "role must be trustee or resident")
 		return
 	}
 	if req.Role == "resident" && req.UnitID == "" {
-		response.Error(w, http.StatusBadRequest, "BAD_REQUEST", "unit_id is required for residents")
+		response.Error(w, http.StatusBadRequest, response.CodeBadRequest, "unit_id is required for residents")
 		return
 	}
 
-	inv, err := h.service.Create(r.Context(), orgID, CreateParams{
+	inv, err := h.service.Create(r.Context(), identity.OrgID, CreateParams{
 		Email:    req.Email,
 		FullName: req.FullName,
 		Role:     req.Role,
@@ -57,9 +64,9 @@ func (h *Handler) Create(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		switch err.Error() {
 		case "invalid scheme_id", "invalid unit_id":
-			response.Error(w, http.StatusBadRequest, "BAD_REQUEST", err.Error())
+			response.Error(w, http.StatusBadRequest, response.CodeBadRequest, err.Error())
 		default:
-			response.Error(w, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to create invitation")
+			response.Error(w, http.StatusInternalServerError, response.CodeInternalError, "failed to create invitation")
 		}
 		return
 	}
@@ -67,37 +74,43 @@ func (h *Handler) Create(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) List(w http.ResponseWriter, r *http.Request) {
-	orgID, _ := r.Context().Value(auth.OrgIDKey).(string)
-	role, _ := r.Context().Value(auth.RoleKey).(string)
-	if role != "admin" {
-		response.Error(w, http.StatusForbidden, "FORBIDDEN", "only org admins can list invitations")
+	identity, ok := auth.IdentityFromRequest(r)
+	if !ok {
+		response.Error(w, http.StatusUnauthorized, response.CodeUnauthorized, "missing auth context")
 		return
 	}
-	invs, err := h.service.List(r.Context(), orgID)
+	if !auth.IsAdminRole(identity.Role) {
+		response.Error(w, http.StatusForbidden, response.CodeForbidden, "only org admins can list invitations")
+		return
+	}
+	invs, err := h.service.List(r.Context(), identity.OrgID)
 	if err != nil {
-		response.Error(w, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to list invitations")
+		response.Error(w, http.StatusInternalServerError, response.CodeInternalError, "failed to list invitations")
 		return
 	}
 	response.JSON(w, http.StatusOK, invs)
 }
 
 func (h *Handler) Resend(w http.ResponseWriter, r *http.Request) {
-	orgID, _ := r.Context().Value(auth.OrgIDKey).(string)
-	role, _ := r.Context().Value(auth.RoleKey).(string)
-	if role != "admin" {
-		response.Error(w, http.StatusForbidden, "FORBIDDEN", "only org admins can resend invitations")
+	identity, ok := auth.IdentityFromRequest(r)
+	if !ok {
+		response.Error(w, http.StatusUnauthorized, response.CodeUnauthorized, "missing auth context")
+		return
+	}
+	if !auth.IsAdminRole(identity.Role) {
+		response.Error(w, http.StatusForbidden, response.CodeForbidden, "only org admins can resend invitations")
 		return
 	}
 	id := chi.URLParam(r, "id")
-	inv, err := h.service.Resend(r.Context(), orgID, id, h.appBaseURL)
+	inv, err := h.service.Resend(r.Context(), identity.OrgID, id, h.appBaseURL)
 	if err != nil {
 		switch err {
 		case ErrNotFound:
-			response.Error(w, http.StatusNotFound, "NOT_FOUND", "invitation not found")
+			response.Error(w, http.StatusNotFound, response.CodeNotFound, "invitation not found")
 		case ErrForbidden:
-			response.Error(w, http.StatusForbidden, "FORBIDDEN", "invitation belongs to a different org")
+			response.Error(w, http.StatusForbidden, response.CodeForbidden, "invitation belongs to a different org")
 		default:
-			response.Error(w, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to resend invitation")
+			response.Error(w, http.StatusInternalServerError, response.CodeInternalError, "failed to resend invitation")
 		}
 		return
 	}
@@ -105,32 +118,35 @@ func (h *Handler) Resend(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) Revoke(w http.ResponseWriter, r *http.Request) {
-	orgID, _ := r.Context().Value(auth.OrgIDKey).(string)
-	role, _ := r.Context().Value(auth.RoleKey).(string)
-	if role != "admin" {
-		response.Error(w, http.StatusForbidden, "FORBIDDEN", "only org admins can revoke invitations")
+	identity, ok := auth.IdentityFromRequest(r)
+	if !ok {
+		response.Error(w, http.StatusUnauthorized, response.CodeUnauthorized, "missing auth context")
+		return
+	}
+	if !auth.IsAdminRole(identity.Role) {
+		response.Error(w, http.StatusForbidden, response.CodeForbidden, "only org admins can revoke invitations")
 		return
 	}
 	id := chi.URLParam(r, "id")
-	if err := h.service.Revoke(r.Context(), orgID, id); err != nil {
+	if err := h.service.Revoke(r.Context(), identity.OrgID, id); err != nil {
 		switch err {
 		case ErrNotFound:
-			response.Error(w, http.StatusNotFound, "NOT_FOUND", "invitation not found")
+			response.Error(w, http.StatusNotFound, response.CodeNotFound, "invitation not found")
 		case ErrForbidden:
-			response.Error(w, http.StatusForbidden, "FORBIDDEN", "invitation belongs to a different org")
+			response.Error(w, http.StatusForbidden, response.CodeForbidden, "invitation belongs to a different org")
 		default:
-			response.Error(w, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to revoke invitation")
+			response.Error(w, http.StatusInternalServerError, response.CodeInternalError, "failed to revoke invitation")
 		}
 		return
 	}
-	w.WriteHeader(http.StatusNoContent)
+	response.NoContent(w)
 }
 
 func (h *Handler) Verify(w http.ResponseWriter, r *http.Request) {
 	token := chi.URLParam(r, "token")
 	v, err := h.service.Verify(r.Context(), token)
 	if err != nil {
-		response.Error(w, http.StatusUnauthorized, "UNAUTHORIZED", "invalid or expired invitation token")
+		response.Error(w, http.StatusUnauthorized, response.CodeUnauthorized, "invalid or expired invitation token")
 		return
 	}
 	response.JSON(w, http.StatusOK, v)
@@ -142,18 +158,18 @@ func (h *Handler) Accept(w http.ResponseWriter, r *http.Request) {
 		Password string `json:"password"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.Password == "" {
-		response.Error(w, http.StatusBadRequest, "BAD_REQUEST", "password is required")
+		response.Error(w, http.StatusBadRequest, response.CodeBadRequest, "password is required")
 		return
 	}
 	authResp, err := h.service.Accept(r.Context(), token, req.Password)
 	if err != nil {
 		switch err {
 		case ErrInvalidToken:
-			response.Error(w, http.StatusUnauthorized, "UNAUTHORIZED", "invalid or expired invitation token")
+			response.Error(w, http.StatusUnauthorized, response.CodeUnauthorized, "invalid or expired invitation token")
 		case ErrEmailExists:
-			response.Error(w, http.StatusConflict, "CONFLICT", "email already registered")
+			response.Error(w, http.StatusConflict, response.CodeConflict, "email already registered")
 		default:
-			response.Error(w, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to accept invitation")
+			response.Error(w, http.StatusInternalServerError, response.CodeInternalError, "failed to accept invitation")
 		}
 		return
 	}

--- a/backend/internal/middleware/auth.go
+++ b/backend/internal/middleware/auth.go
@@ -1,7 +1,6 @@
 package middleware
 
 import (
-	"context"
 	"net/http"
 	"strings"
 
@@ -35,14 +34,11 @@ func Auth(jwtSecret string) func(http.Handler) http.Handler {
 
 			claims, err := auth.ValidateAccessToken(tokenStr, jwtSecret)
 			if err != nil {
-				response.Error(w, http.StatusUnauthorized, "UNAUTHORIZED", "invalid or expired token")
+				response.Error(w, http.StatusUnauthorized, response.CodeUnauthorized, "invalid or expired token")
 				return
 			}
 
-			ctx := context.WithValue(r.Context(), auth.UserIDKey, claims.Subject)
-			ctx = context.WithValue(ctx, auth.OrgIDKey, claims.OrgID)
-			ctx = context.WithValue(ctx, auth.RoleKey, claims.Role)
-			next.ServeHTTP(w, r.WithContext(ctx))
+			next.ServeHTTP(w, r.WithContext(auth.ContextWithClaims(r.Context(), claims)))
 		})
 	}
 }

--- a/backend/internal/platform/response/codes.go
+++ b/backend/internal/platform/response/codes.go
@@ -1,0 +1,18 @@
+package response
+
+import "net/http"
+
+const (
+	CodeBadRequest    = "BAD_REQUEST"
+	CodeConflict      = "CONFLICT"
+	CodeForbidden     = "FORBIDDEN"
+	CodeInternalError = "INTERNAL_ERROR"
+	CodeNotFound      = "NOT_FOUND"
+	CodeNotReady      = "NOT_READY"
+	CodeRateLimited   = "RATE_LIMITED"
+	CodeUnauthorized  = "UNAUTHORIZED"
+)
+
+func NoContent(w http.ResponseWriter) {
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/backend/internal/seed/service.go
+++ b/backend/internal/seed/service.go
@@ -1,0 +1,242 @@
+package seed
+
+import (
+	"context"
+	"errors"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+	"golang.org/x/crypto/bcrypt"
+
+	dbgen "github.com/stratahq/backend/db/gen"
+	"github.com/stratahq/backend/internal/auth"
+	"github.com/stratahq/backend/internal/platform/database"
+)
+
+const (
+	DemoPassword      = "StrataHQ123!"
+	DemoAdminEmail    = "agent@demo.stratahq.test"
+	DemoTrusteeEmail  = "trustee@demo.stratahq.test"
+	DemoResidentEmail = "resident@demo.stratahq.test"
+)
+
+var demoUnits = []struct {
+	Identifier       string
+	OwnerName        string
+	Floor            int32
+	SectionValueBps  int32
+	ResidentEmail    string
+	ResidentFullName string
+	ResidentRole     string
+	ShouldAttachUser bool
+}{
+	{Identifier: "1A", OwnerName: "Henderson, T.", Floor: 1, SectionValueBps: 417},
+	{Identifier: "2B", OwnerName: "Molefe, S.", Floor: 2, SectionValueBps: 417},
+	{Identifier: "3A", OwnerName: "van der Berg, L.", Floor: 3, SectionValueBps: 417},
+	{Identifier: "4B", OwnerName: "Naidoo, R.", Floor: 4, SectionValueBps: 417, ResidentEmail: DemoResidentEmail, ResidentFullName: "Riya Naidoo", ResidentRole: string(auth.RoleResident), ShouldAttachUser: true},
+	{Identifier: "5A", OwnerName: "Khumalo, B.", Floor: 5, SectionValueBps: 417},
+	{Identifier: "6C", OwnerName: "Abrahams, J.", Floor: 6, SectionValueBps: 417},
+	{Identifier: "7B", OwnerName: "Petersen, M.", Floor: 7, SectionValueBps: 417},
+	{Identifier: "8A", OwnerName: "Dlamini, S.", Floor: 8, SectionValueBps: 417},
+}
+
+type Service struct {
+	db *database.Pool
+}
+
+type Result struct {
+	AlreadyExisted bool
+	OrgName        string
+	OrgID          string
+	SchemeName     string
+	SchemeID       string
+	UnitsSeeded    int
+	AdminEmail     string
+	TrusteeEmail   string
+	ResidentEmail  string
+	Password       string
+}
+
+func NewService(db *database.Pool) *Service {
+	return &Service{db: db}
+}
+
+func (s *Service) SeedDemo(ctx context.Context) (*Result, error) {
+	adminUser, err := s.db.Q.GetUserByEmail(ctx, DemoAdminEmail)
+	if err == nil {
+		return s.describeExisting(ctx, adminUser.ID)
+	}
+	if !errors.Is(err, pgx.ErrNoRows) {
+		return nil, err
+	}
+
+	passwordHash, err := bcrypt.GenerateFromPassword([]byte(DemoPassword), 12)
+	if err != nil {
+		return nil, err
+	}
+
+	result := &Result{
+		OrgName:       "Demo Property Management",
+		SchemeName:    "Sunridge Heights",
+		UnitsSeeded:   len(demoUnits),
+		AdminEmail:    DemoAdminEmail,
+		TrusteeEmail:  DemoTrusteeEmail,
+		ResidentEmail: DemoResidentEmail,
+		Password:      DemoPassword,
+	}
+
+	err = database.WithTxQueries(ctx, s.db, func(q *dbgen.Queries) error {
+		adminUser, txErr := q.CreateUser(ctx, dbgen.CreateUserParams{
+			Email:        DemoAdminEmail,
+			PasswordHash: string(passwordHash),
+			FullName:     "Demo Agent",
+		})
+		if txErr != nil {
+			return txErr
+		}
+
+		org, txErr := q.CreateOrg(ctx, result.OrgName)
+		if txErr != nil {
+			return txErr
+		}
+		result.OrgID = org.ID.String()
+
+		if _, txErr = q.UpdateOrg(ctx, dbgen.UpdateOrgParams{
+			Name:         result.OrgName,
+			ContactEmail: pgtype.Text{String: DemoAdminEmail, Valid: true},
+			ID:           org.ID,
+		}); txErr != nil {
+			return txErr
+		}
+
+		if _, txErr = q.CreateOrgMembership(ctx, dbgen.CreateOrgMembershipParams{
+			UserID: adminUser.ID,
+			OrgID:  org.ID,
+			Role:   string(auth.RoleAdmin),
+		}); txErr != nil {
+			return txErr
+		}
+
+		scheme, txErr := q.CreateScheme(ctx, dbgen.CreateSchemeParams{
+			OrgID:     org.ID,
+			Name:      result.SchemeName,
+			Address:   "14 Sunridge Drive, Claremont, Cape Town, 7708",
+			UnitCount: 24,
+		})
+		if txErr != nil {
+			return txErr
+		}
+		result.SchemeID = scheme.ID.String()
+
+		var residentUnitID pgtype.UUID
+		for _, unit := range demoUnits {
+			unitRow, unitErr := q.CreateUnit(ctx, dbgen.CreateUnitParams{
+				SchemeID:        scheme.ID,
+				Identifier:      unit.Identifier,
+				OwnerName:       unit.OwnerName,
+				Floor:           unit.Floor,
+				SectionValueBps: unit.SectionValueBps,
+			})
+			if unitErr != nil {
+				return unitErr
+			}
+			if unit.ShouldAttachUser {
+				residentUnitID = pgtype.UUID{Bytes: unitRow.ID, Valid: true}
+			}
+		}
+
+		trusteeUser, txErr := q.CreateUser(ctx, dbgen.CreateUserParams{
+			Email:        DemoTrusteeEmail,
+			PasswordHash: string(passwordHash),
+			FullName:     "Tina Trustee",
+		})
+		if txErr != nil {
+			return txErr
+		}
+		if _, txErr = q.CreateOrgMembership(ctx, dbgen.CreateOrgMembershipParams{
+			UserID: trusteeUser.ID,
+			OrgID:  org.ID,
+			Role:   string(auth.RoleTrustee),
+		}); txErr != nil {
+			return txErr
+		}
+		if _, txErr = q.UpsertSchemeMembership(ctx, dbgen.UpsertSchemeMembershipParams{
+			UserID:   trusteeUser.ID,
+			SchemeID: scheme.ID,
+			UnitID:   pgtype.UUID{},
+			Role:     string(auth.RoleTrustee),
+		}); txErr != nil {
+			return txErr
+		}
+
+		residentUser, txErr := q.CreateUser(ctx, dbgen.CreateUserParams{
+			Email:        DemoResidentEmail,
+			PasswordHash: string(passwordHash),
+			FullName:     "Riya Naidoo",
+		})
+		if txErr != nil {
+			return txErr
+		}
+		if _, txErr = q.CreateOrgMembership(ctx, dbgen.CreateOrgMembershipParams{
+			UserID: residentUser.ID,
+			OrgID:  org.ID,
+			Role:   string(auth.RoleResident),
+		}); txErr != nil {
+			return txErr
+		}
+		if _, txErr = q.UpsertSchemeMembership(ctx, dbgen.UpsertSchemeMembershipParams{
+			UserID:   residentUser.ID,
+			SchemeID: scheme.ID,
+			UnitID:   residentUnitID,
+			Role:     string(auth.RoleResident),
+		}); txErr != nil {
+			return txErr
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+func (s *Service) describeExisting(ctx context.Context, adminUserID uuid.UUID) (*Result, error) {
+	memberships, err := s.db.Q.ListOrgMembershipsByUser(ctx, adminUserID)
+	if err != nil {
+		return nil, err
+	}
+	if len(memberships) == 0 {
+		return nil, errors.New("seeded admin user has no org memberships")
+	}
+
+	orgID := memberships[0].OrgID
+	schemes, err := s.db.Q.ListSchemesByOrg(ctx, orgID)
+	if err != nil {
+		return nil, err
+	}
+
+	result := &Result{
+		AlreadyExisted: true,
+		OrgName:        memberships[0].OrgName,
+		OrgID:          orgID.String(),
+		AdminEmail:     DemoAdminEmail,
+		TrusteeEmail:   DemoTrusteeEmail,
+		ResidentEmail:  DemoResidentEmail,
+		Password:       DemoPassword,
+	}
+
+	if len(schemes) > 0 {
+		result.SchemeID = schemes[0].ID.String()
+		result.SchemeName = schemes[0].Name
+		units, unitErr := s.db.Q.ListUnitsByScheme(ctx, schemes[0].ID)
+		if unitErr != nil {
+			return nil, unitErr
+		}
+		result.UnitsSeeded = len(units)
+	}
+
+	return result, nil
+}

--- a/backend/scripts/seed.sh
+++ b/backend/scripts/seed.sh
@@ -4,7 +4,4 @@ set -euo pipefail
 DATABASE_URL="${DATABASE_URL:?DATABASE_URL is required}"
 
 echo "Seeding database..."
-# Add seed SQL commands here as the schema is built out.
-# Example:
-# psql "$DATABASE_URL" -f db/seed.sql
-echo "No seed data configured yet. Add seed SQL to this script."
+go run ./cmd/seed

--- a/backend/tests/integration/auth_test.go
+++ b/backend/tests/integration/auth_test.go
@@ -14,10 +14,8 @@ import (
 	"testing"
 	"time"
 
-	dbgen "github.com/stratahq/backend/db/gen"
 	"github.com/stratahq/backend/internal/auth"
 	"github.com/stratahq/backend/internal/notification"
-	"github.com/stratahq/backend/internal/platform/database"
 )
 
 const (
@@ -27,9 +25,8 @@ const (
 
 func newAuthHandler(t *testing.T) *auth.Handler {
 	t.Helper()
-	pool := &database.Pool{Pool: testDB, Q: dbgen.New(testDB)}
 	sender := &notification.NoopSender{}
-	svc := auth.NewService(pool, testRedis, sender, testJWTSigningKey, "http://localhost:3000", 15*time.Minute, 7*24*time.Hour)
+	svc := auth.NewService(testPool, testRedis, sender, testJWTSigningKey, "http://localhost:3000", 15*time.Minute, 7*24*time.Hour)
 	return auth.NewHandler(svc)
 }
 
@@ -38,25 +35,6 @@ func uniqueEmail(t *testing.T) string {
 	b := make([]byte, 4)
 	_, _ = rand.Read(b)
 	return fmt.Sprintf("%s-%x@test.example.com", safe, b)
-}
-
-// withAuthContext injects JWT claims into request context (simulates auth middleware).
-func withAuthContext(r *http.Request, accessToken, jwtSecret string) *http.Request {
-	claims, err := auth.ValidateAccessToken(accessToken, jwtSecret)
-	if err != nil {
-		panic("withAuthContext: invalid token: " + err.Error())
-	}
-	ctx := context.WithValue(r.Context(), auth.UserIDKey, claims.Subject)
-	ctx = context.WithValue(ctx, auth.OrgIDKey, claims.OrgID)
-	ctx = context.WithValue(ctx, auth.RoleKey, claims.Role)
-	return r.WithContext(ctx)
-}
-
-func withNonAdminContext(r *http.Request) *http.Request {
-	ctx := context.WithValue(r.Context(), auth.UserIDKey, "00000000-0000-0000-0000-000000000001")
-	ctx = context.WithValue(ctx, auth.OrgIDKey, "00000000-0000-0000-0000-000000000002")
-	ctx = context.WithValue(ctx, auth.RoleKey, "trustee")
-	return r.WithContext(ctx)
 }
 
 func TestAuth_RegisterLoginRefreshLogout(t *testing.T) {
@@ -193,17 +171,9 @@ func TestAuth_Me(t *testing.T) {
 	}
 	json.NewDecoder(w.Body).Decode(&regResp)
 
-	// Parse claims from the access token to get userID and orgID
-	claims, err := auth.ValidateAccessToken(regResp.Data.AccessToken, testJWTSigningKey)
-	if err != nil {
-		t.Fatalf("ValidateAccessToken: %v", err)
-	}
-
 	// Call Me with context values the middleware would normally inject
 	req = httptest.NewRequest(http.MethodGet, "/me", nil)
-	ctx := context.WithValue(req.Context(), auth.UserIDKey, claims.Subject)
-	ctx = context.WithValue(ctx, auth.OrgIDKey, claims.OrgID)
-	req = req.WithContext(ctx)
+	req = withAuthContext(req, regResp.Data.AccessToken, testJWTSigningKey)
 	w = httptest.NewRecorder()
 	h.Me(w, req)
 	if w.Code != http.StatusOK {
@@ -236,7 +206,9 @@ func TestAuth_SetupOnboarding(t *testing.T) {
 	if w.Code != http.StatusCreated {
 		t.Fatalf("register: status=%d body=%s", w.Code, w.Body)
 	}
-	var regResp struct{ Data auth.AuthResponse `json:"data"` }
+	var regResp struct {
+		Data auth.AuthResponse `json:"data"`
+	}
 	json.NewDecoder(w.Body).Decode(&regResp)
 	accessToken := regResp.Data.AccessToken
 
@@ -248,7 +220,9 @@ func TestAuth_SetupOnboarding(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("me pre-onboarding: status=%d body=%s", w.Code, w.Body)
 	}
-	var meResp struct{ Data auth.MeResponse `json:"data"` }
+	var meResp struct {
+		Data auth.MeResponse `json:"data"`
+	}
 	json.NewDecoder(w.Body).Decode(&meResp)
 	if meResp.Data.WizardComplete {
 		t.Error("expected wizard_complete=false before onboarding")
@@ -270,7 +244,9 @@ func TestAuth_SetupOnboarding(t *testing.T) {
 	if w.Code != http.StatusCreated {
 		t.Fatalf("setup: status=%d body=%s", w.Code, w.Body)
 	}
-	var setupResp struct{ Data auth.SetupResponse `json:"data"` }
+	var setupResp struct {
+		Data auth.SetupResponse `json:"data"`
+	}
 	json.NewDecoder(w.Body).Decode(&setupResp)
 	if setupResp.Data.Org.Name != "Sunset Heights" {
 		t.Errorf("setup: org name=%q, want Sunset Heights", setupResp.Data.Org.Name)

--- a/backend/tests/integration/invitation_test.go
+++ b/backend/tests/integration/invitation_test.go
@@ -14,18 +14,15 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 
-	dbgen "github.com/stratahq/backend/db/gen"
 	"github.com/stratahq/backend/internal/auth"
 	"github.com/stratahq/backend/internal/invitation"
 	"github.com/stratahq/backend/internal/notification"
-	"github.com/stratahq/backend/internal/platform/database"
 )
 
 func newInvitationHandler(t *testing.T) (*invitation.Handler, *notification.NoopSender) {
 	t.Helper()
-	pool := &database.Pool{Pool: testDB, Q: dbgen.New(testDB)}
 	sender := &notification.NoopSender{}
-	svc := invitation.NewService(pool, sender, testJWTSigningKey, 15*time.Minute, 7*24*time.Hour)
+	svc := invitation.NewService(testPool, sender, testJWTSigningKey, 15*time.Minute, 7*24*time.Hour)
 	return invitation.NewHandler(svc, "http://localhost:3000"), sender
 }
 
@@ -42,7 +39,9 @@ func setupAgent(t *testing.T) (accessToken, orgID string) {
 	if w.Code != http.StatusCreated {
 		t.Fatalf("setupAgent register: %d %s", w.Code, w.Body)
 	}
-	var resp struct{ Data auth.AuthResponse `json:"data"` }
+	var resp struct {
+		Data auth.AuthResponse `json:"data"`
+	}
 	json.NewDecoder(w.Body).Decode(&resp)
 	// Extract orgID from JWT claims
 	claims, err := auth.ValidateAccessToken(resp.Data.AccessToken, testJWTSigningKey)
@@ -67,15 +66,11 @@ func setupScheme(t *testing.T, accessToken string) string {
 	if w.Code != http.StatusCreated {
 		t.Fatalf("setupScheme: %d %s", w.Code, w.Body)
 	}
-	var resp struct{ Data auth.SetupResponse `json:"data"` }
+	var resp struct {
+		Data auth.SetupResponse `json:"data"`
+	}
 	json.NewDecoder(w.Body).Decode(&resp)
 	return resp.Data.Scheme.ID
-}
-
-func withOrgRoleContext(r *http.Request, orgID, role string) *http.Request {
-	ctx := context.WithValue(r.Context(), auth.OrgIDKey, orgID)
-	ctx = context.WithValue(ctx, auth.RoleKey, role)
-	return r.WithContext(ctx)
 }
 
 func TestInvitation_CreateListRevokeResend(t *testing.T) {
@@ -99,7 +94,9 @@ func TestInvitation_CreateListRevokeResend(t *testing.T) {
 	if len(sender.InvitationsSent) != 1 || sender.InvitationsSent[0] != trusteeEmail {
 		t.Errorf("expected 1 invitation email to %s, got %v", trusteeEmail, sender.InvitationsSent)
 	}
-	var invResp struct{ Data invitation.InvitationResponse `json:"data"` }
+	var invResp struct {
+		Data invitation.InvitationResponse `json:"data"`
+	}
 	json.NewDecoder(w.Body).Decode(&invResp)
 	invID := invResp.Data.ID
 	if invID == "" {
@@ -114,7 +111,9 @@ func TestInvitation_CreateListRevokeResend(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("list: %d %s", w.Code, w.Body)
 	}
-	var listResp struct{ Data []invitation.InvitationResponse `json:"data"` }
+	var listResp struct {
+		Data []invitation.InvitationResponse `json:"data"`
+	}
 	json.NewDecoder(w.Body).Decode(&listResp)
 	if len(listResp.Data) != 1 {
 		t.Errorf("list: expected 1, got %d", len(listResp.Data))
@@ -127,8 +126,7 @@ func TestInvitation_CreateListRevokeResend(t *testing.T) {
 	rctx := chi.NewRouteContext()
 	rctx.URLParams.Add("id", invID)
 	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
-	ctx = context.WithValue(ctx, auth.OrgIDKey, orgID)
-	ctx = context.WithValue(ctx, auth.RoleKey, "admin")
+	ctx = auth.ContextWithIdentity(ctx, "00000000-0000-0000-0000-000000000003", orgID, string(auth.RoleAdmin))
 	req = req.WithContext(ctx)
 	w = httptest.NewRecorder()
 	ih.Resend(w, req)
@@ -144,8 +142,7 @@ func TestInvitation_CreateListRevokeResend(t *testing.T) {
 	rctx = chi.NewRouteContext()
 	rctx.URLParams.Add("id", invID)
 	ctx = context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
-	ctx = context.WithValue(ctx, auth.OrgIDKey, orgID)
-	ctx = context.WithValue(ctx, auth.RoleKey, "admin")
+	ctx = auth.ContextWithIdentity(ctx, "00000000-0000-0000-0000-000000000003", orgID, string(auth.RoleAdmin))
 	req = req.WithContext(ctx)
 	w = httptest.NewRecorder()
 	ih.Revoke(w, req)
@@ -185,12 +182,11 @@ func TestInvitation_AcceptFlow(t *testing.T) {
 
 	// Read token directly from DB
 	ctx := context.Background()
-	pool := &database.Pool{Pool: testDB, Q: dbgen.New(testDB)}
 	oid, err := uuid.Parse(orgID)
 	if err != nil {
 		t.Fatalf("uuid.Parse orgID: %v", err)
 	}
-	invs, err := pool.Q.ListInvitationsByOrg(ctx, oid)
+	invs, err := testQ.ListInvitationsByOrg(ctx, oid)
 	if err != nil || len(invs) == 0 {
 		t.Fatalf("no invitations in DB: err=%v, count=%d", err, len(invs))
 	}
@@ -206,7 +202,9 @@ func TestInvitation_AcceptFlow(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("verify: %d %s", w.Code, w.Body)
 	}
-	var vResp struct{ Data invitation.VerifyResponse `json:"data"` }
+	var vResp struct {
+		Data invitation.VerifyResponse `json:"data"`
+	}
 	json.NewDecoder(w.Body).Decode(&vResp)
 	if vResp.Data.Email != trusteeEmail {
 		t.Errorf("verify: email=%q, want %q", vResp.Data.Email, trusteeEmail)
@@ -223,7 +221,9 @@ func TestInvitation_AcceptFlow(t *testing.T) {
 	if w.Code != http.StatusCreated {
 		t.Fatalf("accept: %d %s", w.Code, w.Body)
 	}
-	var authResp struct{ Data auth.AuthResponse `json:"data"` }
+	var authResp struct {
+		Data auth.AuthResponse `json:"data"`
+	}
 	json.NewDecoder(w.Body).Decode(&authResp)
 	if authResp.Data.AccessToken == "" {
 		t.Fatal("accept: missing access token")

--- a/backend/tests/integration/seed_test.go
+++ b/backend/tests/integration/seed_test.go
@@ -1,0 +1,36 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stratahq/backend/internal/seed"
+)
+
+func TestSeedDemo_IsIdempotent(t *testing.T) {
+	service := seed.NewService(testPool)
+
+	first, err := service.SeedDemo(context.Background())
+	if err != nil {
+		t.Fatalf("first seed failed: %v", err)
+	}
+	if first.OrgID == "" || first.SchemeID == "" {
+		t.Fatalf("expected org and scheme ids to be populated, got org=%q scheme=%q", first.OrgID, first.SchemeID)
+	}
+	if first.UnitsSeeded != 8 {
+		t.Fatalf("expected 8 units seeded, got %d", first.UnitsSeeded)
+	}
+
+	second, err := service.SeedDemo(context.Background())
+	if err != nil {
+		t.Fatalf("second seed failed: %v", err)
+	}
+	if !second.AlreadyExisted {
+		t.Fatal("expected second seed run to report existing demo data")
+	}
+	if second.OrgID != first.OrgID {
+		t.Fatalf("expected same org id on second seed run, got %q and %q", first.OrgID, second.OrgID)
+	}
+}

--- a/backend/tests/integration/testhelpers_test.go
+++ b/backend/tests/integration/testhelpers_test.go
@@ -4,16 +4,25 @@ package integration
 
 import (
 	"context"
+	"encoding/json"
 	"log/slog"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"testing"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/redis/go-redis/v9"
+	dbgen "github.com/stratahq/backend/db/gen"
+
+	"github.com/stratahq/backend/internal/auth"
+	"github.com/stratahq/backend/internal/platform/database"
 )
 
 var (
 	testDB    *pgxpool.Pool
+	testPool  *database.Pool
+	testQ     *dbgen.Queries
 	testRedis *redis.Client
 	testLog   *slog.Logger
 )
@@ -44,6 +53,8 @@ func TestMain(m *testing.M) {
 		testLog.Error("failed to connect to test database", "error", err)
 		os.Exit(1)
 	}
+	testPool = &database.Pool{Pool: testDB, Q: dbgen.New(testDB)}
+	testQ = testPool.Q
 	defer testDB.Close()
 
 	// Redis
@@ -61,4 +72,59 @@ func TestMain(m *testing.M) {
 	defer testRedis.Close()
 
 	os.Exit(m.Run())
+}
+
+type successEnvelope[T any] struct {
+	Data T `json:"data"`
+}
+
+type errorEnvelope struct {
+	Error struct {
+		Code    string `json:"code"`
+		Message string `json:"message"`
+	} `json:"error"`
+}
+
+func decodeSuccess[T any](t *testing.T, recorder *httptest.ResponseRecorder) T {
+	t.Helper()
+	var envelope successEnvelope[T]
+	if err := json.NewDecoder(recorder.Body).Decode(&envelope); err != nil {
+		t.Fatalf("decode success envelope: %v", err)
+	}
+	return envelope.Data
+}
+
+func decodeError(t *testing.T, recorder *httptest.ResponseRecorder) errorEnvelope {
+	t.Helper()
+	var envelope errorEnvelope
+	if err := json.NewDecoder(recorder.Body).Decode(&envelope); err != nil {
+		t.Fatalf("decode error envelope: %v", err)
+	}
+	return envelope
+}
+
+func withAuthContext(r *http.Request, accessToken, jwtSecret string) *http.Request {
+	tClaims, err := auth.ValidateAccessToken(accessToken, jwtSecret)
+	if err != nil {
+		panic("withAuthContext: invalid token: " + err.Error())
+	}
+	return r.WithContext(auth.ContextWithClaims(r.Context(), tClaims))
+}
+
+func withNonAdminContext(r *http.Request) *http.Request {
+	return r.WithContext(auth.ContextWithIdentity(
+		r.Context(),
+		"00000000-0000-0000-0000-000000000001",
+		"00000000-0000-0000-0000-000000000002",
+		string(auth.RoleTrustee),
+	))
+}
+
+func withOrgRoleContext(r *http.Request, orgID, role string) *http.Request {
+	return r.WithContext(auth.ContextWithIdentity(
+		r.Context(),
+		"00000000-0000-0000-0000-000000000003",
+		orgID,
+		role,
+	))
 }

--- a/components/Copilot.tsx
+++ b/components/Copilot.tsx
@@ -1,6 +1,7 @@
 'use client'
 import { useState, useRef, useEffect } from 'react'
 import { useAuth } from '@/lib/auth'
+import { isResidentRole } from '@/lib/session'
 
 interface Message {
   role: 'user' | 'assistant'
@@ -26,7 +27,7 @@ export default function Copilot() {
   const inputRef = useRef<HTMLTextAreaElement>(null)
 
   // Only available for agents and trustees
-  if (!user || user.role === 'resident') return null
+  if (!user || isResidentRole(user.role)) return null
 
   // eslint-disable-next-line react-hooks/rules-of-hooks
   useEffect(() => {

--- a/lib/api-contract.test.ts
+++ b/lib/api-contract.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getApiErrorMessage,
+  unwrapApiData,
+} from "./api-contract";
+
+describe("unwrapApiData", () => {
+  it("unwraps data envelopes", () => {
+    expect(unwrapApiData<{ id: string }>({ data: { id: "abc" } })).toEqual({
+      id: "abc",
+    });
+  });
+
+  it("returns raw payloads when no envelope exists", () => {
+    expect(unwrapApiData<string[]>(["a", "b"])).toEqual(["a", "b"]);
+  });
+});
+
+describe("getApiErrorMessage", () => {
+  it("prefers the backend error message", () => {
+    expect(
+      getApiErrorMessage(
+        { error: { code: "BAD_REQUEST", message: "invalid request body" } },
+        "fallback",
+      ),
+    ).toBe("invalid request body");
+  });
+
+  it("falls back when the payload is not an api error", () => {
+    expect(getApiErrorMessage({ nope: true }, "fallback")).toBe("fallback");
+  });
+});

--- a/lib/api-contract.ts
+++ b/lib/api-contract.ts
@@ -1,0 +1,70 @@
+export interface ApiMeta {
+  page: number;
+  per_page: number;
+  total: number;
+}
+
+export interface ApiSuccess<T> {
+  data: T;
+  meta?: ApiMeta;
+}
+
+export interface ApiErrorBody {
+  code: string;
+  message: string;
+}
+
+export interface ApiErrorResponse {
+  error: ApiErrorBody;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+export async function readApiBody(response: Response): Promise<unknown> {
+  const text = await response.text();
+  if (!text) return null;
+
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+export function unwrapApiData<T>(body: unknown): T {
+  if (isRecord(body) && "data" in body) {
+    return body.data as T;
+  }
+
+  return body as T;
+}
+
+export function getApiErrorMessage(body: unknown, fallback: string): string {
+  if (isRecord(body) && "error" in body && isRecord(body.error)) {
+    const message = body.error.message;
+    if (typeof message === "string" && message.trim() !== "") {
+      return message;
+    }
+  }
+
+  if (typeof body === "string" && body.trim() !== "") {
+    return body;
+  }
+
+  return fallback;
+}
+
+export async function readApiData<T>(response: Response): Promise<T> {
+  const body = await readApiBody(response);
+  return unwrapApiData<T>(body);
+}
+
+export async function readApiError(
+  response: Response,
+  fallback: string,
+): Promise<string> {
+  const body = await readApiBody(response);
+  return getApiErrorMessage(body, fallback);
+}

--- a/lib/auth-actions.ts
+++ b/lib/auth-actions.ts
@@ -1,7 +1,9 @@
 "use server";
 
 import { cookies } from "next/headers";
-import type { SessionUser } from "./auth";
+import { readApiData, readApiError } from "./api-contract";
+import type { SessionUser } from "./session";
+import { APP_ROLES } from "./session";
 
 const BACKEND = () => process.env.BACKEND_URL ?? "http://localhost:8080";
 
@@ -58,9 +60,7 @@ async function fetchMe(accessToken: string): Promise<SessionUser | null> {
     headers: { Authorization: `Bearer ${accessToken}` },
   });
   if (!res.ok) return null;
-  const body = await res.json();
-  // Unwrap { data: ... } envelope if present
-  return body.data ?? body;
+  return readApiData<SessionUser>(res);
 }
 
 // ─── Login ────────────────────────────────────────────────────────────────────
@@ -77,22 +77,27 @@ export async function loginAction(
 
   if (!res.ok) {
     return {
-      error:
+      error: await readApiError(
+        res,
         res.status === 401
           ? "Invalid email or password"
           : "Login failed — please try again",
+      ),
     };
   }
 
-  const { data } = await res.json();
-  const { access_token, refresh_token, user: rawUser } = data;
+  const { access_token, refresh_token, user: rawUser } = await readApiData<{
+    access_token: string;
+    refresh_token: string;
+    user: Pick<SessionUser, "id" | "email" | "full_name">;
+  }>(res);
 
   // Backend returns user inline; try /me for full shape, fall back to inline user
   const me = (await fetchMe(access_token)) ?? {
     id: rawUser.id,
     email: rawUser.email,
     full_name: rawUser.full_name,
-    role: "admin" as const,
+    role: APP_ROLES.admin,
     wizard_complete: false,
     scheme_memberships: [],
   };
@@ -122,19 +127,29 @@ export async function registerAction(
 
   if (!res.ok) {
     if (res.status === 409)
-      return { error: "An account with this email already exists" };
-    return { error: "Registration failed — please try again" };
+      return {
+        error: await readApiError(
+          res,
+          "An account with this email already exists",
+        ),
+      };
+    return {
+      error: await readApiError(res, "Registration failed — please try again"),
+    };
   }
 
-  const { data } = await res.json();
-  const { access_token, refresh_token, user: rawUser } = data;
+  const { access_token, refresh_token, user: rawUser } = await readApiData<{
+    access_token: string;
+    refresh_token: string;
+    user: Pick<SessionUser, "id" | "email" | "full_name">;
+  }>(res);
 
   // Backend returns user inline; try /me for full shape, fall back to inline user
   const me = (await fetchMe(access_token)) ?? {
     id: rawUser.id,
     email: rawUser.email,
     full_name: rawUser.full_name,
-    role: "admin" as const,
+    role: APP_ROLES.admin,
     wizard_complete: false,
     scheme_memberships: [],
   };
@@ -183,8 +198,7 @@ export async function refreshTokens(): Promise<string | null> {
 
   if (!res.ok) return null;
 
-  const body = await res.json();
-  const access_token = body.data?.access_token ?? body.access_token;
+  const { access_token } = await readApiData<{ access_token: string }>(res);
   if (!access_token) return null;
   cookieStore.set("sh_access", access_token, ACCESS_OPTS);
   return access_token;
@@ -223,8 +237,9 @@ export async function setupAction(data: {
 
   if (!res.ok) return { error: "Setup failed — please try again" };
 
-  const body = await res.json();
-  const result = body.data ?? body;
+  const result = await readApiData<{
+    scheme: { id: string; name: string };
+  }>(res);
 
   // Update session cookie: wizard_complete + first scheme membership
   const raw = cookieStore.get("sh_session")?.value;
@@ -236,7 +251,7 @@ export async function setupAction(data: {
         scheme_id: result.scheme.id,
         scheme_name: result.scheme.name,
         unit_id: null,
-        role: "admin",
+        role: APP_ROLES.admin,
       },
     ];
     cookieStore.set(
@@ -275,8 +290,13 @@ export async function resetPasswordAction(
 
   if (!res.ok) {
     if (res.status === 401)
-      return { error: "This reset link is invalid or has expired" };
-    return { error: "Reset failed — please try again" };
+      return {
+        error: await readApiError(
+          res,
+          "This reset link is invalid or has expired",
+        ),
+      };
+    return { error: await readApiError(res, "Reset failed — please try again") };
   }
 
   return { ok: true };
@@ -296,16 +316,28 @@ export async function acceptInviteAction(
 
   if (!res.ok) {
     if (res.status === 401)
-      return { error: "This invite link is invalid or has expired" };
+      return {
+        error: await readApiError(
+          res,
+          "This invite link is invalid or has expired",
+        ),
+      };
     if (res.status === 409)
       return {
-        error: "An account with this email already exists — log in instead",
+        error: await readApiError(
+          res,
+          "An account with this email already exists — log in instead",
+        ),
       };
-    return { error: "Something went wrong — please try again" };
+    return {
+      error: await readApiError(res, "Something went wrong — please try again"),
+    };
   }
 
-  const inviteBody = await res.json();
-  const { access_token, refresh_token } = inviteBody.data ?? inviteBody;
+  const { access_token, refresh_token } = await readApiData<{
+    access_token: string;
+    refresh_token: string;
+  }>(res);
   const me = await fetchMe(access_token);
   if (!me) return { error: "Something went wrong — please try again" };
 

--- a/lib/auth.tsx
+++ b/lib/auth.tsx
@@ -2,20 +2,7 @@
 
 import React, { createContext, useContext, useEffect, useState } from "react";
 import { logoutAction } from "./auth-actions";
-
-export interface SessionUser {
-  id: string;
-  email: string;
-  full_name: string;
-  role: "admin" | "trustee" | "resident";
-  wizard_complete: boolean;
-  scheme_memberships: {
-    scheme_id: string;
-    scheme_name: string;
-    unit_id: string | null;
-    role: string;
-  }[];
-}
+import type { SessionUser } from "./session";
 
 interface AuthContextValue {
   user: SessionUser | null;

--- a/lib/session.ts
+++ b/lib/session.ts
@@ -1,0 +1,55 @@
+export const APP_ROLES = {
+  admin: "admin",
+  trustee: "trustee",
+  resident: "resident",
+} as const;
+
+export type AppRole = (typeof APP_ROLES)[keyof typeof APP_ROLES];
+
+export interface SchemeMembership {
+  scheme_id: string;
+  scheme_name: string;
+  unit_id: string | null;
+  role: string;
+}
+
+export interface SessionUser {
+  id: string;
+  email: string;
+  full_name: string;
+  role: AppRole;
+  wizard_complete: boolean;
+  scheme_memberships: SchemeMembership[];
+}
+
+export function isAdminRole(role?: string | null): role is "admin" {
+  return role === APP_ROLES.admin;
+}
+
+export function isResidentRole(role?: string | null): role is "resident" {
+  return role === APP_ROLES.resident;
+}
+
+export function primarySchemeId(user: SessionUser | null): string | null {
+  return user?.scheme_memberships[0]?.scheme_id ?? null;
+}
+
+export function hasSchemeMembership(
+  user: SessionUser | null,
+  schemeId: string,
+): boolean {
+  return (
+    user?.scheme_memberships.some(
+      (membership) => membership.scheme_id === schemeId,
+    ) ?? false
+  );
+}
+
+export function postLoginPath(user: SessionUser): string {
+  if (isAdminRole(user.role)) {
+    return user.wizard_complete ? "/agent" : "/agent/setup";
+  }
+
+  const schemeId = primarySchemeId(user);
+  return schemeId ? `/app/${schemeId}` : "/auth/login";
+}


### PR DESCRIPTION
## Summary
- add shared backend auth identity/role helpers plus standardized response code constants
- add a deterministic idempotent demo seed command and integration coverage for the new seed path
- align frontend session and API envelope helpers so auth, invite, and portfolio flows consume one contract
- strengthen integration test helpers around shared envelopes and auth context setup

## Verification
- npm run lint
- npm run test
- npm run build
- cd backend && go test ./internal/...
- cd backend && go test ./tests/integration/... -tags=integration