### PR TITLE
fix: post-merge reliability regressions

### DIFF
--- a/app/agent/page.test.tsx
+++ b/app/agent/page.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const mockUseAuthenticatedQuery = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/auth", () => ({
+  useAuth: vi.fn(() => ({ user: { role: "admin" } })),
+}));
+
+vi.mock("@/hooks/useAuthenticatedQuery", () => ({
+  useAuthenticatedQuery: mockUseAuthenticatedQuery,
+}));
+
+describe("AgentPortfolioPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("passes the attention queue error to AttentionQueue when query fails", async () => {
+    const attentionRefetch = vi.fn();
+
+    mockUseAuthenticatedQuery
+      .mockReturnValueOnce({
+        data: [
+          {
+            id: "scheme-1",
+            name: "Scheme 1",
+            address: "Addr",
+            unit_count: 1,
+            levy_collection_pct: 100,
+            open_maintenance_count: 0,
+            health: "good" as const,
+          },
+        ],
+        isLoading: false,
+      })
+      .mockReturnValueOnce({
+        data: undefined,
+        isLoading: false,
+        error: new Error("Failed to load attention queue"),
+        refetch: attentionRefetch,
+      });
+
+    const { default: AgentPortfolioPage } = await import("@/app/agent/page");
+    render(<AgentPortfolioPage />);
+
+    expect(screen.getByText("Failed to load attention queue")).toBeInTheDocument();
+  });
+});

--- a/app/agent/page.tsx
+++ b/app/agent/page.tsx
@@ -26,19 +26,18 @@ export default function AgentPortfolioPage() {
     staleTime: 30_000,
   });
 
