### PR TITLE
Add security headers and audit event logging

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stratahq/backend/internal/agm"
 	"github.com/stratahq/backend/internal/ai"
+	"github.com/stratahq/backend/internal/audit"
 	"github.com/stratahq/backend/internal/auth"
 	"github.com/stratahq/backend/internal/billing"
 	"github.com/stratahq/backend/internal/communications"
@@ -107,6 +108,7 @@ func main() {
 	billingService := billing.NewService(db, billingProvider, cfg.AppBaseURL)
 	invitationService := invitation.NewService(db, emailClient, cfg.JWTSecret, cfg.JWTExpiry, cfg.RefreshExpiry)
 	earlyAccessService := earlyaccess.NewService(db.Q, authService, emailClient, cfg.BackendBaseURL, cfg.AppBaseURL, cfg.AdminEmail, cfg.AdminSecret)
+	auditService := audit.NewService(db)
 
 	// Handlers
 	handlers := server.Handlers{
@@ -129,7 +131,7 @@ func main() {
 	}
 
 	// Router & Server
-	router := server.NewRouter(cfg, logger, rdb, handlers)
+	router := server.NewRouter(cfg, logger, rdb, auditService, handlers)
 	srv := server.New(router, cfg.Port, logger)
 
 	logger.Info("starting server", "port", cfg.Port, "env", cfg.Env)

--- a/backend/db/migrations/00016_audit_events.sql
+++ b/backend/db/migrations/00016_audit_events.sql
@@ -1,0 +1,28 @@
+-- +goose Up
+
+CREATE TABLE audit_events (
+    id            UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    actor_user_id UUID        REFERENCES users(id) ON DELETE SET NULL,
+    org_id        UUID        REFERENCES orgs(id) ON DELETE SET NULL,
+    actor_role    TEXT,
+    method        TEXT        NOT NULL,
+    path          TEXT        NOT NULL,
+    route_pattern TEXT        NOT NULL,
+    status_code   INTEGER     NOT NULL CHECK (status_code >= 100 AND status_code <= 599),
+    ip_address    TEXT        NOT NULL,
+    user_agent    TEXT        NOT NULL DEFAULT '',
+    occurred_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_audit_events_occurred_at ON audit_events (occurred_at DESC);
+CREATE INDEX idx_audit_events_org_id_occurred_at ON audit_events (org_id, occurred_at DESC);
+CREATE INDEX idx_audit_events_actor_user_id_occurred_at ON audit_events (actor_user_id, occurred_at DESC);
+CREATE INDEX idx_audit_events_route_pattern_occurred_at ON audit_events (route_pattern, occurred_at DESC);
+
+-- +goose Down
+
+DROP INDEX IF EXISTS idx_audit_events_route_pattern_occurred_at;
+DROP INDEX IF EXISTS idx_audit_events_actor_user_id_occurred_at;
+DROP INDEX IF EXISTS idx_audit_events_org_id_occurred_at;
+DROP INDEX IF EXISTS idx_audit_events_occurred_at;
+DROP TABLE IF EXISTS audit_events;

--- a/backend/internal/audit/service.go
+++ b/backend/internal/audit/service.go
@@ -1,0 +1,98 @@
+package audit
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgconn"
+
+	"github.com/stratahq/backend/internal/platform/database"
+)
+
+type Event struct {
+	OccurredAt   time.Time
+	StatusCode   int
+	ActorUserID  string
+	OrgID        string
+	ActorRole    string
+	Method       string
+	Path         string
+	RoutePattern string
+	IPAddress    string
+	UserAgent    string
+}
+
+type Recorder interface {
+	Record(ctx context.Context, event Event) error
+}
+
+type execer interface {
+	Exec(ctx context.Context, sql string, arguments ...interface{}) (pgconn.CommandTag, error)
+}
+
+type Service struct {
+	db execer
+}
+
+func NewService(db *database.Pool) *Service {
+	return &Service{db: db}
+}
+
+const insertAuditEvent = `
+INSERT INTO audit_events (
+	actor_user_id,
+	org_id,
+	actor_role,
+	method,
+	path,
+	route_pattern,
+	status_code,
+	ip_address,
+	user_agent,
+	occurred_at
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+`
+
+func (s *Service) Record(ctx context.Context, event Event) error {
+	if s == nil || s.db == nil {
+		return nil
+	}
+
+	occurredAt := event.OccurredAt.UTC()
+	if occurredAt.IsZero() {
+		occurredAt = time.Now().UTC()
+	}
+
+	routePattern := strings.TrimSpace(event.RoutePattern)
+	if routePattern == "" {
+		routePattern = strings.TrimSpace(event.Path)
+	}
+
+	_, err := s.db.Exec(ctx, insertAuditEvent,
+		parseOptionalUUID(event.ActorUserID),
+		parseOptionalUUID(event.OrgID),
+		strings.TrimSpace(event.ActorRole),
+		strings.TrimSpace(event.Method),
+		strings.TrimSpace(event.Path),
+		routePattern,
+		event.StatusCode,
+		strings.TrimSpace(event.IPAddress),
+		strings.TrimSpace(event.UserAgent),
+		occurredAt,
+	)
+	return err
+}
+
+func parseOptionalUUID(value string) interface{} {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return nil
+	}
+	parsed, err := uuid.Parse(trimmed)
+	if err != nil {
+		return nil
+	}
+	return parsed
+}

--- a/backend/internal/audit/service.go
+++ b/backend/internal/audit/service.go
@@ -12,8 +12,6 @@ import (
 )
 
 type Event struct {
-	OccurredAt   time.Time
-	StatusCode   int
 	ActorUserID  string
 	OrgID        string
 	ActorRole    string
@@ -22,6 +20,8 @@ type Event struct {
 	RoutePattern string
 	IPAddress    string
 	UserAgent    string
+	OccurredAtNS int64
+	StatusCode   int
 }
 
 type Recorder interface {
@@ -60,8 +60,8 @@ func (s *Service) Record(ctx context.Context, event Event) error {
 		return nil
 	}
 
-	occurredAt := event.OccurredAt.UTC()
-	if occurredAt.IsZero() {
+	occurredAt := time.Unix(0, event.OccurredAtNS).UTC()
+	if event.OccurredAtNS == 0 {
 		occurredAt = time.Now().UTC()
 	}
 

--- a/backend/internal/middleware/audit.go
+++ b/backend/internal/middleware/audit.go
@@ -1,0 +1,79 @@
+package middleware
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/stratahq/backend/internal/audit"
+	"github.com/stratahq/backend/internal/auth"
+)
+
+func AuditEvents(recorder audit.Recorder, logger *slog.Logger) func(http.Handler) http.Handler {
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	return func(next http.Handler) http.Handler {
+		if recorder == nil {
+			return next
+		}
+
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if !shouldAuditRequest(r.Method) {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			wrapped := &wrappedWriter{ResponseWriter: w, statusCode: http.StatusOK}
+			next.ServeHTTP(wrapped, r)
+
+			event := audit.Event{
+				OccurredAt:   time.Now().UTC(),
+				StatusCode:   wrapped.statusCode,
+				Method:       r.Method,
+				Path:         r.URL.Path,
+				RoutePattern: routePattern(r),
+				IPAddress:    clientIP(r),
+				UserAgent:    r.UserAgent(),
+			}
+
+			if identity, ok := auth.IdentityFromRequest(r); ok {
+				event.ActorUserID = identity.UserID
+				event.OrgID = identity.OrgID
+				event.ActorRole = identity.Role
+			}
+
+			if err := recorder.Record(context.WithoutCancel(r.Context()), event); err != nil {
+				logger.Error("record audit event",
+					"error", err,
+					"method", event.Method,
+					"path", event.Path,
+					"status", event.StatusCode,
+				)
+			}
+		})
+	}
+}
+
+func shouldAuditRequest(method string) bool {
+	switch method {
+	case http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete:
+		return true
+	default:
+		return false
+	}
+}
+
+func routePattern(r *http.Request) string {
+	if r == nil {
+		return ""
+	}
+	if routeCtx := chi.RouteContext(r.Context()); routeCtx != nil {
+		return routeCtx.RoutePattern()
+	}
+	return ""
+}

--- a/backend/internal/middleware/audit.go
+++ b/backend/internal/middleware/audit.go
@@ -32,13 +32,13 @@ func AuditEvents(recorder audit.Recorder, logger *slog.Logger) func(http.Handler
 			next.ServeHTTP(wrapped, r)
 
 			event := audit.Event{
-				OccurredAt:   time.Now().UTC(),
-				StatusCode:   wrapped.statusCode,
 				Method:       r.Method,
 				Path:         r.URL.Path,
 				RoutePattern: routePattern(r),
 				IPAddress:    clientIP(r),
 				UserAgent:    r.UserAgent(),
+				OccurredAtNS: time.Now().UTC().UnixNano(),
+				StatusCode:   wrapped.statusCode,
 			}
 
 			if identity, ok := auth.IdentityFromRequest(r); ok {

--- a/backend/internal/middleware/audit_test.go
+++ b/backend/internal/middleware/audit_test.go
@@ -1,0 +1,91 @@
+package middleware
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/stratahq/backend/internal/audit"
+	"github.com/stratahq/backend/internal/auth"
+)
+
+type fakeAuditRecorder struct {
+	events []audit.Event
+}
+
+func (f *fakeAuditRecorder) Record(_ context.Context, event audit.Event) error {
+	f.events = append(f.events, event)
+	return nil
+}
+
+func TestAuditEvents_RecordsWriteRequests(t *testing.T) {
+	recorder := &fakeAuditRecorder{}
+	logger := slog.New(slog.NewTextHandler(&discardWriter{}, nil))
+	handler := AuditEvents(recorder, logger)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/auth/org", nil)
+	req.RemoteAddr = "127.0.0.1:8080"
+	req.Header.Set("User-Agent", "audit-test")
+	req = req.WithContext(auth.ContextWithIdentity(req.Context(), "user-123", "org-456", "admin"))
+
+	rctx := chi.NewRouteContext()
+	rctx.RoutePatterns = []string{"/api/v1/auth/org"}
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if len(recorder.events) != 1 {
+		t.Fatalf("events recorded = %d, want 1", len(recorder.events))
+	}
+	event := recorder.events[0]
+	if event.ActorUserID != "user-123" {
+		t.Fatalf("ActorUserID = %q, want %q", event.ActorUserID, "user-123")
+	}
+	if event.OrgID != "org-456" {
+		t.Fatalf("OrgID = %q, want %q", event.OrgID, "org-456")
+	}
+	if event.Method != http.MethodPatch {
+		t.Fatalf("Method = %q, want %q", event.Method, http.MethodPatch)
+	}
+	if event.Path != "/api/v1/auth/org" {
+		t.Fatalf("Path = %q, want %q", event.Path, "/api/v1/auth/org")
+	}
+	if event.StatusCode != http.StatusNoContent {
+		t.Fatalf("StatusCode = %d, want %d", event.StatusCode, http.StatusNoContent)
+	}
+	if event.IPAddress != "127.0.0.1" {
+		t.Fatalf("IPAddress = %q, want %q", event.IPAddress, "127.0.0.1")
+	}
+	if event.UserAgent != "audit-test" {
+		t.Fatalf("UserAgent = %q, want %q", event.UserAgent, "audit-test")
+	}
+}
+
+func TestAuditEvents_SkipsReadRequests(t *testing.T) {
+	recorder := &fakeAuditRecorder{}
+	logger := slog.New(slog.NewTextHandler(&discardWriter{}, nil))
+	handler := AuditEvents(recorder, logger)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/auth/me", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if len(recorder.events) != 0 {
+		t.Fatalf("events recorded = %d, want 0", len(recorder.events))
+	}
+}
+
+type discardWriter struct{}
+
+func (w *discardWriter) Write(p []byte) (int, error) {
+	return len(p), nil
+}

--- a/backend/internal/middleware/security_headers.go
+++ b/backend/internal/middleware/security_headers.go
@@ -1,0 +1,41 @@
+package middleware
+
+import (
+	"net/http"
+	"strings"
+)
+
+const (
+	contentSecurityPolicy = "default-src 'self'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'"
+	permissionsPolicy     = "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()"
+	hstsPolicy            = "max-age=63072000; includeSubDomains; preload"
+)
+
+func SecurityHeaders() func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			headers := w.Header()
+			headers.Set("Content-Security-Policy", contentSecurityPolicy)
+			headers.Set("Permissions-Policy", permissionsPolicy)
+			headers.Set("Referrer-Policy", "strict-origin-when-cross-origin")
+			headers.Set("X-Content-Type-Options", "nosniff")
+			headers.Set("X-Frame-Options", "DENY")
+
+			if requestUsesHTTPS(r) {
+				headers.Set("Strict-Transport-Security", hstsPolicy)
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+func requestUsesHTTPS(r *http.Request) bool {
+	if r == nil {
+		return false
+	}
+	if r.TLS != nil {
+		return true
+	}
+	return strings.EqualFold(strings.TrimSpace(r.Header.Get("X-Forwarded-Proto")), "https")
+}

--- a/backend/internal/middleware/security_headers_test.go
+++ b/backend/internal/middleware/security_headers_test.go
@@ -1,0 +1,55 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestSecurityHeaders_SetsStandardHeaders(t *testing.T) {
+	handler := SecurityHeaders()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	req.Header.Set("X-Forwarded-Proto", "https")
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	if got := w.Header().Get("X-Content-Type-Options"); got != "nosniff" {
+		t.Fatalf("X-Content-Type-Options = %q, want %q", got, "nosniff")
+	}
+	if got := w.Header().Get("X-Frame-Options"); got != "DENY" {
+		t.Fatalf("X-Frame-Options = %q, want %q", got, "DENY")
+	}
+	if got := w.Header().Get("Referrer-Policy"); got != "strict-origin-when-cross-origin" {
+		t.Fatalf("Referrer-Policy = %q, want %q", got, "strict-origin-when-cross-origin")
+	}
+	if got := w.Header().Get("Strict-Transport-Security"); got == "" {
+		t.Fatal("Strict-Transport-Security header was not set")
+	}
+	csp := w.Header().Get("Content-Security-Policy")
+	if !strings.Contains(csp, "default-src 'self'") {
+		t.Fatalf("Content-Security-Policy = %q, want default-src 'self'", csp)
+	}
+	if got := w.Header().Get("Permissions-Policy"); got == "" {
+		t.Fatal("Permissions-Policy header was not set")
+	}
+}
+
+func TestSecurityHeaders_DoesNotSetHSTSOnPlainHTTP(t *testing.T) {
+	handler := SecurityHeaders()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	if got := w.Header().Get("Strict-Transport-Security"); got != "" {
+		t.Fatalf("Strict-Transport-Security = %q, want empty", got)
+	}
+}

--- a/backend/internal/server/router.go
+++ b/backend/internal/server/router.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stratahq/backend/internal/agm"
 	"github.com/stratahq/backend/internal/ai"
+	"github.com/stratahq/backend/internal/audit"
 	"github.com/stratahq/backend/internal/auth"
 	"github.com/stratahq/backend/internal/billing"
 	"github.com/stratahq/backend/internal/communications"
@@ -46,13 +47,14 @@ type Handlers struct {
 	EarlyAccess     *earlyaccess.Handler
 }
 
-func NewRouter(cfg *config.Config, logger *slog.Logger, rdb *redis.Client, h Handlers) *chi.Mux {
+func NewRouter(cfg *config.Config, logger *slog.Logger, rdb *redis.Client, auditRecorder audit.Recorder, h Handlers) *chi.Mux {
 	r := chi.NewRouter()
 
 	// Global middleware stack
 	r.Use(middleware.Recover)
 	r.Use(middleware.Metrics)
 	r.Use(middleware.Logger(logger))
+	r.Use(middleware.SecurityHeaders())
 	r.Use(middleware.CORS(cfg.AllowedOrigins))
 	r.Use(middleware.RateLimit(rdb, 100, 1*time.Minute))
 	r.Use(middleware.MaxBodyHandler())
@@ -69,13 +71,18 @@ func NewRouter(cfg *config.Config, logger *slog.Logger, rdb *redis.Client, h Han
 			// Auth endpoints with stricter per-IP rate limiting
 			r.Route("/auth", func(r chi.Router) {
 				r.Use(middleware.PerEndpointRateLimit(rdb, "auth", 5, 1*time.Minute))
+				r.Use(middleware.AuditEvents(auditRecorder, logger))
 				r.Mount("/", h.Auth.Routes())
 			})
 			r.Mount("/billing/webhooks", h.Billing.WebhookRoutes())
 			r.Mount("/whatsapp/webhooks", h.WhatsAppWebhook.Routes())
-			r.Mount("/invitations/verify", h.Invitation.PublicRoutes())
+			r.Group(func(r chi.Router) {
+				r.Use(middleware.AuditEvents(auditRecorder, logger))
+				r.Mount("/invitations/verify", h.Invitation.PublicRoutes())
+			})
 			r.Route("/early-access", func(r chi.Router) {
 				r.Use(middleware.PerEndpointRateLimit(rdb, "earlyaccess", 3, 1*time.Minute))
+				r.Use(middleware.AuditEvents(auditRecorder, logger))
 				r.Mount("/", h.EarlyAccess.PublicRoutes())
 			})
 		})
@@ -83,6 +90,7 @@ func NewRouter(cfg *config.Config, logger *slog.Logger, rdb *redis.Client, h Han
 		// Protected routes
 		r.Group(func(r chi.Router) {
 			r.Use(middleware.Auth(cfg.JWTSecret))
+			r.Use(middleware.AuditEvents(auditRecorder, logger))
 			r.Get("/auth/me", h.Auth.Me)
 			r.Patch("/auth/profile", h.Auth.UpdateProfile)
 			r.Patch("/auth/org", h.Auth.UpdateOrg)


### PR DESCRIPTION
## Summary
- add global security headers middleware for CSP, HSTS, referrer policy, frame protection, and permissions policy
- add a durable audit event foundation with a new audit_events migration and recorder service
- wire audit middleware into public auth, invitation acceptance, early-access writes, and authenticated write routes

## Verification
- go test ./internal/middleware
- go test ./...
- go vet ./...
- npm test
- npm run lint

## Notes
- local golangci-lint run --path-prefix=backend still fails before code analysis because the installed binary in this environment is incompatible with the repo config format