### PR TITLE
feat(landing): ultra-premium landing page redesign

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -19,6 +19,15 @@
   --color-amber:           #92400E;
   --color-sidebar-header:  #2D4A6E;
   --color-hover-subtle:    #F0EFE9;
+
+  /* ─── Landing page premium tokens ─── */
+  --color-hero-bg:         #0C1220;
+  --color-hero-surface:    #131B2E;
+  --color-hero-border:     rgba(255,255,255,0.06);
+  --color-hero-muted:      rgba(255,255,255,0.45);
+  --color-hero-accent:     #5B9CF6;
+  --color-hero-glow:       rgba(91,156,246,0.15);
+  --color-hero-warm:       #F4A261;
 }
 
 .dark {
@@ -55,11 +64,63 @@
   background: rgba(15, 15, 14, 0.90);
 }
 
+/* ─── Landing nav — always dark, floating ─── */
+.landing-nav {
+  background: rgba(12, 18, 32, 0.7);
+  backdrop-filter: blur(20px) saturate(1.4);
+  -webkit-backdrop-filter: blur(20px) saturate(1.4);
+  border: 1px solid rgba(255,255,255,0.06);
+}
+
+/* ─── Hero mesh gradient ─── */
+.hero-gradient {
+  background:
+    radial-gradient(ellipse 80% 60% at 20% 100%, rgba(91,156,246,0.12) 0%, transparent 60%),
+    radial-gradient(ellipse 60% 50% at 80% 20%, rgba(244,162,97,0.08) 0%, transparent 50%),
+    radial-gradient(ellipse 100% 80% at 50% 50%, rgba(91,156,246,0.04) 0%, transparent 70%),
+    linear-gradient(180deg, #0C1220 0%, #0F1729 40%, #111D33 100%);
+}
+
+/* ─── Hero grid overlay ─── */
+.hero-grid {
+  background-image:
+    linear-gradient(rgba(255,255,255,0.02) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255,255,255,0.02) 1px, transparent 1px);
+  background-size: 64px 64px;
+}
+
+/* ─── Noise texture overlay ─── */
+.noise-overlay::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  opacity: 0.35;
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)' opacity='0.04'/%3E%3C/svg%3E");
+  background-repeat: repeat;
+  background-size: 256px 256px;
+  pointer-events: none;
+  z-index: 0;
+}
+
+/* ─── Glow accent blob ─── */
+.glow-blob {
+  position: absolute;
+  border-radius: 50%;
+  filter: blur(80px);
+  opacity: 0.5;
+  pointer-events: none;
+}
+
+/* ─── Premium section separator ─── */
+.section-fade {
+  background: linear-gradient(180deg, var(--color-hero-bg) 0%, var(--color-page) 100%);
+}
+
 /* ─── Scroll Reveal ─── */
 .reveal {
   opacity: 0;
-  transform: translateY(20px);
-  transition: opacity 0.5s ease, transform 0.5s ease;
+  transform: translateY(24px);
+  transition: opacity 0.7s cubic-bezier(0.16, 1, 0.3, 1), transform 0.7s cubic-bezier(0.16, 1, 0.3, 1);
 }
 .reveal.in {
   opacity: 1;
@@ -68,22 +129,109 @@
 
 .stagger > * {
   opacity: 0;
-  transform: translateY(16px);
-  transition: opacity 0.45s ease, transform 0.45s ease;
+  transform: translateY(20px);
+  transition: opacity 0.6s cubic-bezier(0.16, 1, 0.3, 1), transform 0.6s cubic-bezier(0.16, 1, 0.3, 1);
 }
 .stagger.in > *:nth-child(1) { opacity: 1; transform: none; transition-delay: 0s; }
-.stagger.in > *:nth-child(2) { opacity: 1; transform: none; transition-delay: 0.07s; }
-.stagger.in > *:nth-child(3) { opacity: 1; transform: none; transition-delay: 0.14s; }
-.stagger.in > *:nth-child(4) { opacity: 1; transform: none; transition-delay: 0.21s; }
-.stagger.in > *:nth-child(5) { opacity: 1; transform: none; transition-delay: 0.28s; }
-.stagger.in > *:nth-child(6) { opacity: 1; transform: none; transition-delay: 0.35s; }
+.stagger.in > *:nth-child(2) { opacity: 1; transform: none; transition-delay: 0.08s; }
+.stagger.in > *:nth-child(3) { opacity: 1; transform: none; transition-delay: 0.16s; }
+.stagger.in > *:nth-child(4) { opacity: 1; transform: none; transition-delay: 0.24s; }
+.stagger.in > *:nth-child(5) { opacity: 1; transform: none; transition-delay: 0.32s; }
+.stagger.in > *:nth-child(6) { opacity: 1; transform: none; transition-delay: 0.40s; }
+
+/* ─── Slide-up entrance for hero elements ─── */
+.hero-enter {
+  opacity: 0;
+  transform: translateY(32px);
+  animation: heroSlideUp 0.9s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+}
+.hero-enter-1 { animation-delay: 0.1s; }
+.hero-enter-2 { animation-delay: 0.25s; }
+.hero-enter-3 { animation-delay: 0.4s; }
+.hero-enter-4 { animation-delay: 0.55s; }
+.hero-enter-5 { animation-delay: 0.7s; }
+
+@keyframes heroSlideUp {
+  to { opacity: 1; transform: none; }
+}
+
+/* ─── Floating animation ─── */
+@keyframes float {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(-8px); }
+}
+.animate-float {
+  animation: float 6s ease-in-out infinite;
+}
+
+/* ─── Pulse glow ─── */
+@keyframes pulseGlow {
+  0%, 100% { opacity: 0.4; }
+  50% { opacity: 0.7; }
+}
+.animate-pulse-glow {
+  animation: pulseGlow 4s ease-in-out infinite;
+}
+
+/* ─── Shimmer for premium badges ─── */
+@keyframes shimmer {
+  0% { background-position: -200% 0; }
+  100% { background-position: 200% 0; }
+}
+.shimmer-badge {
+  background: linear-gradient(
+    110deg,
+    rgba(91,156,246,0.1) 0%,
+    rgba(91,156,246,0.25) 25%,
+    rgba(244,162,97,0.15) 50%,
+    rgba(91,156,246,0.25) 75%,
+    rgba(91,156,246,0.1) 100%
+  );
+  background-size: 200% 100%;
+  animation: shimmer 3s ease-in-out infinite;
+}
+
+/* ─── Card hover lift ─── */
+.card-lift {
+  transition: transform 0.3s cubic-bezier(0.16, 1, 0.3, 1), box-shadow 0.3s ease;
+}
+.card-lift:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 20px 60px rgba(0,0,0,0.12), 0 4px 16px rgba(0,0,0,0.08);
+}
+
+/* ─── Premium border glow on hover ─── */
+.glow-border {
+  position: relative;
+  transition: border-color 0.3s ease;
+}
+.glow-border::after {
+  content: '';
+  position: absolute;
+  inset: -1px;
+  border-radius: inherit;
+  background: linear-gradient(135deg, rgba(91,156,246,0.2), rgba(244,162,97,0.1), transparent);
+  opacity: 0;
+  transition: opacity 0.3s ease;
+  z-index: -1;
+  pointer-events: none;
+}
+.glow-border:hover::after {
+  opacity: 1;
+}
 
 @media (prefers-reduced-motion: reduce) {
   .reveal,
-  .stagger > * {
+  .stagger > *,
+  .hero-enter {
     opacity: 1;
     transform: none;
     transition: none;
+    animation: none;
+  }
+  .animate-float,
+  .animate-pulse-glow {
+    animation: none;
   }
 }
 
@@ -95,19 +243,19 @@
 }
 
 /* ─── Clamp utilities not in Tailwind ─── */
-.text-clamp-hero    { font-size: clamp(38px, 6vw, 72px); }
+.text-clamp-hero    { font-size: clamp(42px, 6.5vw, 80px); }
 .text-clamp-section { font-size: clamp(28px, 4vw, 48px); }
 .text-clamp-feature { font-size: clamp(22px, 3vw, 32px); }
 .text-clamp-role    { font-size: clamp(20px, 2.8vw, 28px); }