-  const { data: attentionQueue } = useAuthenticatedQuery<{ items: AttentionItem[] }>({
+  const {
+    data: attentionQueue,
+    isLoading: attentionLoading,
+    error: attentionError,
+    refetch: refetchAttention,
+  } = useAuthenticatedQuery<{ items: AttentionItem[] }>({
     queryKey: portfolioKeys.attention(),
     queryFn: () => getPortfolioAttentionQueue(),
     staleTime: 30_000,
   });
 
   const attentionItems = attentionQueue?.items ?? [];
-  const attentionLoading = !attentionQueue;
-  const attentionError: string | null = null;
-
-  async function loadAttentionQueue() {
-    // This will be handled by the query refetch
-  }
 
   const totalUnits = schemes.reduce((sum, scheme) => sum + scheme.unit_count, 0);
   const totalMaintenance = schemes.reduce(
@@ -164,8 +163,8 @@ export default function AgentPortfolioPage() {
           items={attentionItems}
           scope="portfolio"
           loading={attentionLoading}
-          error={attentionError}
-          onRefresh={loadAttentionQueue}
+          error={attentionError instanceof Error ? attentionError.message : null}
+          onRefresh={() => { void refetchAttention() }}
         />
       </section>
     </div>

--- a/app/agent/page.tsx
+++ b/app/agent/page.tsx
@@ -8,6 +8,7 @@ import type { AttentionItem } from "@/lib/attention";
 import { listSchemes, type SchemeSummary } from "@/lib/scheme-api";
 
 import { useAuthenticatedQuery } from "@/hooks/useAuthenticatedQuery";
+import { portfolioKeys } from "@/lib/query-keys";
 import AttentionQueue from "@/components/AttentionQueue";
 
 const HEALTH_STYLES: Record<SchemeSummary["health"], string> = {
@@ -20,13 +21,13 @@ export default function AgentPortfolioPage() {
   useAuth();
 
   const { data: schemes = [], isLoading: loading } = useAuthenticatedQuery<SchemeSummary[]>({
-    queryKey: ["agent:portfolio"],
+    queryKey: portfolioKeys.overview(),
     queryFn: () => listSchemes(),
     staleTime: 30_000,
   });
 
   const { data: attentionQueue } = useAuthenticatedQuery<{ items: AttentionItem[] }>({
-    queryKey: ["agent:attention-queue"],
+    queryKey: portfolioKeys.attention(),
     queryFn: () => getPortfolioAttentionQueue(),
     staleTime: 30_000,
   });

--- a/app/api/proxy/[...path]/route.test.ts
+++ b/app/api/proxy/[...path]/route.test.ts
@@ -125,4 +125,58 @@ describe("proxyRequest", () => {
       },
     });
   });
+
+  it("forwards the routed path segments and search string exactly once", async () => {
+    const calls: string[] = [];
+    vi.stubGlobal("fetch", vi.fn(async (url: string) => {
+      calls.push(url);
+      return new Response(JSON.stringify({ data: { ok: true } }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }));
+
+    const { GET } = await import("./route");
+
+    const req = new Request(
+      "http://localhost/api/proxy/api/v1/communications/scheme-1?type=agm",
+    );
+    const params = Promise.resolve({
+      path: ["api", "v1", "communications", "scheme-1"],
+    });
+
+    await GET(req as unknown as import("next/server").NextRequest, { params });
+
+    expect(calls[0]).toBe("http://localhost:8080/api/v1/communications/scheme-1?type=agm");
+  });
+
+  it("reuses the original request body for a retry after refresh", async () => {
+    let callCount = 0;
+    const bodies: string[] = [];
+
+    vi.stubGlobal("fetch", vi.fn(async (_url: string, options: RequestInit) => {
+      callCount++;
+      if (options.body) bodies.push(Buffer.from(options.body as Uint8Array).toString());
+      if (callCount === 1) return new Response(null, { status: 401 });
+      return new Response(JSON.stringify({ data: { ok: true } }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }));
+
+    const { POST } = await import("./route");
+
+    const req = new Request("http://localhost/api/proxy/api/v1/invitations", {
+      method: "POST",
+      body: JSON.stringify({ full_name: "Test User" }),
+    });
+    const params = Promise.resolve({ path: ["api", "v1", "invitations"] });
+
+    await POST(req as unknown as import("next/server").NextRequest, { params });
+
+    expect(bodies).toEqual([
+      JSON.stringify({ full_name: "Test User" }),
+      JSON.stringify({ full_name: "Test User" }),
+    ]);
+  });
 });

--- a/app/api/proxy/[...path]/route.ts
+++ b/app/api/proxy/[...path]/route.ts
@@ -95,53 +95,19 @@ function proxyResponse(response: Response, requestId?: string) {
   });
 }
 
-async function forwardRequest(
-  request: NextRequest,
-  url: URL,
-  accessToken: string | undefined,
-  requestId: string,
-  signal?: AbortSignal,
-) {
-  const cookieStore = await cookies();
-
-  const backendPath = buildAllowedBackendProxyPath(
-    request.url.split("/api/proxy/")[1]?.split("/") ?? [],
-    url.search,
-  );
-  if (!backendPath) {
-    return new Response(null, { status: 404 });
-  }
-  const backendUrl = `${BACKEND()}${backendPath}`;
-
-  const headers: Record<string, string> = {
-    "x-request-id": requestId,
-  };
-  if (accessToken) {
-    headers["Authorization"] = `Bearer ${accessToken}`;
-  }
-  for (const name of PROXY_HEADERS) {
-    const value = request.headers.get(name);
-    if (value) headers[name] = value;
-  }
-  for (const name of IDENTITY_HEADERS) {
-    if (name === "x-request-id") continue;
-    const value = request.headers.get(name);
-    if (value) headers[name] = value;
-  }
-
-  let body: BodyInit | undefined;
-  if (request.method !== "GET" && request.method !== "HEAD") {
-    body = await request.bytes();
-  }
-
-  const response = await fetch(backendUrl, {
-    method: request.method,
-    headers,
-    body,
-    signal,
-  });
-
-  return response;
+async function forwardRequest(args: {
+  backendPath: string
+  method: string
+  headers: Record<string, string>
+  body?: Uint8Array
+  signal?: AbortSignal
+}) {
+  return fetch(`${BACKEND()}${args.backendPath}`, {
+    method: args.method,
+    headers: args.headers,
+    body: args.body as BodyInit | undefined,
+    signal: args.signal,
+  })
 }
 
 function shouldRetry(method: string, status: number): boolean {
@@ -160,18 +126,39 @@ async function proxyRequest(request: NextRequest, pathSegments: string[]) {
     return new Response(null, { status: 404 });
   }
 
+  const bufferedBody =
+    request.method !== "GET" && request.method !== "HEAD"
+      ? await request.bytes()
+      : undefined;
+
+  const proxyHeaders: Record<string, string> = {
+    "x-request-id": requestId,
+  };
+  if (accessToken) {
+    proxyHeaders["Authorization"] = `Bearer ${accessToken}`;
+  }
+  for (const name of PROXY_HEADERS) {
+    const value = request.headers.get(name);
+    if (value) proxyHeaders[name] = value;
+  }
+  for (const name of IDENTITY_HEADERS) {
+    if (name === "x-request-id") continue;
+    const value = request.headers.get(name);
+    if (value) proxyHeaders[name] = value;
+  }
+
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), UPSTREAM_TIMEOUT_MS);
 
   let firstResponse: Response;
   try {
-    firstResponse = await forwardRequest(
-      request,
-      url,
-      accessToken,
-      requestId,
-      controller.signal,
-    );
+    firstResponse = await forwardRequest({
+      backendPath,
+      method: request.method,
+      headers: proxyHeaders,
+      body: bufferedBody,
+      signal: controller.signal,
+    });
   } catch (error) {
     clearTimeout(timeout);
     if (error instanceof DOMException && error.name === "AbortError") {
@@ -190,13 +177,13 @@ async function proxyRequest(request: NextRequest, pathSegments: string[]) {
       );
 
       try {
-        const retryResponse = await forwardRequest(
-          request,
-          url,
-          accessToken,
-          requestId,
-          retryController.signal,
-        );
+        const retryResponse = await forwardRequest({
+          backendPath,
+          method: request.method,
+          headers: proxyHeaders,
+          body: bufferedBody,
+          signal: retryController.signal,
+        });
         clearTimeout(retryTimeout);
         return proxyResponse(retryResponse, requestId);
       } catch (error) {
@@ -217,7 +204,13 @@ async function proxyRequest(request: NextRequest, pathSegments: string[]) {
   }
 
   const updatedAccessToken = cookieStore.get("sh_access")?.value;
-  const retryResponse = await forwardRequest(request, url, updatedAccessToken, requestId);
+  const updatedHeaders = { ...proxyHeaders, Authorization: `Bearer ${updatedAccessToken}` };
+  const retryResponse = await forwardRequest({
+    backendPath,
+    method: request.method,
+    headers: updatedHeaders,
+    body: bufferedBody,
+  });
 
   if (retryResponse.status === 401) {
     await clearAuthCookies();

--- a/app/api/session/refresh/route.test.ts
+++ b/app/api/session/refresh/route.test.ts
@@ -166,4 +166,49 @@ describe("POST /api/session/refresh", () => {
       expect.objectContaining({ httpOnly: true }),
     );
   });
+
+  it("writes rotated access and refresh tokens with httpOnly", async () => {
+    cookieGet.mockImplementation((name: string) => {
+      if (name === "sh_access") return { value: "old-access-token" };
+      if (name === "sh_refresh") return { value: "old-refresh-token" };
+      return undefined;
+    });
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(
+          JSON.stringify({
+            data: {
+              access_token: "new-access-token",
+              refresh_token: "new-refresh-token",
+              session: {
+                id: "user-1",
+                email: "person@example.com",
+                full_name: "Person Example",
+                role: "admin",
+                wizard_complete: true,
+                scheme_memberships: [],
+              },
+            },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      ),
+    );
+
+    const { POST } = await import("./route");
+    await POST();
+
+    expect(cookieSet).toHaveBeenCalledWith(
+      "sh_access",
+      "new-access-token",
+      expect.objectContaining({ httpOnly: true }),
+    );
+    expect(cookieSet).toHaveBeenCalledWith(
+      "sh_refresh",
+      "new-refresh-token",
+      expect.objectContaining({ httpOnly: true }),
+    );
+  });
 });

--- a/app/app/[schemeId]/agm/page.tsx
+++ b/app/app/[schemeId]/agm/page.tsx
@@ -13,6 +13,7 @@ import { listSchemeMembers } from '@/lib/scheme-api'
 import { useToast } from '@/lib/toast'
 
 import { queryClient } from '@/lib/query-client'
+import { schemeKeys } from '@/lib/query-keys'
 import { useAuthenticatedQuery } from '@/hooks/useAuthenticatedQuery'
 
 const EMPTY_RESOLUTION = { title: '', description: '' }
@@ -66,7 +67,7 @@ export default function AgmVotingPage() {
   })
 
   const { data: dashboard, isLoading, error, refetch } = useAuthenticatedQuery<AgmDashboard>({
-    queryKey: [`scheme:${schemeId}:agm`],
+    queryKey: schemeKeys.agm(schemeId),
     queryFn: () => getAgmDashboard(schemeId),
     staleTime: 30_000,
   })
@@ -78,7 +79,7 @@ export default function AgmVotingPage() {
   const hasAssignedProxy = Boolean(upcomingMeeting?.user_proxy_grantee_id)
 
   const { data: members = [], isLoading: loadingMembers } = useAuthenticatedQuery<Array<{ user_id: string; full_name: string; role: string }>>({
-    queryKey: [`scheme:${schemeId}:agm:members`],
+    queryKey: schemeKeys.agmMembers(schemeId),
     queryFn: () => listSchemeMembers(schemeId),
     staleTime: 60_000,
   })
@@ -94,7 +95,7 @@ export default function AgmVotingPage() {
 
   async function refreshDashboard() {
     invalidateCache(`scheme:${schemeId}:agm`)
-    await queryClient.invalidateQueries({ queryKey: [`scheme:${schemeId}:agm`] })
+    await queryClient.invalidateQueries({ queryKey: schemeKeys.agm(schemeId) })
     await refetch()
   }
 

--- a/app/app/[schemeId]/communications/page.tsx
+++ b/app/app/[schemeId]/communications/page.tsx
@@ -12,6 +12,7 @@ import { invalidateCache } from '@/lib/data-cache'
 import { useToast } from '@/lib/toast'
 
 import { queryClient } from '@/lib/query-client'
+import { schemeKeys } from '@/lib/query-keys'
 import { useAuthenticatedQuery } from '@/hooks/useAuthenticatedQuery'
 
 const TYPE_STYLES: Record<NoticeType, string> = {
@@ -43,7 +44,7 @@ export default function CommunicationsPage() {
   const canCompose = user?.role === 'admin' || user?.role === 'trustee'
 
   const { data: notices = [], isLoading, error, refetch } = useAuthenticatedQuery<NoticeInfo[]>({
-    queryKey: [`scheme:${schemeId}:communications:${typeFilter}`],
+    queryKey: schemeKeys.communications(schemeId, typeFilter),
     queryFn: () => getCommunicationsDashboard(schemeId, typeFilter).then(d => d.notices),
     staleTime: 30_000,
   })
@@ -59,7 +60,7 @@ export default function CommunicationsPage() {
         type: form.type,
       })
       invalidateCache(`scheme:${schemeId}:communications`)
-      await queryClient.invalidateQueries({ queryKey: [`scheme:${schemeId}:communications`] })
+      await queryClient.invalidateQueries({ queryKey: schemeKeys.communicationsBase(schemeId) })
       setShowModal(false)
       setForm({ title: '', body: '', type: 'general' })
       addToast('Notice sent to scheme members', 'success')

--- a/app/app/[schemeId]/documents/page.tsx
+++ b/app/app/[schemeId]/documents/page.tsx
@@ -13,6 +13,7 @@ import { invalidateCache } from '@/lib/data-cache'
 import { useToast } from '@/lib/toast'
 
 import { queryClient } from '@/lib/query-client'
+import { schemeKeys } from '@/lib/query-keys'
 import { useAuthenticatedQuery } from '@/hooks/useAuthenticatedQuery'
 
 const CATEGORY_LABELS: Record<DocumentCategory, string> = {
@@ -68,7 +69,7 @@ export default function DocumentsPage() {
   const canUpload = user?.role === 'admin'
 
   const { data: documents = [], isLoading, error, refetch } = useAuthenticatedQuery<SchemeDocumentInfo[]>({
-    queryKey: [`scheme:${schemeId}:documents:${categoryFilter}`],
+    queryKey: schemeKeys.documents(schemeId, categoryFilter),
     queryFn: () => getDocumentsDashboard(schemeId, categoryFilter).then(d => d.documents),
     staleTime: 30_000,
   })
@@ -88,7 +89,7 @@ export default function DocumentsPage() {
         size_bytes: selectedFile.size,
       })
       invalidateCache(`scheme:${schemeId}:documents`)
-      await queryClient.invalidateQueries({ queryKey: [`scheme:${schemeId}:documents`] })
+      await queryClient.invalidateQueries({ queryKey: schemeKeys.documentsBase(schemeId) })
       setShowModal(false)
       setForm(EMPTY_FORM)
       setSelectedFile(null)
@@ -108,7 +109,7 @@ export default function DocumentsPage() {
     setDeletingId(document.id)
     try {
       await deleteDocument(schemeId, document.id)
-      await queryClient.invalidateQueries({ queryKey: [`scheme:${schemeId}:documents`] })
+      await queryClient.invalidateQueries({ queryKey: schemeKeys.documentsBase(schemeId) })
       addToast(`"${document.name}" deleted`, 'success')
     } catch (error) {
       addToast(

--- a/app/app/[schemeId]/financials/page.tsx
+++ b/app/app/[schemeId]/financials/page.tsx
@@ -11,6 +11,7 @@ import type { BudgetLineInfo, FinancialDashboard } from '@/lib/financials'
 import { useToast } from '@/lib/toast'
 
 import { queryClient } from '@/lib/query-client'
+import { schemeKeys } from '@/lib/query-keys'
 import { useAuthenticatedQuery } from '@/hooks/useAuthenticatedQuery'
 
 function formatRand(cents: number): string {
@@ -42,7 +43,7 @@ export default function FinancialsPage() {
   const canManage = user?.role === 'admin' || user?.role === 'trustee'
 
   const { data: dashboard, isLoading: loading } = useAuthenticatedQuery<FinancialDashboard>({
-    queryKey: [`scheme:${schemeId}:financials:${selectedPeriod}`],
+    queryKey: schemeKeys.financials(schemeId, selectedPeriod || 'current'),
     queryFn: () => getFinancialDashboard(schemeId, selectedPeriod || undefined),
     staleTime: 30_000,
   })
@@ -86,8 +87,8 @@ export default function FinancialsPage() {
 
   async function refreshDashboard(nextPeriod?: string) {
     invalidateCache(`scheme:${schemeId}:financials`)
-    const newPeriod = nextPeriod || selectedPeriod || ''
-    await queryClient.invalidateQueries({ queryKey: [`scheme:${schemeId}:financials:${newPeriod}`] })
+    const newPeriod = nextPeriod || selectedPeriod || 'current'
+    await queryClient.invalidateQueries({ queryKey: schemeKeys.financials(schemeId, newPeriod) })
     if (!nextPeriod && dashboard?.selected_period) {
       setSelectedPeriod(dashboard.selected_period)
     }

--- a/app/app/[schemeId]/levy/page.tsx
+++ b/app/app/[schemeId]/levy/page.tsx
@@ -13,6 +13,7 @@ import type { LevyAccountInfo, LevyDashboard, ReconcilePaymentInput } from '@/li
 import { useToast } from '@/lib/toast'
 
 import { queryClient } from '@/lib/query-client'
+import { schemeKeys } from '@/lib/query-keys'
 import { useAuthenticatedQuery } from '@/hooks/useAuthenticatedQuery'
 
 function formatRand(cents: number): string {
@@ -55,14 +56,14 @@ export default function LevyPaymentsPage() {
   const canEdit = user?.role === 'admin'
 
   const { data: dashboard, isLoading, error, refetch } = useAuthenticatedQuery<LevyDashboard>({
-    queryKey: [`scheme:${schemeId}:levy`],
+    queryKey: schemeKeys.levy(schemeId),
     queryFn: () => getLevyDashboard(schemeId),
     staleTime: 30_000,
   })
 
   async function refreshDashboard() {
     invalidateCache(`scheme:${schemeId}:levy`)
-    await queryClient.invalidateQueries({ queryKey: [`scheme:${schemeId}:levy`] })
+    await queryClient.invalidateQueries({ queryKey: schemeKeys.levy(schemeId) })
     await refetch()
   }
 

--- a/app/app/[schemeId]/maintenance/page.tsx
+++ b/app/app/[schemeId]/maintenance/page.tsx
@@ -17,6 +17,7 @@ import type { MaintenanceDashboard, MaintenanceRequestInfo } from '@/lib/mainten
 import { useToast } from '@/lib/toast'
 
 import { queryClient } from '@/lib/query-client'
+import { schemeKeys } from '@/lib/query-keys'
 import { useAuthenticatedQuery } from '@/hooks/useAuthenticatedQuery'
 
 const STATUS_STYLES: Record<string, string> = {
@@ -70,14 +71,14 @@ export default function MaintenancePage() {
   )
 
   const { data: dashboard, isLoading, error, refetch } = useAuthenticatedQuery<MaintenanceDashboard>({
-    queryKey: [`scheme:${schemeId}:maintenance`],
+    queryKey: schemeKeys.maintenance(schemeId),
     queryFn: () => getMaintenanceDashboard(schemeId),
     staleTime: 30_000,
   })
 
   async function refreshDashboard() {
     invalidateCache(`scheme:${schemeId}:maintenance`)
-    await queryClient.invalidateQueries({ queryKey: [`scheme:${schemeId}:maintenance`] })
+    await queryClient.invalidateQueries({ queryKey: schemeKeys.maintenance(schemeId) })
     await refetch()
   }
 

--- a/app/app/[schemeId]/members/page.test.tsx
+++ b/app/app/[schemeId]/members/page.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const mockUseAuthenticatedQuery = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/auth", () => ({
+  useAuth: vi.fn(() => ({ user: { role: "admin" } })),
+}));
+
+vi.mock("next/navigation", () => ({
+  useParams: vi.fn(() => ({ schemeId: "scheme-1" })),
+}));
+
+vi.mock("@/hooks/useAuthenticatedQuery", () => ({
+  useAuthenticatedQuery: mockUseAuthenticatedQuery,
+}));
+
+describe("MembersPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders RetryState when members query fails", async () => {
+    const membersRefetch = vi.fn();
+    const unitsRefetch = vi.fn();
+
+    mockUseAuthenticatedQuery
+      .mockReturnValueOnce({
+        data: undefined,
+        isLoading: false,
+        error: new Error("Failed to load members"),
+        refetch: membersRefetch,
+      })
+      .mockReturnValueOnce({
+        data: [],
+        isLoading: false,
+        refetch: unitsRefetch,
+      });
+
+    const { default: MembersPage } = await import("@/app/app/[schemeId]/members/page");
+    render(<MembersPage />);
+
+    expect(screen.getByText("Could not load members")).toBeInTheDocument();
+  });
+
+  it("renders RetryState when only units query fails", async () => {
+    const membersRefetch = vi.fn();
+    const unitsRefetch = vi.fn();
+
+    mockUseAuthenticatedQuery
+      .mockReturnValueOnce({
+        data: [{ user_id: "u1", full_name: "John", email: "john@test.com", role: "trustee" as const }],
+        isLoading: false,
+        refetch: membersRefetch,
+      })
+      .mockReturnValueOnce({
+        data: undefined,
+        isLoading: false,
+        error: new Error("Failed to load units"),
+        refetch: unitsRefetch,
+      });
+
+    const { default: MembersPage } = await import("@/app/app/[schemeId]/members/page");
+    render(<MembersPage />);
+
+    expect(screen.getByText("Could not load members")).toBeInTheDocument();
+  });
+});

--- a/app/app/[schemeId]/members/page.tsx
+++ b/app/app/[schemeId]/members/page.tsx
@@ -20,6 +20,7 @@ import { useToast } from '@/lib/toast'
 import { queryClient } from '@/lib/query-client'
 import { schemeKeys } from '@/lib/query-keys'
 import { useAuthenticatedQuery } from '@/hooks/useAuthenticatedQuery'
+import RetryState from '@/components/RetryState'
 
 const ROLE_STYLES: Record<string, string> = {
   trustee: 'bg-accent-bg text-accent',
@@ -69,17 +70,32 @@ export default function MembersPage() {
 
   const canEdit = user?.role === 'admin'
 
-  const { data: members = [], isLoading: loading } = useAuthenticatedQuery<MemberInfo[]>({
+  const {
+    data: members = [],
+    isLoading: loading,
+    error: membersError,
+    refetch: membersRefetch,
+  } = useAuthenticatedQuery<MemberInfo[]>({
     queryKey: schemeKeys.members(schemeId),
     queryFn: () => listSchemeMembers(schemeId),
     staleTime: 30_000,
   })
 
-  const { data: units = [] } = useAuthenticatedQuery<UnitInfo[]>({
+  const {
+    data: units = [],
+    error: unitsError,
+    refetch: unitsRefetch,
+  } = useAuthenticatedQuery<UnitInfo[]>({
     queryKey: schemeKeys.membersUnits(schemeId),
     queryFn: () => listSchemeUnits(schemeId),
     staleTime: 30_000,
   })
+
+  const pageError = membersError ?? unitsError
+  const retryPage = () => {
+    void membersRefetch()
+    void unitsRefetch()
+  }
 
   const trustees = useMemo(
     () => members.filter(member => member.role === 'trustee'),
@@ -182,6 +198,16 @@ export default function MembersPage() {
           Loading members…
         </div>
       </div>
+    )
+  }
+
+  if (pageError) {
+    return (
+      <RetryState
+        title="Could not load members"
+        message="Temporary service issue. Try again."
+        onRetry={retryPage}
+      />
     )
   }
 

--- a/app/app/[schemeId]/members/page.tsx
+++ b/app/app/[schemeId]/members/page.tsx
@@ -18,6 +18,7 @@ import {
 import { useToast } from '@/lib/toast'
 
 import { queryClient } from '@/lib/query-client'
+import { schemeKeys } from '@/lib/query-keys'
 import { useAuthenticatedQuery } from '@/hooks/useAuthenticatedQuery'
 
 const ROLE_STYLES: Record<string, string> = {
@@ -69,13 +70,13 @@ export default function MembersPage() {
   const canEdit = user?.role === 'admin'
 
   const { data: members = [], isLoading: loading } = useAuthenticatedQuery<MemberInfo[]>({
-    queryKey: [`scheme:${schemeId}:members`],
+    queryKey: schemeKeys.members(schemeId),
     queryFn: () => listSchemeMembers(schemeId),
     staleTime: 30_000,
   })
 
   const { data: units = [] } = useAuthenticatedQuery<UnitInfo[]>({
-    queryKey: [`scheme:${schemeId}:members:units`],
+    queryKey: schemeKeys.membersUnits(schemeId),
     queryFn: () => listSchemeUnits(schemeId),
     staleTime: 30_000,
   })
@@ -159,7 +160,7 @@ export default function MembersPage() {
         role: editForm.role,
         unit_id: editForm.role === 'resident' ? editForm.unit_id : null,
       })
-      await queryClient.invalidateQueries({ queryKey: [`scheme:${schemeId}:members`] })
+      await queryClient.invalidateQueries({ queryKey: schemeKeys.members(schemeId) })
       setShowEditModal(false)
       setSelectedMember(null)
       setEditForm(EMPTY_EDIT_FORM)

--- a/app/app/[schemeId]/page.test.tsx
+++ b/app/app/[schemeId]/page.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+
+const mockUseAuthenticatedQuery = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/auth", () => ({
+  useAuth: vi.fn(() => ({ user: { role: "admin" } })),
+}));
+
+vi.mock("next/navigation", () => ({
+  useParams: vi.fn(() => ({ schemeId: "scheme-1" })),
+}));
+
+vi.mock("@/hooks/useAuthenticatedQuery", () => ({
+  useAuthenticatedQuery: mockUseAuthenticatedQuery,
+}));
+
+describe("SchemeOverviewPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders RetryState when the overview query fails", async () => {
+    const refetch = vi.fn();
+
+    mockUseAuthenticatedQuery
+      .mockReturnValueOnce({
+        data: undefined,
+        isLoading: false,
+        error: new Error("Failed to load scheme"),
+        refetch,
+      })
+      .mockReturnValueOnce({
+        data: { items: [] },
+        isLoading: false,
+      });
+
+    const { default: SchemeOverviewPage } = await import("@/app/app/[schemeId]/page");
+    render(<SchemeOverviewPage />);
+
+    expect(screen.getByText("Could not load scheme overview")).toBeInTheDocument();
+  });
+});

--- a/app/app/[schemeId]/page.tsx
+++ b/app/app/[schemeId]/page.tsx
@@ -11,6 +11,7 @@ import { getScheme, type SchemeDetail } from '@/lib/scheme-api'
 import { useAuthenticatedQuery } from '@/hooks/useAuthenticatedQuery'
 import { schemeKeys } from '@/lib/query-keys'
 import AttentionQueue from '@/components/AttentionQueue'
+import RetryState from '@/components/RetryState'
 
 const HEALTH_STYLES = {
   good: 'bg-green-bg text-green',
@@ -31,13 +32,23 @@ export default function SchemeOverviewPage() {
   const params = useParams()
   const schemeId = params.schemeId as string
 
-  const { data: scheme, isLoading: loading } = useAuthenticatedQuery<SchemeDetail>({
+  const {
+    data: scheme,
+    isLoading: loading,
+    error,
+    refetch,
+  } = useAuthenticatedQuery<SchemeDetail>({
     queryKey: schemeKeys.overview(schemeId),
     queryFn: () => getScheme(schemeId),
     staleTime: 30_000,
   })
 
-  const { data: attentionQueue } = useAuthenticatedQuery<{ items: AttentionItem[] }>({
+  const {
+    data: attentionQueue,
+    isLoading: attentionLoading,
+    error: attentionError,
+    refetch: refetchAttention,
+  } = useAuthenticatedQuery<{ items: AttentionItem[] }>({
     queryKey: schemeKeys.attentionQueue(schemeId),
     queryFn: () => getSchemeAttentionQueue(schemeId),
     staleTime: 30_000,
@@ -45,14 +56,8 @@ export default function SchemeOverviewPage() {
   })
 
   const attentionItems = attentionQueue?.items ?? []
-  const attentionLoading = !attentionQueue
-  const attentionError: string | null = null
 
   const isResident = user?.role === 'resident'
-
-  async function loadAttentionQueue() {
-    // Handled by React Query refetch
-  }
 
   const unitLabel = scheme?.unit_identifier
     ? `Unit ${scheme.unit_identifier}`
@@ -65,6 +70,16 @@ export default function SchemeOverviewPage() {
           Loading scheme overview…
         </div>
       </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <RetryState
+        title="Could not load scheme overview"
+        message="Temporary service issue. Try again."
+        onRetry={() => { void refetch() }}
+      />
     )
   }
 
@@ -205,8 +220,8 @@ export default function SchemeOverviewPage() {
             items={attentionItems}
             scope="scheme"
             loading={attentionLoading}
-            error={attentionError}
-            onRefresh={loadAttentionQueue}
+            error={attentionError instanceof Error ? attentionError.message : null}
+            onRefresh={() => { void refetchAttention() }}
           />
         </section>
       )}

--- a/app/app/[schemeId]/page.tsx
+++ b/app/app/[schemeId]/page.tsx
@@ -9,6 +9,7 @@ import type { AttentionItem } from '@/lib/attention'
 import { getScheme, type SchemeDetail } from '@/lib/scheme-api'
 
 import { useAuthenticatedQuery } from '@/hooks/useAuthenticatedQuery'
+import { schemeKeys } from '@/lib/query-keys'
 import AttentionQueue from '@/components/AttentionQueue'
 
 const HEALTH_STYLES = {
@@ -31,13 +32,13 @@ export default function SchemeOverviewPage() {
   const schemeId = params.schemeId as string
 
   const { data: scheme, isLoading: loading } = useAuthenticatedQuery<SchemeDetail>({
-    queryKey: [`scheme:${schemeId}:overview`],
+    queryKey: schemeKeys.overview(schemeId),
     queryFn: () => getScheme(schemeId),
     staleTime: 30_000,
   })
 
   const { data: attentionQueue } = useAuthenticatedQuery<{ items: AttentionItem[] }>({
-    queryKey: [`scheme:${schemeId}:attention-queue`],
+    queryKey: schemeKeys.attentionQueue(schemeId),
     queryFn: () => getSchemeAttentionQueue(schemeId),
     staleTime: 30_000,
     enabled: user?.role !== 'resident',

--- a/lib/auth-actions.ts
+++ b/lib/auth-actions.ts
@@ -118,31 +118,6 @@ export async function logoutAction(): Promise<void> {
   await clearAuthCookies();
 }
 
-// ─── Token refresh ────────────────────────────────────────────────────────────
-
-export async function refreshTokens(): Promise<string | null> {
-  const cookieStore = await cookies();
-  const refreshToken = cookieStore.get("sh_refresh")?.value;
-  if (!refreshToken) return null;
-
-  const res = await fetch(`${BACKEND()}/api/v1/auth/refresh`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ refresh_token: refreshToken }),
-  });
-
-  if (!res.ok) return null;
-
-  const { access_token, refresh_token } = await readApiData<{
-    access_token: string;
-    refresh_token: string;
-  }>(res);
-  if (!access_token || !refresh_token) return null;
-  cookieStore.set("sh_access", access_token, ACCESS_OPTS);
-  cookieStore.set("sh_refresh", refresh_token, REFRESH_OPTS);
-  return access_token;
-}
-
 // ─── Clear auth ───────────────────────────────────────────────────────────────
 
 export async function clearAuth(): Promise<void> {

--- a/lib/query-keys.test.ts
+++ b/lib/query-keys.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest"
+import { schemeKeys } from "./query-keys"
+
+describe("schemeKeys", () => {
+  it("keeps filtered communication keys under one invalidation family", () => {
+    expect(schemeKeys.communicationsBase("scheme-1")).toEqual([
+      "scheme",
+      "scheme-1",
+      "communications",
+    ])
+    expect(schemeKeys.communications("scheme-1", "agm")).toEqual([
+      "scheme",
+      "scheme-1",
+      "communications",
+      "agm",
+    ])
+  })
+})

--- a/lib/query-keys.ts
+++ b/lib/query-keys.ts
@@ -1,0 +1,25 @@
+export const portfolioKeys = {
+  overview: () => ["agent", "portfolio", "overview"] as const,
+  attention: () => ["agent", "portfolio", "attention"] as const,
+}
+
+export const schemeKeys = {
+  overview: (schemeId: string) => ["scheme", schemeId, "overview"] as const,
+  attention: (schemeId: string) => ["scheme", schemeId, "attention"] as const,
+  attentionQueue: (schemeId: string) => ["scheme", schemeId, "attention-queue"] as const,
+  members: (schemeId: string) => ["scheme", schemeId, "members"] as const,
+  membersUnits: (schemeId: string) => ["scheme", schemeId, "members", "units"] as const,
+  communicationsBase: (schemeId: string) => ["scheme", schemeId, "communications"] as const,
+  communications: (schemeId: string, type: string) =>
+    ["scheme", schemeId, "communications", type] as const,
+  documentsBase: (schemeId: string) => ["scheme", schemeId, "documents"] as const,
+  documents: (schemeId: string, category: string) =>
+    ["scheme", schemeId, "documents", category] as const,
+  financialsBase: (schemeId: string) => ["scheme", schemeId, "financials"] as const,
+  financials: (schemeId: string, period: string) =>
+    ["scheme", schemeId, "financials", period] as const,
+  maintenance: (schemeId: string) => ["scheme", schemeId, "maintenance"] as const,
+  levy: (schemeId: string) => ["scheme", schemeId, "levy"] as const,
+  agm: (schemeId: string) => ["scheme", schemeId, "agm"] as const,
+  agmMembers: (schemeId: string) => ["scheme", schemeId, "agm", "members"] as const,
+}

--- a/lib/server-auth.test.ts
+++ b/lib/server-auth.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { refreshAuthSession } from "./server-auth";
+
+const cookieSet = vi.fn();
+const cookieGet = vi.fn();
+
+vi.mock("next/headers", () => ({
+  cookies: vi.fn(async () => ({
+    get: cookieGet,
+    set: cookieSet,
+  })),
+}));
+
+describe("refreshAuthSession", () => {
+  beforeEach(() => {
+    cookieSet.mockReset();
+    cookieGet.mockReset();
+    vi.restoreAllMocks();
+  });
+
+  it("writes the rotated access and refresh tokens returned by /auth/refresh", async () => {
+    cookieGet.mockImplementation((name: string) => {
+      if (name === "sh_refresh") return { value: "old-refresh-token" };
+      if (name === "sh_access") return { value: "old-access-token" };
+      return undefined;
+    });
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(
+          JSON.stringify({
+            data: {
+              access_token: "new-access-token",
+              refresh_token: "new-refresh-token",
+              session: {
+                id: "user-1",
+                email: "person@example.com",
+                full_name: "Person Example",
+                role: "admin",
+                wizard_complete: true,
+                scheme_memberships: [],
+              },
+            },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      ),
+    );
+
+    const result = await refreshAuthSession();
+
+    expect(result).toEqual({
+      id: "user-1",
+      email: "person@example.com",
+      full_name: "Person Example",
+      role: "admin",
+      wizard_complete: true,
+      scheme_memberships: [],
+    });
+    expect(cookieSet).toHaveBeenCalledWith(
+      "sh_access",
+      "new-access-token",
+      expect.any(Object),
+    );
+    expect(cookieSet).toHaveBeenCalledWith(
+      "sh_refresh",
+      "new-refresh-token",
+      expect.any(Object),
+    );
+  });
+});

--- a/lib/server-auth.ts
+++ b/lib/server-auth.ts
@@ -55,19 +55,12 @@ export async function refreshAuthSession(): Promise<SessionUser | null> {
 
   if (!res.ok) return null;
 
-  const { session } = await readApiData<{ session: SessionUser }>(res);
-  if (!session) return null;
+  const payload = await readApiData<AuthSessionPayload>(res);
+  if (!payload.access_token || !payload.refresh_token || !payload.session) {
+    return null;
+  }
 
-  const access_token = cookieStore.get("sh_access")?.value ?? "";
-  cookieStore.set("sh_access", access_token, ACCESS_OPTS);
-  cookieStore.set("sh_refresh", refreshToken, SESSION_OPTS);
-  cookieStore.set(
-    "sh_session",
-    encodeURIComponent(JSON.stringify(session)),
-    SESSION_OPTS,
-  );
-
-  return session;
+  return writeAuthCookies(payload);
 }
 
 export async function clearAuthCookies(): Promise<void> {


### PR DESCRIPTION
## Summary
- Fix rotated token persistence during refresh (use writeAuthCookies)
- Fix proxy path reconstruction (compute once, not twice)
- Fix POST body reuse on retry (buffer once upfront)
- Add structured query key factories (lib/query-keys.ts)
- Restore retryable error states on overview/members/attention pages
- Remove unused refreshTokens from lib/auth-actions.ts

## Test Plan
- [x] 63 frontend tests pass
- [x] TypeScript lint passes