### PR TITLE
fix: resolve login redirect issues and add API caching

### DIFF
--- a/app/agent/page.tsx
+++ b/app/agent/page.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useState } from "react";
 
 import { useAuth } from "@/lib/auth";
-import { listSchemes, type SchemeSummary } from "@/lib/scheme-api";
+import { useApiData } from "@/lib/use-api-data";
+import { type SchemeSummary } from "@/lib/scheme-api";
 import { useToast } from "@/lib/toast";
 
 const HEALTH_STYLES: Record<SchemeSummary["health"], string> = {
@@ -16,36 +16,26 @@ const HEALTH_STYLES: Record<SchemeSummary["health"], string> = {
 export default function AgentPortfolioPage() {
   useAuth();
   const { addToast } = useToast();
-  const [schemes, setSchemes] = useState<SchemeSummary[]>([]);
-  const [loading, setLoading] = useState(true);
 
-  useEffect(() => {
-    async function load() {
-      try {
-        setSchemes(await listSchemes());
-      } catch (error) {
-        addToast(
-          error instanceof Error ? error.message : "Failed to load schemes",
-          "error",
-        );
-      } finally {
-        setLoading(false);
-      }
+  const { data: schemes, error, isLoading } = useApiData<SchemeSummary[]>(
+    "/api/v1/schemes",
+    {
+      onError: (err) => addToast(err.message, "error"),
+      revalidateOnMount: false,
     }
+  );
 
-    load();
-  }, [addToast]);
-
-  const totalUnits = schemes.reduce((sum, scheme) => sum + scheme.unit_count, 0);
-  const totalMaintenance = schemes.reduce(
+  const schemeList = schemes ?? []
+  const totalUnits = schemeList.reduce((sum, scheme) => sum + scheme.unit_count, 0);
+  const totalMaintenance = schemeList.reduce(
     (sum, scheme) => sum + scheme.open_maintenance_count,
     0,
   );
   const avgCollection =
-    schemes.length > 0
+    schemeList.length > 0
       ? Math.round(
-          schemes.reduce((sum, scheme) => sum + scheme.levy_collection_pct, 0) /
-            schemes.length,
+          schemeList.reduce((sum, scheme) => sum + scheme.levy_collection_pct, 0) /
+            schemeList.length,
         )
       : 0;
 
@@ -55,14 +45,14 @@ export default function AgentPortfolioPage() {
         Portfolio overview
       </h1>
       <p className="text-[14px] text-muted mb-8">
-        {loading
+        {isLoading
           ? "Loading schemes under management…"
-          : `${schemes.length} schemes under management.`}
+          : `${schemeList.length} schemes under management.`}
       </p>
 
       <div className="grid grid-cols-2 md:grid-cols-4 gap-3 sm:gap-4 mb-8">
         {[
-          { label: "Active schemes", value: String(schemes.length) },
+          { label: "Active schemes", value: String(schemeList.length) },
           { label: "Units managed", value: String(totalUnits) },
           { label: "Open maintenance", value: String(totalMaintenance) },
           { label: "Avg collection rate", value: `${avgCollection}%` },
@@ -72,18 +62,18 @@ export default function AgentPortfolioPage() {
             className="bg-surface border border-border rounded-lg px-5 py-4"
           >
             <div className="text-[24px] font-semibold text-ink font-serif mb-1">
-              {loading ? "…" : value}
+              {isLoading ? "…" : value}
             </div>
             <div className="text-[12px] text-muted">{label}</div>
           </div>
         ))}
       </div>
 
-      {loading ? (
+      {isLoading ? (
         <div className="bg-surface border border-border rounded-lg px-6 py-12 text-center text-muted text-[14px]">
           Loading portfolio…
         </div>
-      ) : schemes.length === 0 ? (
+      ) : schemeList.length === 0 ? (
         <div className="bg-hover-subtle border border-border rounded-lg px-6 py-12 text-center">
           <p className="text-[15px] text-ink font-medium mb-2">
             No schemes found
@@ -110,11 +100,11 @@ export default function AgentPortfolioPage() {
                 <span>Health</span>
                 <span></span>
               </div>
-              {schemes.map((scheme, index) => (
+              {schemeList.map((scheme, index) => (
                 <div
                   key={scheme.id}
                   className={`grid grid-cols-[1fr_44px_80px_100px_68px_60px] gap-4 items-center py-3 text-[13px] ${
-                    index < schemes.length - 1 ? "border-b border-border" : ""
+                    index < schemeList.length - 1 ? "border-b border-border" : ""
                   }`}
                 >
                   <div>

--- a/app/agent/schemes/page.tsx
+++ b/app/agent/schemes/page.tsx
@@ -1,10 +1,10 @@
 'use client'
 
 import Link from 'next/link'
-import { useEffect, useState } from 'react'
 
 import { useAuth } from '@/lib/auth'
-import { listSchemes, type SchemeSummary } from '@/lib/scheme-api'
+import { useApiData } from '@/lib/use-api-data'
+import { type SchemeSummary } from '@/lib/scheme-api'
 import { useToast } from '@/lib/toast'
 
 const HEALTH_STYLES: Record<SchemeSummary['health'], string> = {
@@ -16,38 +16,27 @@ const HEALTH_STYLES: Record<SchemeSummary['health'], string> = {
 export default function SchemesPage() {
   useAuth()
   const { addToast } = useToast()
-  const [schemes, setSchemes] = useState<SchemeSummary[]>([])
-  const [loading, setLoading] = useState(true)
 
-  useEffect(() => {
-    async function load() {
-      try {
-        setSchemes(await listSchemes())
-      } catch (error) {
-        addToast(
-          error instanceof Error ? error.message : 'Failed to load schemes',
-          'error',
-        )
-      } finally {
-        setLoading(false)
-      }
+  const { data: schemes, error, isLoading } = useApiData<SchemeSummary[]>(
+    '/api/v1/schemes',
+    {
+      onError: (err) => addToast(err.message, 'error'),
+      revalidateOnMount: false,
     }
-
-    load()
-  }, [addToast])
+  )
 
   return (
     <div className="px-4 py-6 sm:px-8 sm:py-8 max-w-[900px]">
       <h1 className="font-serif text-[28px] font-semibold text-ink mb-1">All schemes</h1>
       <p className="text-[14px] text-muted mb-8">Schemes managed by your organisation.</p>
 
-      {loading ? (
+      {isLoading ? (
         <div className="bg-surface border border-border rounded-lg px-6 py-12 text-center text-muted text-[14px]">
           Loading schemes…
         </div>
       ) : (
         <div className="flex flex-col gap-3">
-          {schemes.map(scheme => (
+          {(schemes ?? []).map(scheme => (
             <div key={scheme.id} className="bg-surface border border-border rounded-lg px-5 py-4 flex items-center justify-between gap-4">
               <div>
                 <div className="text-[14px] font-semibold text-ink">{scheme.name}</div>
@@ -66,7 +55,7 @@ export default function SchemesPage() {
               </div>
             </div>
           ))}
-          {schemes.length === 0 && (
+          {(schemes ?? []).length === 0 && (
             <div className="bg-hover-subtle border border-border rounded-lg px-6 py-12 text-center text-[14px] text-muted">
               No schemes found.
             </div>

--- a/app/app/[schemeId]/agm/page.tsx
+++ b/app/app/[schemeId]/agm/page.tsx
@@ -5,7 +5,8 @@ import { useParams } from 'next/navigation'
 
 import Modal from '@/components/Modal'
 import { useAuth } from '@/lib/auth'
-import { assignAgmProxy, castAgmVote, getAgmDashboard, scheduleAgmMeeting } from '@/lib/agm-api'
+import { useApiData } from '@/lib/use-api-data'
+import { assignAgmProxy, castAgmVote, scheduleAgmMeeting } from '@/lib/agm-api'
 import type { AgmDashboard, AgmMeetingInfo, AgmResolutionInfo, AgmVoteChoice } from '@/lib/agm'
 import { listSchemeMembers } from '@/lib/scheme-api'
 import { useToast } from '@/lib/toast'
@@ -46,9 +47,6 @@ export default function AgmVotingPage() {
   const params = useParams()
   const schemeId = params.schemeId as string
 
-  const [dashboard, setDashboard] = useState<AgmDashboard | null>(null)
-  const [loading, setLoading] = useState(true)
-  const [loadingMembers, setLoadingMembers] = useState(true)
   const [proxyCandidates, setProxyCandidates] = useState<Array<{ user_id: string; full_name: string; role: string }>>([])
   const [showScheduleModal, setShowScheduleModal] = useState(false)
   const [savingSchedule, setSavingSchedule] = useState(false)
@@ -66,6 +64,29 @@ export default function AgmVotingPage() {
 
   const isAdmin = user?.role === 'admin'
   const canVote = user?.role === 'resident' || user?.role === 'trustee'
+
+  const { data: dashboard, error, isLoading, mutate } = useApiData<AgmDashboard>(
+    schemeId ? `/api/v1/agm/${schemeId}/dashboard` : null,
+    {
+      onError: (err) => addToast(err.message, 'error'),
+      revalidateOnMount: false,
+    }
+  )
+
+  const { data: members, isLoading: membersLoading } = useApiData<Array<{ user_id: string; full_name: string; role: string }>>(
+    schemeId ? `/api/v1/schemes/${schemeId}/members` : null,
+    {
+      onError: () => {},
+      revalidateOnMount: false,
+    }
+  )
+
+  useEffect(() => {
+    if (members) {
+      setProxyCandidates(members)
+    }
+  }, [members])
+
   const latestMeeting = dashboard?.latest ?? null
   const upcomingMeeting = dashboard?.upcoming ?? null
 
@@ -75,45 +96,11 @@ export default function AgmVotingPage() {
   )
 
   useEffect(() => {
-    async function load() {
-      try {
-        setLoading(true)
-        setDashboard(await getAgmDashboard(schemeId))
-      } catch (error) {
-        addToast(
-          error instanceof Error ? error.message : 'Failed to load AGM dashboard',
-          'error',
-        )
-      } finally {
-        setLoading(false)
-      }
-    }
-
-    load()
-  }, [addToast, schemeId])
-
-  useEffect(() => {
-    async function loadMembers() {
-      try {
-        setLoadingMembers(true)
-        const members = await listSchemeMembers(schemeId)
-        setProxyCandidates(members)
-      } catch {
-        setProxyCandidates([])
-      } finally {
-        setLoadingMembers(false)
-      }
-    }
-
-    loadMembers()
-  }, [schemeId])
-
-  useEffect(() => {
     setProxyUserId(upcomingMeeting?.user_proxy_grantee_id ?? '')
   }, [upcomingMeeting?.user_proxy_grantee_id])
 
   async function refreshDashboard() {
-    setDashboard(await getAgmDashboard(schemeId))
+    await mutate()
   }
 
   async function handleVote(resolutionId: string, choice: AgmVoteChoice) {
@@ -185,7 +172,7 @@ export default function AgmVotingPage() {
     }
   }
 
-  if (loading) {
+  if (isLoading) {
     return (
       <div className="px-4 py-6 sm:px-8 sm:py-8 max-w-[900px]">
         <div className="bg-surface border border-border rounded-lg px-6 py-12 text-center text-muted text-[14px]">
@@ -291,7 +278,7 @@ export default function AgmVotingPage() {
                   <select
                     value={proxyUserId}
                     onChange={event => setProxyUserId(event.target.value)}
-                    disabled={loadingMembers || assigningProxy || !!upcomingMeeting.user_proxy_grantee_id}
+                    disabled={membersLoading || assigningProxy || !!upcomingMeeting.user_proxy_grantee_id}
                     className="border border-border rounded px-3 py-2 text-[13px] text-ink bg-surface focus:outline-none focus:border-accent disabled:opacity-50"
                   >
                     <option value="">Select proxy member</option>

--- a/app/app/[schemeId]/communications/page.tsx
+++ b/app/app/[schemeId]/communications/page.tsx
@@ -1,10 +1,11 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { useParams } from 'next/navigation'
 
 import Modal from '@/components/Modal'
-import { createNotice, getCommunicationsDashboard } from '@/lib/communications-api'
+import { useApiData } from '@/lib/use-api-data'
+import { createNotice } from '@/lib/communications-api'
 import type { NoticeInfo, NoticeType } from '@/lib/communications'
 import { useAuth } from '@/lib/auth'
 import { useToast } from '@/lib/toast'
@@ -29,8 +30,6 @@ export default function CommunicationsPage() {
   const params = useParams()
   const schemeId = params.schemeId as string
 
-  const [notices, setNotices] = useState<NoticeInfo[]>([])
-  const [loading, setLoading] = useState(true)
   const [typeFilter, setTypeFilter] = useState<'all' | NoticeType>('all')
   const [expanded, setExpanded] = useState<string | null>(null)
   const [showModal, setShowModal] = useState(false)
@@ -39,40 +38,29 @@ export default function CommunicationsPage() {
 
   const canCompose = user?.role === 'admin' || user?.role === 'trustee'
 
-  useEffect(() => {
-    async function load() {
-      try {
-        setLoading(true)
-        const dashboard = await getCommunicationsDashboard(schemeId, typeFilter)
-        setNotices(dashboard.notices)
-      } catch (error) {
-        addToast(
-          error instanceof Error ? error.message : 'Failed to load notices',
-          'error',
-        )
-      } finally {
-        setLoading(false)
-      }
+  const query = typeFilter === 'all' ? '' : `?type=${typeFilter}`
+  const { data: dashboard, error, isLoading, mutate } = useApiData<{ notices: NoticeInfo[] }>(
+    schemeId ? `/api/v1/communications/${schemeId}${query}` : null,
+    {
+      onError: (err) => addToast(err.message, 'error'),
+      revalidateOnMount: false,
     }
+  )
 
-    load()
-  }, [addToast, schemeId, typeFilter])
+  const notices = dashboard?.notices ?? []
 
   async function handleCompose() {
     if (!form.title.trim() || !form.body.trim()) return
 
     setSending(true)
     try {
-      const notice = await createNotice(schemeId, {
+      await createNotice(schemeId, {
         title: form.title.trim(),
         body: form.body.trim(),
         type: form.type,
       })
 
-      if (typeFilter === 'all' || typeFilter === notice.type) {
-        setNotices(current => [notice, ...current])
-      }
-      setExpanded(notice.id)
+      await mutate()
       setShowModal(false)
       setForm({ title: '', body: '', type: 'general' })
       addToast('Notice sent to scheme members', 'success')
@@ -86,7 +74,7 @@ export default function CommunicationsPage() {
     }
   }
 
-  if (loading) {
+  if (isLoading) {
     return (
       <div className="px-4 py-6 sm:px-8 sm:py-8 max-w-[900px]">
         <div className="bg-surface border border-border rounded-lg px-6 py-12 text-center text-muted text-[14px]">

--- a/app/app/[schemeId]/compliance/page.tsx
+++ b/app/app/[schemeId]/compliance/page.tsx
@@ -1,10 +1,10 @@
 'use client'
 
-import { useEffect, useMemo, useState } from 'react'
+import { useMemo, useState } from 'react'
 import { useParams } from 'next/navigation'
 
 import { useAuth } from '@/lib/auth'
-import { getComplianceDashboard } from '@/lib/compliance-api'
+import { useApiData } from '@/lib/use-api-data'
 import {
   COMPLIANCE_CATEGORIES,
   type ComplianceCategory,
@@ -164,31 +164,15 @@ export default function CompliancePage() {
   const params = useParams()
   const schemeId = params.schemeId as string
 
-  const [dashboard, setDashboard] = useState<ComplianceDashboard | null>(null)
-  const [loading, setLoading] = useState(true)
+  const isResident = user?.role === 'resident'
 
-  useEffect(() => {
-    if (user?.role === 'resident') {
-      setLoading(false)
-      return
+  const { data: dashboard, error, isLoading } = useApiData<ComplianceDashboard>(
+    isResident || !schemeId ? null : `/api/v1/compliance/${schemeId}/dashboard`,
+    {
+      onError: (err) => addToast(err.message, 'error'),
+      revalidateOnMount: false,
     }
-
-    async function load() {
-      try {
-        setLoading(true)
-        setDashboard(await getComplianceDashboard(schemeId))
-      } catch (error) {
-        addToast(
-          error instanceof Error ? error.message : 'Failed to load compliance dashboard',
-          'error',
-        )
-      } finally {
-        setLoading(false)
-      }
-    }
-
-    load()
-  }, [addToast, schemeId, user?.role])
+  )
 
   const groupedItems = useMemo(() => {
     if (!dashboard) return new Map<ComplianceCategory, ComplianceItem[]>()
@@ -212,7 +196,7 @@ export default function CompliancePage() {
     )
   }
 
-  if (loading || !dashboard) {
+  if (isLoading || !dashboard) {
     return (
       <div className="px-4 py-6 sm:px-8 sm:py-8 max-w-[900px]">
         <div className="bg-surface border border-border rounded-lg px-6 py-12 text-center text-muted text-[14px]">

--- a/app/app/[schemeId]/documents/page.tsx
+++ b/app/app/[schemeId]/documents/page.tsx
@@ -1,10 +1,11 @@
 'use client'
 
-import { useEffect, useMemo, useState } from 'react'
+import { useMemo, useState } from 'react'
 import { useParams } from 'next/navigation'
 
 import Modal from '@/components/Modal'
-import { createDocument, deleteDocument, getDocumentsDashboard } from '@/lib/documents-api'
+import { useApiData } from '@/lib/use-api-data'
+import { createDocument, deleteDocument } from '@/lib/documents-api'
 import type { DocumentCategory, DocumentFileType, SchemeDocumentInfo } from '@/lib/documents'
 import { useAuth } from '@/lib/auth'
 import { useToast } from '@/lib/toast'
@@ -52,8 +53,6 @@ export default function DocumentsPage() {
   const params = useParams()
   const schemeId = params.schemeId as string
 
-  const [documents, setDocuments] = useState<SchemeDocumentInfo[]>([])
-  const [loading, setLoading] = useState(true)
   const [categoryFilter, setCategoryFilter] = useState<'all' | DocumentCategory>('all')
   const [showModal, setShowModal] = useState(false)
   const [form, setForm] = useState(EMPTY_FORM)
@@ -63,24 +62,16 @@ export default function DocumentsPage() {
 
   const canUpload = user?.role === 'admin'
 
-  useEffect(() => {
-    async function load() {
-      try {
-        setLoading(true)
-        const dashboard = await getDocumentsDashboard(schemeId, categoryFilter)
-        setDocuments(dashboard.documents)
-      } catch (error) {
-        addToast(
-          error instanceof Error ? error.message : 'Failed to load documents',
-          'error',
-        )
-      } finally {
-        setLoading(false)
-      }
+  const query = categoryFilter === 'all' ? '' : `?category=${categoryFilter}`
+  const { data: documents, error, isLoading, mutate } = useApiData<{ documents: SchemeDocumentInfo[] }>(
+    schemeId ? `/api/v1/documents/${schemeId}${query}` : null,
+    {
+      onError: (err) => addToast(err.message, 'error'),
+      revalidateOnMount: false,
     }
+  )
 
-    load()
-  }, [addToast, categoryFilter, schemeId])
+  const documentList = documents?.documents ?? []
 
   async function handleUpload() {
     if (!selectedFile || !form.name.trim()) return
@@ -97,7 +88,7 @@ export default function DocumentsPage() {
         size_bytes: selectedFile.size,
       })
       if (categoryFilter === 'all' || categoryFilter === created.category) {
-        setDocuments(current => [created, ...current])
+        await mutate()
       }
       setShowModal(false)
       setForm(EMPTY_FORM)
@@ -117,7 +108,7 @@ export default function DocumentsPage() {
     setDeletingId(document.id)
     try {
       await deleteDocument(schemeId, document.id)
-      setDocuments(current => current.filter(item => item.id !== document.id))
+      await mutate()
       addToast(`"${document.name}" deleted`, 'success')
     } catch (error) {
       addToast(
@@ -129,9 +120,9 @@ export default function DocumentsPage() {
     }
   }
 
-  const grouped = useMemo(() => groupByCategory(documents), [documents])
+  const grouped = useMemo(() => groupByCategory(documentList), [documentList])
 
-  if (loading) {
+  if (isLoading) {
     return (
       <div className="px-4 py-6 sm:px-8 sm:py-8 max-w-[900px]">
         <div className="bg-surface border border-border rounded-lg px-6 py-12 text-center text-muted text-[14px]">
@@ -148,7 +139,7 @@ export default function DocumentsPage() {
       <p className="text-[14px] text-muted mb-8">Scheme rules, minutes, insurance certificates, and shared files.</p>
 
       <div className="flex flex-wrap items-center justify-between gap-3 mb-6">
-        <span className="text-[13px] text-muted">{documents.length} documents</span>
+        <span className="text-[13px] text-muted">{documentList.length} documents</span>
         {canUpload && (
           <button
             onClick={() => setShowModal(true)}

--- a/app/app/[schemeId]/financials/page.tsx
+++ b/app/app/[schemeId]/financials/page.tsx
@@ -1,11 +1,12 @@
 'use client'
 
-import { useEffect, useMemo, useState } from 'react'
+import { useMemo, useState } from 'react'
 import { useParams } from 'next/navigation'
 
 import Modal from '@/components/Modal'
 import { useAuth } from '@/lib/auth'
-import { getFinancialDashboard, updateReserveFund, upsertBudgetLine } from '@/lib/financials-api'
+import { useApiData } from '@/lib/use-api-data'
+import { updateReserveFund, upsertBudgetLine } from '@/lib/financials-api'
 import type { BudgetLineInfo, FinancialDashboard } from '@/lib/financials'
 import { useToast } from '@/lib/toast'
 
@@ -19,8 +20,6 @@ export default function FinancialsPage() {
   const params = useParams()
   const schemeId = params.schemeId as string
 
-  const [dashboard, setDashboard] = useState<FinancialDashboard | null>(null)
-  const [loading, setLoading] = useState(true)
   const [selectedPeriod, setSelectedPeriod] = useState('')
   const [showBudgetModal, setShowBudgetModal] = useState(false)
   const [showReserveModal, setShowReserveModal] = useState(false)
@@ -39,27 +38,16 @@ export default function FinancialsPage() {
 
   const canManage = user?.role === 'admin' || user?.role === 'trustee'
 
-  useEffect(() => {
-    async function load() {
-      try {
-        setLoading(true)
-        const nextDashboard = await getFinancialDashboard(schemeId, selectedPeriod || undefined)
-        setDashboard(nextDashboard)
-        if (!selectedPeriod && nextDashboard.selected_period) {
-          setSelectedPeriod(nextDashboard.selected_period)
-        }
-      } catch (error) {
-        addToast(
-          error instanceof Error ? error.message : 'Failed to load financial dashboard',
-          'error',
-        )
-      } finally {
-        setLoading(false)
-      }
+  const query = selectedPeriod ? `?period=${selectedPeriod}` : ''
+  const { data: dashboard, error, isLoading, mutate } = useApiData<FinancialDashboard>(
+    schemeId ? `/api/v1/financials/${schemeId}/dashboard${query}` : null,
+    {
+      onError: (err) => addToast(err.message, 'error'),
+      revalidateOnMount: false,
     }
+  )
 
-    load()
-  }, [addToast, schemeId, selectedPeriod])
+  const isLoadingDashboard = isLoading
 
   const budgetLines = dashboard?.budget_lines ?? []
   const reserveFund = dashboard?.reserve_fund ?? null
@@ -99,16 +87,10 @@ export default function FinancialsPage() {
   }
 
   async function refreshDashboard(nextPeriod?: string) {
-    setLoading(true)
-    try {
-      const dashboardData = await getFinancialDashboard(schemeId, nextPeriod || selectedPeriod || undefined)
-      setDashboard(dashboardData)
-      if (dashboardData.selected_period && dashboardData.selected_period !== selectedPeriod) {
-        setSelectedPeriod(dashboardData.selected_period)
-      }
-    } finally {
-      setLoading(false)
+    if (nextPeriod && nextPeriod !== selectedPeriod) {
+      setSelectedPeriod(nextPeriod)
     }
+    await mutate()
   }
 
   async function handleBudgetSave() {
@@ -186,7 +168,7 @@ export default function FinancialsPage() {
     setShowReserveModal(true)
   }
 
-  if (loading) {
+  if (isLoading) {
     return (
       <div className="px-4 py-6 sm:px-8 sm:py-8 max-w-[900px]">
         <div className="bg-surface border border-border rounded-lg px-6 py-12 text-center text-muted text-[14px]">

--- a/app/app/[schemeId]/levy/page.tsx
+++ b/app/app/[schemeId]/levy/page.tsx
@@ -1,12 +1,13 @@
 'use client'
 
-import { useEffect, useMemo, useState } from 'react'
+import { useMemo, useState } from 'react'
 import { useParams } from 'next/navigation'
 
 import Modal from '@/components/Modal'
 import ReconcileModal from '@/components/ReconcileModal'
 import { useAuth } from '@/lib/auth'
-import { createLevyPeriod, getLevyDashboard, reconcileLevyPayments } from '@/lib/levy-api'
+import { useApiData } from '@/lib/use-api-data'
+import { createLevyPeriod, reconcileLevyPayments } from '@/lib/levy-api'
 import type { LevyAccountInfo, LevyDashboard, ReconcilePaymentInput } from '@/lib/levy'
 import { useToast } from '@/lib/toast'
 
@@ -40,8 +41,6 @@ export default function LevyPaymentsPage() {
   const params = useParams()
   const schemeId = params.schemeId as string
 
-  const [dashboard, setDashboard] = useState<LevyDashboard | null>(null)
-  const [loading, setLoading] = useState(true)
   const [reconcileOpen, setReconcileOpen] = useState(false)
   const [createOpen, setCreateOpen] = useState(false)
   const [creatingPeriod, setCreatingPeriod] = useState(false)
@@ -51,36 +50,16 @@ export default function LevyPaymentsPage() {
   const isResident = user?.role === 'resident'
   const canEdit = user?.role === 'admin'
 
-  useEffect(() => {
-    async function load() {
-      try {
-        setLoading(true)
-        setDashboard(await getLevyDashboard(schemeId))
-      } catch (error) {
-        addToast(
-          error instanceof Error ? error.message : 'Failed to load levy dashboard',
-          'error',
-        )
-      } finally {
-        setLoading(false)
-      }
+  const { data: dashboard, error, isLoading, mutate } = useApiData<LevyDashboard>(
+    schemeId ? `/api/v1/levy/${schemeId}/dashboard` : null,
+    {
+      onError: (err) => addToast(err.message, 'error'),
+      revalidateOnMount: false,
     }
-
-    load()
-  }, [addToast, schemeId])
+  )
 
   async function refreshDashboard() {
-    try {
-      setLoading(true)
-      setDashboard(await getLevyDashboard(schemeId))
-    } catch (error) {
-      addToast(
-        error instanceof Error ? error.message : 'Failed to load levy dashboard',
-        'error',
-      )
-    } finally {
-      setLoading(false)
-    }
+    await mutate()
   }
 
   async function handleCreatePeriod() {
@@ -145,7 +124,7 @@ export default function LevyPaymentsPage() {
     [schemeId, user?.scheme_memberships],
   )
 
-  if (loading) {
+  if (isLoading) {
     return (
       <div className="px-4 py-6 sm:px-8 sm:py-8 max-w-[900px]">
         <div className="bg-surface border border-border rounded-lg px-6 py-12 text-center text-muted text-[14px]">

--- a/app/app/[schemeId]/maintenance/page.tsx
+++ b/app/app/[schemeId]/maintenance/page.tsx
@@ -1,14 +1,14 @@
 'use client'
 
-import { useEffect, useMemo, useState } from 'react'
+import { useMemo, useState } from 'react'
 import { useParams } from 'next/navigation'
 
 import Modal from '@/components/Modal'
 import { useAuth } from '@/lib/auth'
+import { useApiData } from '@/lib/use-api-data'
 import {
   assignMaintenanceRequest,
   createMaintenanceRequest,
-  getMaintenanceDashboard,
   resolveMaintenanceRequest,
 } from '@/lib/maintenance-api'
 import type { MaintenanceDashboard, MaintenanceRequestInfo } from '@/lib/maintenance'
@@ -46,8 +46,6 @@ export default function MaintenancePage() {
   const params = useParams()
   const schemeId = params.schemeId as string
 
-  const [dashboard, setDashboard] = useState<MaintenanceDashboard | null>(null)
-  const [loading, setLoading] = useState(true)
   const [showCreateModal, setShowCreateModal] = useState(false)
   const [jobForm, setJobForm] = useState(EMPTY_JOB_FORM)
   const [assignJobId, setAssignJobId] = useState<string | null>(null)
@@ -66,26 +64,16 @@ export default function MaintenancePage() {
     [schemeId, user?.scheme_memberships],
   )
 
-  useEffect(() => {
-    async function load() {
-      try {
-        setLoading(true)
-        setDashboard(await getMaintenanceDashboard(schemeId))
-      } catch (error) {
-        addToast(
-          error instanceof Error ? error.message : 'Failed to load maintenance requests',
-          'error',
-        )
-      } finally {
-        setLoading(false)
-      }
+  const { data: dashboard, error, isLoading, mutate } = useApiData<MaintenanceDashboard>(
+    schemeId ? `/api/v1/maintenance/${schemeId}/dashboard` : null,
+    {
+      onError: (err) => addToast(err.message, 'error'),
+      revalidateOnMount: false,
     }
-
-    load()
-  }, [addToast, schemeId])
+  )
 
   async function refreshDashboard() {
-    setDashboard(await getMaintenanceDashboard(schemeId))
+    await mutate()
   }
 
   async function handleCreate() {
@@ -156,7 +144,7 @@ export default function MaintenancePage() {
 
   const requests = dashboard?.requests ?? []
 
-  if (loading) {
+  if (isLoading) {
     return (
       <div className="px-4 py-6 sm:px-8 sm:py-8 max-w-[900px]">
         <div className="bg-surface border border-border rounded-lg px-6 py-12 text-center text-muted text-[14px]">

--- a/app/app/[schemeId]/members/page.tsx
+++ b/app/app/[schemeId]/members/page.tsx
@@ -1,12 +1,13 @@
 'use client'
 
-import { useEffect, useMemo, useState } from 'react'
+import { useMemo, useState } from 'react'
 import { useParams } from 'next/navigation'
 
 import Modal from '@/components/Modal'
 import { apiFetch } from '@/lib/api'
 import { readApiError } from '@/lib/api-contract'
 import { useAuth } from '@/lib/auth'
+import { useApiData } from '@/lib/use-api-data'
 import {
   listSchemeMembers,
   listSchemeUnits,
@@ -53,9 +54,6 @@ export default function MembersPage() {
   const params = useParams()
   const schemeId = params.schemeId as string
 
-  const [members, setMembers] = useState<MemberInfo[]>([])
-  const [units, setUnits] = useState<UnitInfo[]>([])
-  const [loading, setLoading] = useState(true)
   const [search, setSearch] = useState('')
   const [showInviteModal, setShowInviteModal] = useState(false)
   const [showEditModal, setShowEditModal] = useState(false)
@@ -67,41 +65,37 @@ export default function MembersPage() {
 
   const canEdit = user?.role === 'admin'
 
-  useEffect(() => {
-    async function load() {
-      try {
-        const [loadedMembers, loadedUnits] = await Promise.all([
-          listSchemeMembers(schemeId),
-          listSchemeUnits(schemeId),
-        ])
-        setMembers(loadedMembers)
-        setUnits(loadedUnits)
-      } catch (error) {
-        addToast(
-          error instanceof Error ? error.message : 'Failed to load members',
-          'error',
-        )
-      } finally {
-        setLoading(false)
-      }
+  const { data: members, error: membersError, isLoading: membersLoading, mutate: mutateMembers } = useApiData<MemberInfo[]>(
+    schemeId ? `/api/v1/schemes/${schemeId}/members` : null,
+    {
+      onError: (err) => addToast(err.message, 'error'),
+      revalidateOnMount: false,
     }
+  )
 
-    load()
-  }, [addToast, schemeId])
+  const { data: units, error: unitsError, isLoading: unitsLoading, mutate: mutateUnits } = useApiData<UnitInfo[]>(
+    schemeId ? `/api/v1/schemes/${schemeId}/units` : null,
+    {
+      onError: (err) => addToast(err.message, 'error'),
+      revalidateOnMount: false,
+    }
+  )
+
+  const isLoading = membersLoading || unitsLoading
 
   const trustees = useMemo(
-    () => members.filter(member => member.role === 'trustee'),
+    () => (members ?? []).filter(member => member.role === 'trustee'),
     [members],
   )
   const residents = useMemo(
-    () => members.filter(member => member.role === 'resident'),
+    () => (members ?? []).filter(member => member.role === 'resident'),
     [members],
   )
 
   const filteredMembers = useMemo(() => {
     const query = search.trim().toLowerCase()
-    if (!query) return members
-    return members.filter(member =>
+    if (!query) return members ?? []
+    return (members ?? []).filter(member =>
       member.full_name.toLowerCase().includes(query) ||
       member.email.toLowerCase().includes(query) ||
       (member.unit_identifier ?? '').toLowerCase().includes(query),
@@ -167,9 +161,7 @@ export default function MembersPage() {
         role: editForm.role,
         unit_id: editForm.role === 'resident' ? editForm.unit_id : null,
       })
-      setMembers(current =>
-        current.map(member => member.user_id === updated.user_id ? updated : member),
-      )
+      await mutateMembers()
       setShowEditModal(false)
       setSelectedMember(null)
       setEditForm(EMPTY_EDIT_FORM)
@@ -184,7 +176,7 @@ export default function MembersPage() {
     }
   }
 
-  if (loading) {
+  if (isLoading) {
     return (
       <div className="px-4 py-6 sm:px-8 sm:py-8 max-w-[900px]">
         <div className="bg-surface border border-border rounded-lg px-6 py-12 text-center text-muted text-[14px]">
@@ -230,7 +222,7 @@ export default function MembersPage() {
 
       <div className="grid grid-cols-3 gap-3 sm:gap-4 mb-8">
         {[
-          { label: 'Total members', value: String(members.length) },
+          { label: 'Total members', value: String((members ?? []).length) },
           { label: 'Trustees', value: String(trustees.length) },
           { label: 'Residents', value: String(residents.length) },
         ].map(({ label, value }) => (
@@ -342,7 +334,7 @@ export default function MembersPage() {
                 className="w-full border border-border rounded px-3 py-2 text-[13px] text-ink bg-surface focus:outline-none focus:border-accent disabled:bg-page disabled:text-muted"
               >
                 <option value="">Select unit</option>
-                {units.map(unit => (
+                {(units ?? []).map(unit => (
                   <option key={unit.id} value={unit.id}>
                     {unit.identifier} · {unit.owner_name}
                   </option>
@@ -390,7 +382,7 @@ export default function MembersPage() {
               className="w-full border border-border rounded px-3 py-2 text-[13px] text-ink bg-surface focus:outline-none focus:border-accent disabled:bg-page disabled:text-muted"
             >
               <option value="">Select unit</option>
-              {units.map(unit => (
+              {(units ?? []).map(unit => (
                 <option key={unit.id} value={unit.id}>
                   {unit.identifier} · {unit.owner_name}
                 </option>

--- a/app/app/[schemeId]/page.tsx
+++ b/app/app/[schemeId]/page.tsx
@@ -1,11 +1,11 @@
 'use client'
 
 import Link from 'next/link'
-import { useEffect, useState } from 'react'
 import { useParams } from 'next/navigation'
 
 import { useAuth } from '@/lib/auth'
-import { getScheme, type SchemeDetail } from '@/lib/scheme-api'
+import { useApiData } from '@/lib/use-api-data'
+import { type SchemeDetail } from '@/lib/scheme-api'
 import { useToast } from '@/lib/toast'
 
 const HEALTH_STYLES = {
@@ -27,32 +27,21 @@ export default function SchemeOverviewPage() {
   const { addToast } = useToast()
   const params = useParams()
   const schemeId = params.schemeId as string
-  const [scheme, setScheme] = useState<SchemeDetail | null>(null)
-  const [loading, setLoading] = useState(true)
 
-  useEffect(() => {
-    async function load() {
-      try {
-        setScheme(await getScheme(schemeId))
-      } catch (error) {
-        addToast(
-          error instanceof Error ? error.message : 'Failed to load scheme',
-          'error',
-        )
-      } finally {
-        setLoading(false)
-      }
+  const { data: scheme, error, isLoading } = useApiData<SchemeDetail>(
+    schemeId ? `/api/v1/schemes/${schemeId}` : null,
+    {
+      onError: (err) => addToast(err.message, 'error'),
+      revalidateOnMount: false,
     }
-
-    load()
-  }, [addToast, schemeId])
+  )
 
   const isResident = user?.role === 'resident'
   const unitLabel = scheme?.unit_identifier
     ? `Unit ${scheme.unit_identifier}`
     : 'No unit linked yet'
 
-  if (loading) {
+  if (isLoading) {
     return (
       <div className="px-4 py-6 sm:px-8 sm:py-8 max-w-[900px]">
         <div className="bg-surface border border-border rounded-lg px-6 py-12 text-center text-muted text-[14px]">

--- a/app/app/[schemeId]/whatsapp/page.tsx
+++ b/app/app/[schemeId]/whatsapp/page.tsx
@@ -1,12 +1,13 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { useParams } from 'next/navigation'
 
 import Modal from '@/components/Modal'
 import { useAuth } from '@/lib/auth'
+import { useApiData } from '@/lib/use-api-data'
 import { useToast } from '@/lib/toast'
-import { createWhatsAppBroadcast, getWhatsAppDashboard } from '@/lib/whatsapp-api'
+import { createWhatsAppBroadcast } from '@/lib/whatsapp-api'
 import type {
   WhatsAppBroadcast,
   WhatsAppBroadcastType,
@@ -391,28 +392,15 @@ export default function WhatsAppPage() {
   const params = useParams()
   const schemeId = params.schemeId as string
 
-  const [dashboard, setDashboard] = useState<WhatsAppDashboard | null>(null)
-  const [loading, setLoading] = useState(true)
-
-  async function loadDashboard() {
-    try {
-      setLoading(true)
-      setDashboard(await getWhatsAppDashboard(schemeId))
-    } catch (error) {
-      addToast(
-        error instanceof Error ? error.message : 'Failed to load WhatsApp dashboard',
-        'error',
-      )
-    } finally {
-      setLoading(false)
+  const { data: dashboard, error, isLoading, mutate } = useApiData<WhatsAppDashboard>(
+    schemeId ? `/api/v1/whatsapp/${schemeId}/dashboard` : null,
+    {
+      onError: (err) => addToast(err.message, 'error'),
+      revalidateOnMount: false,
     }
-  }
+  )
 
-  useEffect(() => {
-    loadDashboard()
-  }, [addToast, schemeId])
-
-  if (loading || !dashboard) {
+  if (isLoading || !dashboard) {
     return (
       <div className="px-4 py-6 sm:px-8 sm:py-8 max-w-[900px]">
         <div className="bg-surface border border-border rounded-lg px-6 py-12 text-center text-muted text-[14px]">
@@ -426,5 +414,5 @@ export default function WhatsAppPage() {
     return <ResidentView thread={dashboard.resident_thread} phoneNumber={dashboard.phone_number} />
   }
 
-  return <OperatorView dashboard={dashboard} schemeId={schemeId} onReload={loadDashboard} />
+  return <OperatorView dashboard={dashboard} schemeId={schemeId} onReload={async () => { await mutate() }} />
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Lora, DM_Sans } from "next/font/google";
+import { SWRConfig } from "swr";
 import "./globals.css";
 import { AuthProvider } from "@/lib/auth";
 import { ThemeProvider } from "@/components/ThemeProvider";
@@ -55,9 +56,11 @@ export default function RootLayout({
         <script dangerouslySetInnerHTML={{ __html: themeScript }} />
       </head>
       <body className="bg-page text-ink font-sans antialiased leading-relaxed">
-        <ThemeProvider>
-          <AuthProvider>{children}</AuthProvider>
-        </ThemeProvider>
+        <SWRConfig value={{ revalidateOnFocus: false, dedupingInterval: 30000 }}>
+          <ThemeProvider>
+            <AuthProvider>{children}</AuthProvider>
+          </ThemeProvider>
+        </SWRConfig>
       </body>
     </html>
   );

--- a/lib/auth-actions.ts
+++ b/lib/auth-actions.ts
@@ -94,15 +94,11 @@ export async function loginAction(
     user: Pick<SessionUser, "id" | "email" | "full_name">;
   }>(res);
 
-  // Backend returns user inline; try /me for full shape, fall back to inline user
-  const me = (await fetchMe(access_token)) ?? {
-    id: rawUser.id,
-    email: rawUser.email,
-    full_name: rawUser.full_name,
-    role: APP_ROLES.admin,
-    wizard_complete: false,
-    scheme_memberships: [],
-  };
+  // Backend returns user inline; try /me for full shape
+  const me = await fetchMe(access_token);
+  if (!me) {
+    return { error: "Failed to load user profile — please try again" };
+  }
 
   const cookieStore = await cookies();
   const session = await setAuthCookies(
@@ -146,15 +142,11 @@ export async function registerAction(
     user: Pick<SessionUser, "id" | "email" | "full_name">;
   }>(res);
 
-  // Backend returns user inline; try /me for full shape, fall back to inline user
-  const me = (await fetchMe(access_token)) ?? {
-    id: rawUser.id,
-    email: rawUser.email,
-    full_name: rawUser.full_name,
-    role: APP_ROLES.admin,
-    wizard_complete: false,
-    scheme_memberships: [],
-  };
+  // Backend returns user inline; try /me for full shape
+  const me = await fetchMe(access_token);
+  if (!me) {
+    return { error: "Failed to load user profile — please try again" };
+  }
 
   const cookieStore = await cookies();
   const session = await setAuthCookies(

--- a/lib/use-api-data.ts
+++ b/lib/use-api-data.ts
@@ -1,0 +1,39 @@
+"use client";
+
+import useSWR, { type SWRConfiguration } from "swr";
+import { apiFetch } from "@/lib/api";
+import { readApiData, readApiError } from "@/lib/api-contract";
+
+function fetcher<T>(path: string): Promise<T> {
+  return apiFetch(path).then(async (res) => {
+    if (!res.ok) {
+      throw new Error(await readApiError(res, "Failed to fetch"));
+    }
+    return readApiData<T>(res);
+  });
+}
+
+export function useApiData<T>(
+  path: string | null,
+  config?: SWRConfiguration<T>,
+) {
+  return useSWR<T>(path, (path) => fetcher<T>(path), {
+    revalidateOnFocus: false,
+    revalidateOnReconnect: true,
+    dedupingInterval: 30000,
+    ...config,
+  });
+}
+
+export function useMutation<T>(
+  path: string,
+  options?: RequestInit,
+): () => Promise<T> {
+  return () =>
+    apiFetch(path, options).then(async (res) => {
+      if (!res.ok) {
+        throw new Error(await readApiError(res, "Request failed"));
+      }
+      return readApiData<T>(res);
+    });
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,70 @@
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
+
+const PUBLIC_PATHS = ['/', '/auth/login', '/auth/register', '/auth/forgot-password', '/auth/reset-password', '/early-access']
+
+function isPublicPath(pathname: string): boolean {
+  return PUBLIC_PATHS.some(
+    (p) => pathname === p || pathname.startsWith('/auth/reset-password/')
+  )
+}
+
+function readSessionCookie(request: NextRequest) {
+  const match = request.cookies.get('sh_session')?.value
+  if (!match) return null
+  try {
+    return JSON.parse(decodeURIComponent(match))
+  } catch {
+    return null
+  }
+}
+
+export function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl
+
+  if (isPublicPath(pathname)) {
+    const session = readSessionCookie(request)
+    if (session && pathname.startsWith('/auth/')) {
+      return NextResponse.redirect(new URL('/app', request.url))
+    }
+    return NextResponse.next()
+  }
+
+  const session = readSessionCookie(request)
+  if (!session) {
+    const loginUrl = new URL('/auth/login', request.url)
+    loginUrl.searchParams.set('redirect', pathname)
+    return NextResponse.redirect(loginUrl)
+  }
+
+  if (pathname.startsWith('/agent')) {
+    if (session.role !== 'admin') {
+      const schemeId = session.scheme_memberships?.[0]?.scheme_id
+      return NextResponse.redirect(
+        new URL(schemeId ? `/app/${schemeId}` : '/auth/login', request.url)
+      )
+    }
+  }
+
+  if (pathname.startsWith('/app')) {
+    if (session.role === 'admin') {
+      return NextResponse.next()
+    }
+    const schemeId = pathname.split('/')[2]
+    const hasAccess = session.scheme_memberships?.some(
+      (m: { scheme_id: string }) => m.scheme_id === schemeId
+    )
+    if (!hasAccess) {
+      const primaryScheme = session.scheme_memberships?.[0]?.scheme_id
+      return NextResponse.redirect(
+        new URL(primaryScheme ? `/app/${primaryScheme}` : '/auth/login', request.url)
+      )
+    }
+  }
+
+  return NextResponse.next()
+}
+
+export const config = {
+  matcher: ['/((?!api|_next/static|_next/image|favicon.ico).*)'],
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
         "@anthropic-ai/sdk": "^0.80.0",
         "next": "16.1.6",
         "react": "^19.0.0",
-        "react-dom": "^19.0.0"
+        "react-dom": "^19.0.0",
+        "swr": "^2.4.1"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.9.1",
@@ -1983,7 +1984,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -3500,6 +3500,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/swr": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.4.1.tgz",
+      "integrity": "sha512-2CC6CiKQtEwaEeNiqWTAw9PGykW8SR5zZX8MZk6TeAvEAnVS7Visz8WzphqgtQ8v2xz/4Q5K+j+SeMaKXeeQIA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -3781,6 +3794,15 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "@anthropic-ai/sdk": "^0.80.0",
     "next": "16.1.6",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "swr": "^2.4.1"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.9.1",


### PR DESCRIPTION
## Summary

This PR fixes two critical issues affecting user login and navigation:

### 1. Login Race Condition (Critical)
When logging in, if the  endpoint failed, the code fell back to assuming  role for ALL users. This caused:
- Residents being redirected to  after login
- Multiple login attempts required
- Users seeing wrong dashboards

**Fix:** Instead of falling back to  role on  failure, the login now returns an error and prompts retry.

### 2. Excessive API Calls (Performance)
Every tab navigation triggered re-fetching of all data because:
- No caching library was used
- Pages remounted on navigation
- Free tier Render backend was being hammered

**Fix:** Added SWR for data caching with:
- 30-second deduplication interval
- No revalidation on focus (prevents unnecessary calls)
- Background revalidation only when data is stale
- 11 pages migrated to use  hook

### 3. Client-side Auth Protection
Auth checks happened only in  after render, causing:
- Brief flash of protected content
- SEO issues

**Fix:** Added  for server-side auth protection.

## Changes

### New Files
-  - Server-side auth protection
-  - SWR-based data fetching hook

### Modified Files
-  - Login no longer assumes admin role on  failure
-  - Added SWR provider
- 11 page components migrated to use SWR caching

## Testing
- [ ] Verify residents are redirected to  after login
- [ ] Verify agents are redirected to  after login  
- [ ] Verify tab navigation doesn't trigger full page reload
- [ ] Verify API calls are cached (check network tab)