-.text-clamp-sub     { font-size: clamp(16px, 2vw, 19px); }
+.text-clamp-sub     { font-size: clamp(16px, 2vw, 20px); }
 .text-clamp-p       { font-size: clamp(14px, 1.8vw, 17px); }
 .text-clamp-stat    { font-size: clamp(24px, 3.5vw, 36px); }
 .text-clamp-cta     { font-size: clamp(28px, 4vw, 44px); }
 .text-clamp-quote   { font-size: clamp(20px, 3vw, 28px); }
 .text-clamp-price   { font-size: clamp(28px, 4vw, 40px); }
 
-.padding-hero    { padding-top: clamp(64px, 12vh, 120px); padding-bottom: clamp(48px, 8vh, 80px); }
-.padding-section { padding-top: clamp(56px, 9vh, 96px);  padding-bottom: clamp(56px, 9vh, 96px); }
+.padding-hero    { padding-top: clamp(80px, 14vh, 140px); padding-bottom: clamp(60px, 10vh, 100px); }
+.padding-section { padding-top: clamp(64px, 10vh, 112px);  padding-bottom: clamp(64px, 10vh, 112px); }
 .px-container    { padding-left: clamp(20px, 5vw, 48px); padding-right: clamp(20px, 5vw, 48px); }
 
 /* ─── Focus visible ─── */
@@ -124,7 +272,6 @@ input:focus, textarea:focus, select:focus {
 }
 
 /* ─── Premium dark mode card elevation ─── */
-/* Subtle top-edge highlight + depth shadow for rounded surface cards */
 .dark .bg-surface.rounded-lg,
 .dark .bg-surface.rounded-xl {
   box-shadow: 0 1px 3px rgba(0,0,0,0.4), inset 0 1px 0 rgba(255,255,255,0.04);
@@ -143,4 +290,50 @@ h1, h2, h3, h4 {
   text-transform: uppercase;
   color: var(--color-muted);
   margin-bottom: 12px;
+}
+
+/* ─── Mobile menu overlay ─── */
+.mobile-menu-overlay {
+  background: rgba(12, 18, 32, 0.85);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+}
+
+/* ─── Premium section backgrounds ─── */
+.bg-premium-dark {
+  background: linear-gradient(180deg, #0C1220 0%, #0F1729 100%);
+}
+
+.bg-premium-surface {
+  background:
+    radial-gradient(ellipse 50% 40% at 10% 100%, rgba(91,156,246,0.04) 0%, transparent 50%),
+    var(--color-surface);
+}
+
+/* ─── Testimonial card quote mark ─── */
+.quote-mark::before {
+  content: '\201C';
+  position: absolute;
+  top: -8px;
+  left: 20px;
+  font-size: 72px;
+  font-family: var(--font-lora), Georgia, serif;
+  line-height: 1;
+  color: var(--color-accent);
+  opacity: 0.12;
+  pointer-events: none;
+}
+
+/* ─── Pricing featured card gradient ─── */
+.pricing-featured {
+  background:
+    radial-gradient(ellipse 80% 60% at 50% 0%, rgba(91,156,246,0.15) 0%, transparent 60%),
+    #0C1220;
+}
+
+/* ─── Stats counter glow line ─── */
+.stat-glow-line {
+  height: 2px;
+  background: linear-gradient(90deg, transparent, var(--color-hero-accent), transparent);
+  opacity: 0.3;
 }

--- a/components/CTASection.tsx
+++ b/components/CTASection.tsx
@@ -2,25 +2,38 @@ import Link from 'next/link'
 
 export default function CTASection() {
   return (
-    <section className="bg-surface border-t border-border">
-      <div className="max-w-container mx-auto px-container">
-        <div className="reveal max-w-[600px] mx-auto text-center py-[clamp(56px,9vh,80px)]">
-          <h2 className="font-serif text-clamp-cta font-bold tracking-[-0.02em] text-ink leading-[1.2] mb-4">
-            Ready to bring order to your scheme?
+    <section className="relative overflow-hidden border-t border-border">
+      {/* Dark cinematic background */}
+      <div className="absolute inset-0 hero-gradient" />
+      <div className="absolute inset-0 hero-grid" />
+
+      {/* Glow accents */}
+      <div className="glow-blob w-[400px] h-[400px] bg-[var(--color-hero-accent)] top-[-100px] left-[20%] animate-pulse-glow" />
+      <div className="glow-blob w-[300px] h-[300px] bg-[var(--color-hero-warm)] bottom-[-80px] right-[10%] opacity-30 animate-pulse-glow" style={{ animationDelay: '2s' }} />
+
+      <div className="relative z-10 max-w-[1080px] mx-auto px-container">
+        <div className="reveal max-w-[640px] mx-auto text-center py-[clamp(80px,12vh,120px)]">
+          <h2 className="font-serif text-clamp-cta font-bold tracking-[-0.02em] text-white leading-[1.15] mb-5">
+            Ready to bring order{' '}
+            <br className="hidden sm:block" />
+            <span className="bg-gradient-to-r from-[var(--color-hero-accent)] to-[var(--color-hero-warm)] bg-clip-text text-transparent">
+              to your scheme?
+            </span>
           </h2>
-          <p className="text-[16px] text-ink-2 mb-8 leading-[1.65]">
+          <p className="text-[16px] text-white/45 mb-10 leading-[1.7]">
             We&apos;re onboarding a limited number of schemes. Request early access and we&apos;ll be in touch.
           </p>
-          <div className="flex flex-wrap items-center justify-center gap-[10px] mb-[14px]">
+          <div className="flex flex-wrap items-center justify-center gap-3 mb-5">
             <Link
               href="/early-access"
-              className="px-7 py-3 text-[15px] font-medium text-white bg-accent border border-accent
-                rounded hover:opacity-90 transition-opacity duration-150 no-underline"
+              className="group px-8 py-3.5 text-[15px] font-medium text-white bg-[var(--color-hero-accent)]
+                rounded-lg hover:shadow-[0_0_40px_rgba(91,156,246,0.3)] hover:brightness-110 transition-all duration-300 no-underline inline-flex items-center gap-2"
             >
-              Request early access →
+              Request early access
+              <span className="inline-block transition-transform duration-200 group-hover:translate-x-0.5">→</span>
             </Link>
           </div>
-          <p className="text-[13px] text-muted-2">
+          <p className="text-[13px] text-white/25 tracking-[0.02em]">
             Limited spots · STSMA compliant · No credit card needed
           </p>
         </div>

--- a/components/FeaturesSection.tsx
+++ b/components/FeaturesSection.tsx
@@ -13,21 +13,23 @@ interface FeatureBlockProps {
   items: FeatureItem[]
   MockPanel: React.ComponentType
   flip?: boolean
-  bg?: string
+  accent?: 'blue' | 'warm'
 }
 
 function CheckIcon() {
   return (
-    <span className="w-[18px] h-[18px] rounded-full bg-green-bg border border-[rgba(39,103,73,0.2)] grid place-items-center flex-shrink-0 mt-[1px] text-[9px] text-green">
+    <span className="w-[20px] h-[20px] rounded-full bg-green-bg border border-[rgba(39,103,73,0.18)] grid place-items-center flex-shrink-0 mt-[1px] text-[10px] text-green font-bold">
       ✓
     </span>
   )
 }
 
-function FeatureBlock({ tag, heading, body, items, MockPanel, flip = false, bg }: FeatureBlockProps) {
+function FeatureBlock({ tag, heading, body, items, MockPanel, flip = false, accent = 'blue' }: FeatureBlockProps) {
+  const isWarm = accent === 'warm'
+
   return (
-    <section className={`padding-section border-t border-border ${bg ?? ''}`}>
-      <div className="max-w-container mx-auto px-container">
+    <section className="padding-section border-t border-border">
+      <div className="max-w-[1080px] mx-auto px-container">
         <div
           className={`grid grid-cols-1 md:grid-cols-2 gap-[clamp(40px,6vw,80px)] items-center ${
             flip ? 'md:[direction:rtl]' : ''
@@ -35,16 +37,20 @@ function FeatureBlock({ tag, heading, body, items, MockPanel, flip = false, bg }
         >
           {/* Text */}
           <div className={flip ? '[direction:ltr]' : ''}>
-            <span className="inline-block text-[11px] font-semibold tracking-[0.08em] uppercase text-accent bg-accent-bg rounded px-2 py-[3px] mb-[14px]">
+            <span className={`inline-block text-[11px] font-semibold tracking-[0.1em] uppercase rounded-lg px-3 py-1.5 mb-4 border ${
+              isWarm
+                ? 'text-[var(--color-hero-warm)] bg-[rgba(244,162,97,0.08)] border-[rgba(244,162,97,0.15)]'
+                : 'text-accent bg-accent-bg border-[rgba(43,108,176,0.12)]'
+            }`}>
               {tag}
             </span>
-            <h3 className="font-serif text-clamp-feature font-bold leading-[1.2] tracking-[-0.015em] text-ink mb-[14px]">
+            <h3 className="font-serif text-clamp-feature font-bold leading-[1.18] tracking-[-0.015em] text-ink mb-4">
               {heading}
             </h3>
-            <p className="text-[15px] text-ink-2 leading-[1.7] mb-5">{body}</p>
-            <ul className="flex flex-col gap-2">
+            <p className="text-[15px] text-ink-2 leading-[1.7] mb-6">{body}</p>
+            <ul className="flex flex-col gap-2.5">
               {items.map(({ check }) => (
-                <li key={check} className="flex items-start gap-[10px] text-[14px] text-ink-2">
+                <li key={check} className="flex items-start gap-3 text-[14px] text-ink-2 leading-[1.5]">
                   <CheckIcon />
                   {check}
                 </li>
@@ -54,7 +60,9 @@ function FeatureBlock({ tag, heading, body, items, MockPanel, flip = false, bg }
 
           {/* Mock panel */}
           <div className={`reveal ${flip ? '[direction:ltr]' : ''}`}>
-            <MockPanel />
+            <div className="card-lift rounded-xl">
+              <MockPanel />
+            </div>
           </div>
         </div>
       </div>
@@ -77,7 +85,6 @@ export default function FeaturesSection() {
           { check: 'Attorney handoff workflow built in' },
         ]}
         MockPanel={LevyMockPanel}
-        bg="bg-surface border-b border-border"
       />
 
       <FeatureBlock
@@ -93,6 +100,7 @@ export default function FeaturesSection() {
         ]}
         MockPanel={MaintenanceMockPanel}
         flip
+        accent="warm"
       />
 
       <FeatureBlock
@@ -107,7 +115,6 @@ export default function FeaturesSection() {
           { check: 'Signed minutes generated automatically' },
         ]}
         MockPanel={AGMMockPanel}
-        bg="bg-surface border-b border-border"
       />
     </>
   )

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -9,21 +9,21 @@ const footerLinks = {
 
 export default function Footer() {
   return (
-    <footer className="border-t border-border bg-page pt-[clamp(40px,6vw,56px)] pb-[clamp(24px,4vw,32px)]">
-      <div className="max-w-container mx-auto px-container">
+    <footer className="border-t border-border bg-page pt-[clamp(48px,7vw,64px)] pb-[clamp(28px,4vw,36px)]">
+      <div className="max-w-[1080px] mx-auto px-container">
         {/* Top grid */}
-        <div className="grid grid-cols-2 sm:grid-cols-[1.5fr_1fr_1fr_1fr] gap-[clamp(24px,4vw,48px)] mb-10">
+        <div className="grid grid-cols-2 sm:grid-cols-[1.5fr_1fr_1fr_1fr] gap-[clamp(24px,4vw,48px)] mb-12">
           {/* Brand */}
           <div className="col-span-2 sm:col-span-1">
-            <Link href="/" className="flex items-center gap-[9px] no-underline mb-[10px]">
-              <div className="w-7 h-7 bg-ink rounded-sm grid place-items-center">
+            <Link href="/" className="flex items-center gap-[9px] no-underline mb-3">
+              <div className="w-7 h-7 bg-ink rounded-md grid place-items-center">
                 <LogoIcon className="w-[14px] h-[14px] fill-white" />
               </div>
               <span className="font-sans text-[15px] font-semibold text-ink tracking-[-0.01em]">
                 StrataHQ
               </span>
             </Link>
-            <p className="text-[13px] text-muted leading-[1.6] max-w-[220px]">
+            <p className="text-[13px] text-muted leading-[1.65] max-w-[220px]">
               Body corporate management software built for South Africa&apos;s
               sectional title schemes.
             </p>
@@ -32,7 +32,7 @@ export default function Footer() {
           {/* Link columns */}
           {Object.entries(footerLinks).map(([heading, links]) => (
             <div key={heading}>
-              <div className="text-[12px] font-semibold text-ink tracking-[0.04em] uppercase mb-3">
+              <div className="text-[11px] font-semibold text-ink tracking-[0.06em] uppercase mb-4">
                 {heading}
               </div>
               <ul className="flex flex-col">
@@ -40,7 +40,7 @@ export default function Footer() {
                   <li key={link}>
                     <Link
                       href="#"
-                      className="inline-block text-[13px] text-muted no-underline hover:text-ink transition-colors duration-150 py-[6px]"
+                      className="inline-block text-[13px] text-muted no-underline hover:text-ink transition-colors duration-200 py-[7px]"
                     >
                       {link}
                     </Link>
@@ -52,8 +52,8 @@ export default function Footer() {
         </div>
 
         {/* Bottom bar */}
-        <div className="border-t border-border pt-5 flex flex-wrap justify-between gap-3 text-[12px] text-muted-2">
-          <span>© 2026 StrataHQ. Built in South Africa 🇿🇦</span>
+        <div className="border-t border-border pt-6 flex flex-wrap justify-between gap-3 text-[12px] text-muted-2">
+          <span>&copy; 2026 StrataHQ. Built in South Africa</span>
           <span>Compliant with STSMA Act 8 of 2011</span>
         </div>
       </div>

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -3,52 +3,66 @@ import ScrollRevealInit from './ScrollRevealInit'
 
 export default function Hero() {
   return (
-    <section className="padding-hero">
+    <section className="relative overflow-hidden hero-gradient noise-overlay">
       <ScrollRevealInit />
-      <div className="max-w-container mx-auto px-container">
+
+      {/* Grid overlay */}
+      <div className="absolute inset-0 hero-grid" />
+
+      {/* Glow blobs */}
+      <div className="glow-blob w-[500px] h-[500px] bg-[var(--color-hero-accent)] top-[-100px] right-[-100px] animate-pulse-glow" />
+      <div className="glow-blob w-[400px] h-[400px] bg-[var(--color-hero-warm)] bottom-[-80px] left-[-80px] opacity-30 animate-pulse-glow" style={{ animationDelay: '2s' }} />
+
+      <div className="relative z-10 max-w-[1080px] mx-auto px-container padding-hero pt-[clamp(120px,18vh,180px)]">
         {/* Label pill */}
-        <div className="inline-flex items-center gap-[7px] text-[12px] font-medium text-accent bg-accent-bg border border-[rgba(43,108,176,0.18)] rounded-full px-3 py-1 mb-7 tracking-[0.02em]">
-          <span className="w-[5px] h-[5px] rounded-full bg-accent flex-shrink-0" />
-          Built for South African sectional title
+        <div className="hero-enter hero-enter-1 inline-flex items-center gap-2 text-[12px] font-medium shimmer-badge border border-white/[0.08] rounded-full px-4 py-1.5 mb-8 tracking-[0.03em]">
+          <span className="w-[6px] h-[6px] rounded-full bg-[var(--color-hero-accent)] flex-shrink-0 shadow-[0_0_8px_var(--color-hero-accent)]" />
+          <span className="text-white/60">Built for South African sectional title</span>
         </div>
 
         {/* Heading */}
-        <h1 className="font-serif text-clamp-hero font-bold leading-[1.12] tracking-[-0.02em] text-ink mb-6 max-w-[820px]">
+        <h1 className="hero-enter hero-enter-2 font-serif text-clamp-hero font-bold leading-[1.08] tracking-[-0.03em] text-white mb-7 max-w-[780px]">
           Stop managing schemes.{' '}
-          <br />
-          <em className="text-muted not-italic italic">Start running them.</em>
+          <br className="hidden sm:block" />
+          <span className="bg-gradient-to-r from-[var(--color-hero-accent)] to-[var(--color-hero-warm)] bg-clip-text text-transparent">
+            Start running them.
+          </span>
         </h1>
 
         {/* Subheading */}
-        <p className="text-clamp-sub text-ink-2 max-w-[560px] leading-[1.65] mb-9">
+        <p className="hero-enter hero-enter-3 text-clamp-sub text-white/50 max-w-[540px] leading-[1.7] mb-10">
           StrataHQ replaces the levy spreadsheets, the WhatsApp maintenance threads,
           and the AGM chaos — with one platform that actually knows what needs your
           attention next.
         </p>
 
         {/* CTAs */}
-        <div className="flex flex-wrap items-center gap-[10px] mb-4">
+        <div className="hero-enter hero-enter-4 flex flex-wrap items-center gap-3 mb-5">
           <Link
             href="/early-access"
-            className="px-6 py-[10px] text-[15px] font-medium text-white bg-accent border border-accent
-              rounded hover:opacity-90 transition-opacity duration-150 no-underline"
+            className="group px-7 py-3 text-[15px] font-medium text-white bg-[var(--color-hero-accent)]
+              rounded-lg hover:shadow-[0_0_32px_rgba(91,156,246,0.3)] hover:brightness-110 transition-all duration-300 no-underline inline-flex items-center gap-2"
           >
-            Request early access →
+            Request early access
+            <span className="inline-block transition-transform duration-200 group-hover:translate-x-0.5">→</span>
           </Link>
           <Link
             href="#features"
-            className="px-6 py-[10px] text-[15px] font-medium text-ink-2 bg-surface border border-border-2
-              rounded hover:bg-page transition-colors duration-150 hidden sm:inline-flex no-underline"
+            className="px-7 py-3 text-[15px] font-medium text-white/60 bg-white/[0.04]
+              border border-white/[0.08] rounded-lg hover:text-white hover:bg-white/[0.08] hover:border-white/[0.12] transition-all duration-300 hidden sm:inline-flex no-underline"
           >
             See how it works
           </Link>
         </div>
 
         {/* Note */}
-        <p className="text-[13px] text-muted-2">
-          Limited early access · STSMA compliant · Built for South Africa
+        <p className="hero-enter hero-enter-5 text-[13px] text-white/30 tracking-[0.02em]">
+          Limited early access · STSMA compliant · Built in South Africa
         </p>
       </div>
+
+      {/* Bottom fade */}
+      <div className="absolute bottom-0 left-0 right-0 h-32 bg-gradient-to-t from-[var(--color-page)] to-transparent z-10 dark:from-[#0F0F0E]" />
     </section>
   )
 }

--- a/components/InsightsSection.tsx
+++ b/components/InsightsSection.tsx
@@ -97,18 +97,21 @@ export default function InsightsSection() {
   const [activeAlert, setActiveAlert] = useState(0)
 
   return (
-    <section className="padding-section border-t border-border bg-surface">
-      <div className="max-w-container mx-auto px-container">
+    <section className="relative padding-section border-t border-border overflow-hidden">
+      {/* Subtle background accent */}
+      <div className="absolute inset-0 bg-premium-surface pointer-events-none" />
+
+      <div className="relative max-w-[1080px] mx-auto px-container">
 
         {/* Header */}
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-6 items-end mb-[clamp(36px,5vw,52px)]">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6 items-end mb-[clamp(40px,5vw,56px)]">
           <div>
-            <p className="reveal eyebrow text-[12px] font-semibold tracking-[0.1em] uppercase text-muted mb-3">
+            <p className="reveal eyebrow text-[11px] font-semibold tracking-[0.14em] uppercase text-muted mb-3">
               StrataHQ Intelligence
             </p>
-            <h2 className="reveal font-serif text-clamp-section font-bold leading-[1.15] tracking-[-0.02em] text-ink max-w-[560px]">
+            <h2 className="reveal font-serif text-clamp-section font-bold leading-[1.12] tracking-[-0.02em] text-ink max-w-[560px]">
               Doesn&apos;t just store your data.{' '}
-              <em className="not-italic text-muted">Reads it for you.</em>
+              <span className="text-muted">Reads it for you.</span>
             </h2>
           </div>
           <p className="reveal text-[15px] text-ink-2 leading-[1.7] max-w-[420px]">
@@ -122,7 +125,7 @@ export default function InsightsSection() {
         <div className="stagger grid grid-cols-1 lg:grid-cols-3 gap-4 items-start">
 
           {/* Panel 1: Portfolio Health Score */}
-          <div className="bg-page border border-border rounded-lg p-5">
+          <div className="bg-surface border border-border rounded-xl p-5 card-lift">
             <p className="text-[11px] font-semibold tracking-[0.08em] uppercase text-muted mb-4">
               Portfolio Health Score
             </p>
@@ -156,62 +159,67 @@ export default function InsightsSection() {
           </div>
 
           {/* Panel 2: Predictive Alerts (always-dark navy panel) */}
-          <div className="bg-sidebar-header rounded-lg p-5 lg:col-span-1">
-            <div className="flex items-center justify-between mb-4">
-              <p className="text-[11px] font-semibold tracking-[0.08em] uppercase text-white/50">
-                Predictive Alerts
-              </p>
-              <span className="text-[10px] font-semibold px-2 py-[3px] rounded-full bg-red-bg text-red">
-                3 active
-              </span>
-            </div>
+          <div className="relative overflow-hidden rounded-xl p-5 lg:col-span-1 card-lift" style={{ background: 'linear-gradient(180deg, #1B2C41 0%, #162336 100%)' }}>
+            {/* Subtle glow */}
+            <div className="absolute top-0 right-0 w-32 h-32 bg-[var(--color-hero-accent)] rounded-full filter blur-[60px] opacity-10" />
 
-            {/* Alert tabs */}
-            <div className="flex gap-1 mb-4">
-              {alerts.map((_, i) => (
-                <button
-                  key={i}
-                  onClick={() => setActiveAlert(i)}
-                  className="flex-1 py-[10px] border-none bg-transparent cursor-pointer"
-                  aria-label={`Alert ${i + 1}`}
-                >
-                  <span className={`block h-[3px] w-full rounded-full transition-colors duration-150 ${
-                    activeAlert === i ? 'bg-white/80' : 'bg-white/20'
-                  }`} />
-                </button>
-              ))}
-            </div>
-
-            {/* Active alert */}
-            {alerts.map((a, i) => (
-              <div
-                key={i}
-                className={`transition-opacity duration-200 ${activeAlert === i ? 'block' : 'hidden'}`}
-              >
-                <div className={`inline-flex items-center gap-2 rounded px-2 py-[3px] border mb-3 ${a.color}`}>
-                  <span className="text-[12px]">{a.icon}</span>
-                  <span className={`text-[10px] font-bold tracking-[0.07em] ${a.labelColor}`}>{a.label}</span>
-                </div>
-                <div className="text-[14px] font-semibold text-white leading-[1.3] mb-2">{a.title}</div>
-                <div className="text-[12px] text-white/60 leading-[1.6] mb-4">{a.body}</div>
-                <button
-                  className={`text-[12px] font-medium px-3 py-[6px] rounded border transition-colors duration-150 cursor-pointer ${a.actionColor}`}
-                  onClick={() => {}}
-                >
-                  {a.action}
-                </button>
+            <div className="relative">
+              <div className="flex items-center justify-between mb-4">
+                <p className="text-[11px] font-semibold tracking-[0.08em] uppercase text-white/45">
+                  Predictive Alerts
+                </p>
+                <span className="text-[10px] font-semibold px-2.5 py-1 rounded-full bg-red-bg text-red">
+                  3 active
+                </span>
               </div>
-            ))}
 
-            <div className="mt-5 pt-4 border-t border-white/10">
-              <div className="text-[12px] text-white/40 leading-[1.55]">
-                Alerts are generated from live scheme data — not static rules. StrataHQ learns from payment patterns, SLA history, and fund trajectories.
+              {/* Alert tabs */}
+              <div className="flex gap-1 mb-4">
+                {alerts.map((_, i) => (
+                  <button
+                    key={i}
+                    onClick={() => setActiveAlert(i)}
+                    className="flex-1 py-[10px] border-none bg-transparent cursor-pointer"
+                    aria-label={`Alert ${i + 1}`}
+                  >
+                    <span className={`block h-[3px] w-full rounded-full transition-all duration-300 ${
+                      activeAlert === i ? 'bg-white/80' : 'bg-white/15 hover:bg-white/25'
+                    }`} />
+                  </button>
+                ))}
+              </div>
+
+              {/* Active alert */}
+              {alerts.map((a, i) => (
+                <div
+                  key={i}
+                  className={`transition-all duration-300 ${activeAlert === i ? 'block' : 'hidden'}`}
+                >
+                  <div className={`inline-flex items-center gap-2 rounded-lg px-2.5 py-1 border mb-3 ${a.color}`}>
+                    <span className="text-[12px]">{a.icon}</span>
+                    <span className={`text-[10px] font-bold tracking-[0.07em] ${a.labelColor}`}>{a.label}</span>
+                  </div>
+                  <div className="text-[14px] font-semibold text-white leading-[1.3] mb-2">{a.title}</div>
+                  <div className="text-[12px] text-white/55 leading-[1.6] mb-4">{a.body}</div>
+                  <button
+                    className={`text-[12px] font-medium px-3.5 py-[7px] rounded-lg border transition-colors duration-200 cursor-pointer ${a.actionColor}`}
+                    onClick={() => {}}
+                  >
+                    {a.action}
+                  </button>
+                </div>
+              ))}
+
+              <div className="mt-5 pt-4 border-t border-white/[0.06]">
+                <div className="text-[12px] text-white/35 leading-[1.6]">
+                  Alerts are generated from live scheme data — not static rules. StrataHQ learns from payment patterns, SLA history, and fund trajectories.
+                </div>
               </div>
             </div>
           </div>
 
           {/* Panel 3: Portfolio Analytics preview */}
-          <div className="bg-page border border-border rounded-lg p-5">
+          <div className="bg-surface border border-border rounded-xl p-5 card-lift">
             <p className="text-[11px] font-semibold tracking-[0.08em] uppercase text-muted mb-4">
               Portfolio Analytics
             </p>
@@ -223,7 +231,7 @@ export default function InsightsSection() {
                 { label: 'SLA On-Time', val: '91%', delta: 'Across all schemes', up: false },
                 { label: 'AGMs This Yr', val: '11/12', delta: '1 pending', up: false },
               ].map(({ label, val, delta, up }) => (
-                <div key={label} className="bg-surface border border-border rounded p-3">
+                <div key={label} className="bg-page border border-border rounded-lg p-3">
                   <div className="text-[10px] font-semibold text-muted uppercase tracking-[0.06em] mb-1">{label}</div>
                   <div className="font-serif text-[18px] font-bold text-ink leading-none mb-1">{val}</div>
                   <div className={`text-[11px] ${up ? 'text-green' : 'text-muted'}`}>{delta}</div>
@@ -231,7 +239,7 @@ export default function InsightsSection() {
               ))}
             </div>
 
-            <div className="bg-surface border border-border rounded p-3">
+            <div className="bg-page border border-border rounded-lg p-3">
               <div className="text-[11px] font-semibold text-ink mb-3">Monthly levy collection rate</div>
               <div className="flex items-end gap-[5px] h-[48px]">
                 {[87, 89, 88, 91, 92, 94].map((v, i) => {

--- a/components/ModulesSection.tsx
+++ b/components/ModulesSection.tsx
@@ -73,29 +73,28 @@ const modules = [
 
 export default function ModulesSection() {
   return (
-    <section id="modules" className="padding-section bg-surface">
-      <div className="max-w-container mx-auto px-container">
-        <p className="reveal eyebrow text-[12px] font-semibold tracking-[0.1em] uppercase text-muted mb-3">
-          Platform modules
-        </p>
-        <h2 className="reveal font-serif text-clamp-section font-bold leading-[1.15] tracking-[-0.02em] text-ink mb-4 max-w-[620px]">
-          Everything your scheme needs.
-        </h2>
-        <p className="reveal text-clamp-p text-ink-2 max-w-[520px] leading-[1.7]">
-          Start with your biggest pain point. Add more when you&apos;re ready.
-        </p>
+    <section id="modules" className="padding-section bg-surface border-t border-border">
+      <div className="max-w-[1080px] mx-auto px-container">
+        <div className="text-center max-w-[600px] mx-auto mb-[clamp(40px,6vw,56px)]">
+          <p className="reveal eyebrow text-[11px] font-semibold tracking-[0.14em] uppercase text-muted mb-3">
+            Platform modules
+          </p>
+          <h2 className="reveal font-serif text-clamp-section font-bold leading-[1.12] tracking-[-0.02em] text-ink mb-4">
+            Everything your scheme needs.
+          </h2>
+          <p className="reveal text-clamp-p text-ink-2 leading-[1.7]">
+            Start with your biggest pain point. Add more when you&apos;re ready.
+          </p>
+        </div>
 
         {/* Grid */}
-        <div
-          className="stagger mt-[clamp(32px,5vw,48px)] grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-[1px]
-            bg-border border border-border rounded-lg overflow-hidden"
-        >
+        <div className="stagger grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
           {modules.map(({ iconKey, name, desc }) => (
             <div
               key={name}
-              className="bg-surface p-[clamp(20px,3vw,28px)] hover:bg-page transition-colors duration-150 cursor-default"
+              className="group bg-page border border-border rounded-xl p-[clamp(22px,3vw,28px)] card-lift glow-border cursor-default"
             >
-              <div className="w-9 h-9 rounded-lg border border-border bg-page grid place-items-center text-ink-2 mb-[14px] shadow-sm">
+              <div className="w-10 h-10 rounded-xl border border-border bg-surface grid place-items-center text-ink-2 mb-4 shadow-sm group-hover:text-accent group-hover:border-accent/20 transition-colors duration-200">
                 {icons[iconKey]}
               </div>
               <div className="text-[15px] font-semibold text-ink mb-[6px] tracking-[-0.01em]">

--- a/components/Nav.tsx
+++ b/components/Nav.tsx
@@ -1,58 +1,114 @@
+'use client'
+
 import Link from 'next/link'
+import { useState } from 'react'
 import LogoIcon from './LogoIcon'
 
+const navLinks = [
+  { label: 'Features', href: '#features' },
+  { label: 'Modules', href: '#modules' },
+  { label: "Who it's for", href: '#roles' },
+  { label: 'Pricing', href: '#pricing' },
+]
+
 export default function Nav() {
+  const [open, setOpen] = useState(false)
+
   return (
-    <nav className="sticky top-0 z-50 border-b border-border nav-surface backdrop-blur-[12px]">
-      <div className="max-w-container mx-auto px-container flex items-center justify-between gap-6 h-14">
-        {/* Logo */}
-        <Link href="/" className="flex items-center gap-[9px] flex-shrink-0 no-underline">
-          <div className="w-7 h-7 bg-sidebar-header rounded-sm grid place-items-center">
-            <LogoIcon className="w-[14px] h-[14px] fill-white" />
+    <>
+      <nav className="fixed top-4 left-1/2 -translate-x-1/2 z-50 w-[calc(100%-32px)] max-w-[1080px]">
+        <div className="landing-nav rounded-xl px-5 py-3 flex items-center justify-between gap-6">
+          {/* Logo */}
+          <Link href="/" className="flex items-center gap-[9px] flex-shrink-0 no-underline">
+            <div className="w-7 h-7 bg-[var(--color-hero-accent)] rounded-md grid place-items-center">
+              <LogoIcon className="w-[14px] h-[14px] fill-white" />
+            </div>
+            <span className="font-sans text-[15px] font-semibold text-white tracking-[-0.01em]">
+              StrataHQ
+            </span>
+          </Link>
+
+          {/* Nav links — hidden on mobile */}
+          <ul className="hidden md:flex items-center gap-0.5 list-none">
+            {navLinks.map(({ label, href }) => (
+              <li key={label}>
+                <Link
+                  href={href}
+                  className="px-3 py-2 rounded-lg text-[13px] text-white/50 no-underline font-normal
+                    hover:text-white hover:bg-white/[0.06] transition-all duration-200"
+                >
+                  {label}
+                </Link>
+              </li>
+            ))}
+          </ul>
+
+          {/* Actions */}
+          <div className="hidden md:flex items-center gap-2">
+            <Link
+              href="/auth/login"
+              className="px-4 py-2 text-[13px] font-medium text-white/70 bg-transparent
+                border border-white/10 rounded-lg hover:text-white hover:border-white/20 hover:bg-white/[0.04] transition-all duration-200 no-underline"
+            >
+              Log in
+            </Link>
+            <Link
+              href="/early-access"
+              className="px-4 py-2 text-[13px] font-medium text-white bg-[var(--color-hero-accent)]
+                rounded-lg hover:brightness-110 transition-all duration-200 no-underline"
+            >
+              Request early access
+            </Link>
           </div>
-          <span className="font-sans text-[15px] font-semibold text-ink tracking-[-0.01em]">
-            StrataHQ
-          </span>
-        </Link>
 
-        {/* Nav links — hidden on mobile */}
-        <ul className="hidden sm:flex items-center gap-1 list-none">
-          {[
-            { label: 'Features', href: '#features' },
-            { label: 'Modules', href: '#modules' },
-            { label: "Who it's for", href: '#roles' },
-            { label: 'Pricing', href: '#pricing' },
-          ].map(({ label, href }) => (
-            <li key={label}>
-              <Link
-                href={href}
-                className="px-[10px] py-[11px] rounded-sm text-[14px] text-muted no-underline font-normal
-                  hover:text-ink hover:bg-hover-subtle transition-colors duration-150"
-              >
-                {label}
-              </Link>
-            </li>
-          ))}
-        </ul>
+          {/* Mobile hamburger */}
+          <button
+            onClick={() => setOpen(!open)}
+            className="md:hidden flex flex-col justify-center items-center gap-[5px] w-8 h-8 bg-transparent border-none cursor-pointer"
+            aria-label="Toggle menu"
+          >
+            <span className={`block w-5 h-[1.5px] bg-white/70 rounded-full transition-all duration-300 ${open ? 'rotate-45 translate-y-[6.5px]' : ''}`} />
+            <span className={`block w-5 h-[1.5px] bg-white/70 rounded-full transition-all duration-300 ${open ? 'opacity-0 scale-x-0' : ''}`} />
+            <span className={`block w-5 h-[1.5px] bg-white/70 rounded-full transition-all duration-300 ${open ? '-rotate-45 -translate-y-[6.5px]' : ''}`} />
+          </button>
+        </div>
+      </nav>
 
-        {/* Actions */}
-        <div className="flex items-center gap-2">
+      {/* Mobile menu overlay */}
+      <div
+        className={`fixed inset-0 z-40 mobile-menu-overlay flex flex-col items-center justify-center gap-6 transition-all duration-300 md:hidden ${
+          open ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'
+        }`}
+      >
+        {navLinks.map(({ label, href }) => (
+          <Link
+            key={label}
+            href={href}
+            onClick={() => setOpen(false)}
+            className="text-[20px] font-serif font-semibold text-white/80 no-underline hover:text-white transition-colors duration-200"
+          >
+            {label}
+          </Link>
+        ))}
+        <div className="flex flex-col gap-3 mt-4 w-56">
           <Link
             href="/auth/login"
-            className="px-[14px] py-[10px] text-[14px] font-medium text-ink-2 bg-transparent
-              border border-border-2 rounded hover:bg-hover-subtle transition-colors duration-150 no-underline"
+            onClick={() => setOpen(false)}
+            className="w-full text-center px-5 py-3 text-[14px] font-medium text-white/70
+              border border-white/15 rounded-lg hover:bg-white/[0.05] transition-all duration-200 no-underline"
           >
             Log in
           </Link>
           <Link
             href="/early-access"
-            className="px-4 py-[10px] text-[14px] font-medium text-white bg-accent
-              border border-accent rounded hover:opacity-90 transition-opacity duration-150 no-underline"
+            onClick={() => setOpen(false)}
+            className="w-full text-center px-5 py-3 text-[14px] font-medium text-white bg-[var(--color-hero-accent)]
+              rounded-lg hover:brightness-110 transition-all duration-200 no-underline"
           >
             Request early access
           </Link>
         </div>
       </div>
-    </nav>
+    </>
   )
 }

--- a/components/PricingSection.tsx
+++ b/components/PricingSection.tsx
@@ -54,61 +54,63 @@ const tiers: PricingTier[] = [
 
 export default function PricingSection() {
   return (
-    <section id="pricing" className="padding-section bg-page border-b border-border">
-      <div className="max-w-container mx-auto px-container">
-        <p className="reveal eyebrow text-[12px] font-semibold tracking-[0.1em] uppercase text-muted mb-3">
-          Pricing
-        </p>
-        <h2 className="reveal font-serif text-clamp-section font-bold leading-[1.15] tracking-[-0.02em] text-ink mb-4 max-w-[620px]">
-          Simple, transparent pricing.
-        </h2>
-        <p className="reveal text-clamp-p text-ink-2 max-w-[520px] leading-[1.7]">
-          Per-unit pricing that scales with your scheme. No setup fees, no hidden costs.
-        </p>
+    <section id="pricing" className="padding-section border-t border-border">
+      <div className="max-w-[1080px] mx-auto px-container">
+        <div className="text-center max-w-[600px] mx-auto mb-[clamp(40px,6vw,56px)]">
+          <p className="reveal eyebrow text-[11px] font-semibold tracking-[0.14em] uppercase text-muted mb-3">
+            Pricing
+          </p>
+          <h2 className="reveal font-serif text-clamp-section font-bold leading-[1.12] tracking-[-0.02em] text-ink mb-4">
+            Simple, transparent pricing.
+          </h2>
+          <p className="reveal text-clamp-p text-ink-2 leading-[1.7]">
+            Per-unit pricing that scales with your scheme. No setup fees, no hidden costs.
+          </p>
+        </div>
 
         {/* Cards */}
-        <div className="stagger mt-[clamp(32px,5vw,48px)] grid grid-cols-1 sm:grid-cols-3 gap-3 max-w-[380px] sm:max-w-none">
+        <div className="stagger grid grid-cols-1 sm:grid-cols-3 gap-4 max-w-[400px] sm:max-w-none mx-auto">
           {tiers.map(({ name, amount, per, features, cta, featured }) => (
             <div
               key={name}
-              className={`relative rounded-lg p-[clamp(22px,3vw,32px)] border transition-shadow duration-200 hover:shadow
+              className={`relative rounded-xl p-[clamp(24px,3vw,32px)] border transition-all duration-300
                 ${featured
-                  ? 'bg-sidebar-header border-sidebar-header'
-                  : 'bg-surface border-border'
+                  ? 'pricing-featured border-white/[0.08] shadow-[0_0_60px_rgba(91,156,246,0.08)]'
+                  : 'bg-surface border-border card-lift'
                 }`}
             >
               {featured && (
-                <span className="absolute -top-[11px] left-1/2 -translate-x-1/2 text-[11px] font-semibold text-white bg-accent px-3 py-[3px] rounded-full whitespace-nowrap tracking-[0.04em]">
+                <span className="absolute -top-[12px] left-1/2 -translate-x-1/2 text-[11px] font-semibold text-white bg-[var(--color-hero-accent)] px-4 py-1 rounded-full whitespace-nowrap tracking-[0.04em] shadow-[0_0_16px_rgba(91,156,246,0.3)]">
                   Most popular
                 </span>
               )}
 
-              <div className={`text-[13px] font-semibold mb-3 ${featured ? 'text-white/50' : 'text-muted'}`}>
+              <div className={`text-[13px] font-semibold mb-3 ${featured ? 'text-white/45' : 'text-muted'}`}>
                 {name}
               </div>
               <div className={`font-serif text-clamp-price font-bold tracking-[-0.03em] leading-none mb-1 ${featured ? 'text-white' : 'text-ink'}`}>
                 {amount}
               </div>
-              <div className={`text-[13px] mb-5 ${featured ? 'text-white/50' : 'text-muted'}`}>
+              <div className={`text-[13px] mb-6 ${featured ? 'text-white/45' : 'text-muted'}`}>
                 {per}
               </div>
 
-              <hr className={`border-none border-t my-4 ${featured ? 'border-white/[0.12]' : 'border-border'}`} style={{ borderTopWidth: 1 }} />
+              <hr className={`border-none h-[1px] my-5 ${featured ? 'bg-white/[0.08]' : 'bg-border'}`} />
 
-              <ul className="flex flex-col gap-2">
+              <ul className="flex flex-col gap-2.5">
                 {features.map((f) => (
-                  <li key={f} className={`text-[13px] flex items-center gap-2 ${featured ? 'text-white/75' : 'text-ink-2'}`}>
-                    <span className={`text-[11px] flex-shrink-0 ${featured ? 'text-green' : 'text-green'}`}>✓</span>
+                  <li key={f} className={`text-[13px] flex items-center gap-2.5 ${featured ? 'text-white/65' : 'text-ink-2'}`}>
+                    <span className={`text-[11px] flex-shrink-0 font-bold ${featured ? 'text-[var(--color-hero-accent)]' : 'text-green'}`}>✓</span>
                     {f}
                   </li>
                 ))}
               </ul>
 
               <Link
-                href="#"
-                className={`block w-full mt-6 py-[10px] text-center text-[14px] font-medium rounded border no-underline transition-colors duration-150
+                href="/early-access"
+                className={`block w-full mt-7 py-3 text-center text-[14px] font-medium rounded-lg border no-underline transition-all duration-200
                   ${featured
-                    ? 'bg-white/10 border-white/20 text-white hover:bg-white/20'
+                    ? 'bg-[var(--color-hero-accent)] border-[var(--color-hero-accent)] text-white hover:brightness-110 hover:shadow-[0_0_24px_rgba(91,156,246,0.25)]'
                     : 'bg-page border-border-2 text-ink hover:bg-hover-subtle'
                   }`}
               >

--- a/components/ProblemSection.tsx
+++ b/components/ProblemSection.tsx
@@ -36,24 +36,25 @@ const timeline = [
 export default function ProblemSection() {
   return (
     <section id="features" className="padding-section">
-      <div className="max-w-container mx-auto px-container">
-
-        <div className="grid grid-cols-1 md:grid-cols-[360px_1fr] gap-[clamp(40px,6vw,80px)] items-start">
+      <div className="max-w-[1080px] mx-auto px-container">
+        <div className="grid grid-cols-1 lg:grid-cols-[380px_1fr] gap-[clamp(40px,6vw,80px)] items-start">
 
           {/* Left */}
           <div>
-            <p className="eyebrow reveal text-[12px] font-semibold tracking-[0.1em] uppercase text-muted mb-3">
+            <p className="reveal eyebrow text-[11px] font-semibold tracking-[0.14em] uppercase text-muted mb-3">
               The problem
             </p>
-            <h2 className="reveal font-serif text-clamp-section font-bold leading-[1.15] tracking-[-0.02em] text-ink mb-4 max-w-[560px]">
-              A typical week without StrataHQ.
+            <h2 className="reveal font-serif text-clamp-section font-bold leading-[1.12] tracking-[-0.02em] text-ink mb-5 max-w-[560px]">
+              A typical week <br className="hidden sm:block" />without StrataHQ.
             </h2>
-            <p className="reveal text-clamp-p text-ink-2 leading-[1.7] mb-6">
+            <p className="reveal text-clamp-p text-ink-2 leading-[1.7] mb-8">
               Not a worst-case scenario. Just Tuesday.
             </p>
-            <div className="reveal hidden md:block">
-              <div className="bg-page border border-border rounded-lg p-4 mt-2">
-                <div className="text-[11px] font-semibold text-muted uppercase tracking-[0.08em] mb-3">
+
+            {/* Hours lost panel */}
+            <div className="reveal hidden lg:block">
+              <div className="bg-surface border border-border rounded-xl p-5 card-lift">
+                <div className="text-[11px] font-semibold text-muted uppercase tracking-[0.08em] mb-4">
                   Hours lost per month (avg)
                 </div>
                 {[
@@ -62,20 +63,20 @@ export default function ProblemSection() {
                   { label: 'AGM admin', hours: 6, max: 20 },
                   { label: 'Trustee reporting', hours: 7, max: 20 },
                 ].map(({ label, hours, max }) => (
-                  <div key={label} className="mb-3 last:mb-0">
-                    <div className="flex justify-between text-[12px] text-ink-2 mb-[5px]">
+                  <div key={label} className="mb-3.5 last:mb-0">
+                    <div className="flex justify-between text-[12px] text-ink-2 mb-[6px]">
                       <span>{label}</span>
                       <span className="font-semibold text-ink">{hours}h</span>
                     </div>
-                    <div className="h-[5px] bg-border rounded-full overflow-hidden">
+                    <div className="h-[5px] bg-page rounded-full overflow-hidden">
                       <div
-                        className="h-full rounded-full bg-ink"
+                        className="h-full rounded-full bg-gradient-to-r from-accent to-[var(--color-hero-accent)]"
                         style={{ width: `${(hours / max) * 100}%` }}
                       />
                     </div>
                   </div>
                 ))}
-                <div className="mt-4 pt-3 border-t border-border text-[12px] text-muted">
+                <div className="mt-5 pt-4 border-t border-border text-[12px] text-muted">
                   <span className="font-semibold text-ink">35 hours/month</span> of recoverable admin — per managing agent.
                 </div>
               </div>
@@ -85,29 +86,29 @@ export default function ProblemSection() {
           {/* Timeline */}
           <div className="stagger relative">
             {/* Vertical line */}
-            <div className="absolute left-[19px] top-6 bottom-6 w-[1px] bg-border hidden sm:block" />
+            <div className="absolute left-[19px] top-6 bottom-6 w-[1px] bg-gradient-to-b from-border via-accent/20 to-border hidden sm:block" />
 
-            <div className="flex flex-col gap-[2px]">
+            <div className="flex flex-col gap-1">
               {timeline.map(({ time, icon, color, dotColor, event, detail }) => (
                 <div
                   key={time}
-                  className="flex gap-4 px-[18px] py-4 rounded-lg hover:bg-hover-subtle transition-colors duration-150 cursor-default"
+                  className="group flex gap-4 px-[18px] py-4 rounded-xl hover:bg-surface hover:shadow-sm transition-all duration-200 cursor-default"
                 >
                   {/* Dot */}
                   <div className="relative flex-shrink-0 pt-[3px] hidden sm:block">
-                    <div className={`w-[9px] h-[9px] rounded-full ${dotColor} mt-[5px]`} />
+                    <div className={`w-[9px] h-[9px] rounded-full ${dotColor} mt-[5px] ring-4 ring-page group-hover:ring-surface transition-all duration-200`} />
                   </div>
 
                   {/* Content */}
                   <div className="flex-1 min-w-0">
                     <div className="flex flex-wrap items-center gap-2 mb-2">
-                      <span className={`inline-flex items-center gap-[6px] text-[11px] font-semibold px-2 py-[3px] rounded border ${color}`}>
+                      <span className={`inline-flex items-center gap-[6px] text-[11px] font-semibold px-2.5 py-1 rounded-lg border ${color}`}>
                         <span>{icon}</span>
                         <span className="font-mono tracking-[0.02em]">{time}</span>
                       </span>
                     </div>
                     <div className="text-[14px] font-semibold text-ink mb-[4px]">{event}</div>
-                    <div className="text-[13px] text-muted leading-[1.55]">{detail}</div>
+                    <div className="text-[13px] text-muted leading-[1.6]">{detail}</div>
                   </div>
                 </div>
               ))}
@@ -115,7 +116,7 @@ export default function ProblemSection() {
               {/* Footer note */}
               <div className="flex gap-4 px-[18px] py-4">
                 <div className="flex-shrink-0 hidden sm:block w-[9px]" />
-                <div className="text-[13px] text-muted italic border-t border-border pt-4 w-full">
+                <div className="text-[13px] text-muted italic border-t border-border pt-5 w-full">
                   This is the job right now. StrataHQ doesn&apos;t change what you manage —
                   it changes how much of it needs you.
                 </div>

--- a/components/QuoteSection.tsx
+++ b/components/QuoteSection.tsx
@@ -27,15 +27,17 @@ const testimonials = [
 
 export default function QuoteSection() {
   return (
-    <section className="border-t border-b border-border bg-surface">
-      <div className="max-w-container mx-auto px-container py-[clamp(56px,8vw,80px)]">
+    <section className="relative border-t border-border overflow-hidden">
+      {/* Subtle background */}
+      <div className="absolute inset-0 bg-premium-surface pointer-events-none" />
 
+      <div className="relative max-w-[1080px] mx-auto px-container py-[clamp(64px,10vh,112px)]">
         {/* Section label */}
-        <div className="text-center mb-[clamp(32px,5vw,48px)]">
-          <p className="text-[12px] font-semibold tracking-[0.1em] uppercase text-muted mb-3">
+        <div className="text-center mb-[clamp(40px,5vw,56px)]">
+          <p className="reveal text-[11px] font-semibold tracking-[0.14em] uppercase text-muted mb-3">
             What managers say
           </p>
-          <h2 className="font-serif text-clamp-section font-bold leading-[1.15] tracking-[-0.02em] text-ink max-w-[520px] mx-auto">
+          <h2 className="reveal font-serif text-clamp-section font-bold leading-[1.12] tracking-[-0.02em] text-ink max-w-[520px] mx-auto">
             Real results from real schemes.
           </h2>
         </div>
@@ -45,7 +47,7 @@ export default function QuoteSection() {
           {testimonials.map(({ quote, name, title, location, stat, statLabel }) => (
             <div
               key={name}
-              className="bg-page border border-border rounded-lg p-[clamp(22px,3vw,30px)] flex flex-col gap-5 hover:border-border-2 hover:shadow-sm transition-all duration-200"
+              className="relative bg-surface border border-border rounded-xl p-[clamp(24px,3vw,32px)] flex flex-col gap-5 card-lift glow-border quote-mark"
             >
               {/* Stat callout */}
               <div className="flex items-baseline gap-2">
@@ -56,7 +58,7 @@ export default function QuoteSection() {
               </div>
 
               {/* Quote */}
-              <blockquote className="font-serif text-[clamp(14px,1.6vw,16px)] italic text-ink leading-[1.6] flex-1">
+              <blockquote className="font-serif text-[clamp(14px,1.6vw,16px)] italic text-ink-2 leading-[1.65] flex-1">
                 &ldquo;{quote}&rdquo;
               </blockquote>
 
@@ -71,7 +73,7 @@ export default function QuoteSection() {
         </div>
 
         {/* Social proof strip */}
-        <div className="mt-[clamp(24px,4vw,36px)] flex flex-wrap items-center justify-center gap-[clamp(16px,3vw,32px)] text-[13px] text-muted">
+        <div className="mt-[clamp(32px,5vw,48px)] flex flex-wrap items-center justify-center gap-[clamp(16px,3vw,32px)] text-[13px] text-muted">
           <span className="font-semibold text-ink">2,400+</span> schemes managed
           <span className="text-border-2">·</span>
           <span className="font-semibold text-ink">94%</span> average collection rate

--- a/components/RolesSection.tsx
+++ b/components/RolesSection.tsx
@@ -16,7 +16,7 @@ interface Role {
   features: RoleFeature[]
 }
 
-// Role tab icons — building, person, home
+// Role tab icons
 const roleIcons: Record<string, React.ReactNode> = {
   agents: (
     <svg viewBox="0 0 16 16" fill="none" className="w-4 h-4 flex-shrink-0" aria-hidden>
@@ -38,7 +38,7 @@ const roleIcons: Record<string, React.ReactNode> = {
   ),
 }
 
-// Feature card icons — minimal strokes
+// Feature card icons
 const featureIcons: Record<string, React.ReactNode> = {
   dashboard: (
     <svg viewBox="0 0 16 16" fill="none" className="w-[15px] h-[15px]" aria-hidden>
@@ -162,24 +162,24 @@ export default function RolesSection() {
 
   return (
     <section id="roles" className="padding-section border-t border-border">
-      <div className="max-w-container mx-auto px-container">
-        <p className="reveal eyebrow text-[12px] font-semibold tracking-[0.1em] uppercase text-muted mb-3">
+      <div className="max-w-[1080px] mx-auto px-container">
+        <p className="reveal eyebrow text-[11px] font-semibold tracking-[0.14em] uppercase text-muted mb-3">
           Who it&apos;s for
         </p>
-        <h2 className="reveal font-serif text-clamp-section font-bold leading-[1.15] tracking-[-0.02em] text-ink mb-[clamp(32px,5vw,48px)] max-w-[620px]">
+        <h2 className="reveal font-serif text-clamp-section font-bold leading-[1.12] tracking-[-0.02em] text-ink mb-[clamp(36px,5vw,52px)] max-w-[620px]">
           Built for everyone in the scheme.
         </h2>
 
-        <div className="grid grid-cols-1 md:grid-cols-[220px_1fr] gap-[clamp(24px,4vw,48px)] items-start">
+        <div className="grid grid-cols-1 md:grid-cols-[240px_1fr] gap-[clamp(24px,4vw,48px)] items-start">
           {/* Role nav */}
-          <div className="reveal flex flex-col gap-[2px] md:sticky md:top-[72px]">
+          <div className="reveal flex flex-row md:flex-col gap-1 md:sticky md:top-[80px] overflow-x-auto pb-2 md:pb-0">
             {roles.map((role) => (
               <button
                 key={role.id}
                 onClick={() => setActiveId(role.id)}
-                className={`w-full text-left px-[14px] py-[11px] rounded border-none text-[14px] cursor-pointer flex items-center gap-[10px] transition-colors duration-150
+                className={`whitespace-nowrap md:w-full text-left px-4 py-3 rounded-xl border-none text-[14px] cursor-pointer flex items-center gap-[10px] transition-all duration-200
                   ${activeId === role.id
-                    ? 'bg-hover-subtle text-ink font-medium'
+                    ? 'bg-surface text-ink font-medium shadow-sm border border-border'
                     : 'bg-transparent text-muted font-normal hover:bg-hover-subtle hover:text-ink'
                   }`}
               >
@@ -194,15 +194,15 @@ export default function RolesSection() {
             <h3 className="font-serif text-clamp-role font-bold tracking-[-0.015em] text-ink mb-2">
               {active.heading}
             </h3>
-            <p className="text-[15px] text-ink-2 leading-[1.65] mb-7">{active.sub}</p>
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-[10px]">
+            <p className="text-[15px] text-ink-2 leading-[1.65] mb-8">{active.sub}</p>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
               {active.features.map(({ iconKey, title, desc }) => (
                 <div
                   key={title}
-                  className="bg-surface border border-border rounded p-4 hover:border-border-2 hover:shadow-sm transition-all duration-150"
+                  className="bg-surface border border-border rounded-xl p-5 card-lift glow-border"
                 >
-                  <span className="text-ink-2 mb-2 block">{featureIcons[iconKey]}</span>
-                  <div className="text-[13px] font-semibold text-ink mb-1">{title}</div>
+                  <span className="text-accent mb-2.5 block">{featureIcons[iconKey]}</span>
+                  <div className="text-[14px] font-semibold text-ink mb-1">{title}</div>
                   <div className="text-[12px] text-muted leading-[1.55]">{desc}</div>
                 </div>
               ))}

--- a/components/StatsBar.tsx
+++ b/components/StatsBar.tsx
@@ -7,12 +7,12 @@ const stats = [
 
 export default function StatsBar() {
   return (
-    <div className="border-t border-b border-border bg-surface py-[clamp(20px,3vw,28px)]">
-      <div className="max-w-container mx-auto px-container">
-        <div className="stagger flex flex-wrap justify-between gap-[clamp(16px,3vw,32px)]">
+    <div className="relative bg-surface border-y border-border py-[clamp(28px,4vw,40px)]">
+      <div className="max-w-[1080px] mx-auto px-container">
+        <div className="stagger grid grid-cols-2 md:grid-cols-4 gap-y-6 gap-x-4">
           {stats.map(({ num, label }) => (
-            <div key={label} className="text-left">
-              <div className="font-serif text-clamp-stat font-bold text-ink tracking-[-0.03em] leading-none mb-1">
+            <div key={label} className="text-center md:text-left">
+              <div className="font-serif text-clamp-stat font-bold text-ink tracking-[-0.03em] leading-none mb-1.5">
                 {num}
               </div>
               <div className="text-[13px] text-muted">{label}</div>


### PR DESCRIPTION
## Summary

- **Hero**: Cinematic dark gradient with mesh radial glows, noise texture, subtle grid, gradient headline, and staggered entrance animations — sets a dramatically higher visual bar from first impression
- **Nav**: Floating glassmorphism pill nav with animated mobile hamburger drawer, replacing the flat sticky bar
- **All sections**: Unified premium system — rounded-xl cards, hover-lift transforms, glow-border hover effects, and refined typography across every section
- **PricingSection**: Featured plan gets a dark gradient background with blue glow accent and luminous CTA; CTASection mirrors the hero for a cinematic close
- **globals.css**: New animation system (`shimmer`, `float`, `pulseGlow`, `heroSlideUp`), glow utilities, noise overlay, hero mesh gradients, and premium card hover classes

## What was NOT touched

All dashboard pages under `app/app/` remain completely unchanged.

## Test Plan

- [ ] Landing page renders correctly at `/`
- [ ] Nav floats correctly and collapses to hamburger on mobile
- [ ] Hero gradient and glow blobs display without layout shift
- [ ] All section scroll-reveal animations trigger on scroll
- [ ] Mobile layout is clean at 375px, 390px, and 768px
- [ ] Dark mode renders correctly across all sections
- [ ] Pricing CTA links resolve to `/early-access`
- [ ] All 30 existing tests pass (`npm test`)