### PR TITLE
feat: WhatsApp maintenance inbox — auto-ticketing, operator intake, and media handling

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -5,7 +5,6 @@ on:
     branches: [main]
     paths: ["backend/**"]
   pull_request:
-    branches: [main]
     paths: ["backend/**"]
 
 defaults:

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -17,7 +17,6 @@ on:
       - "proxy.ts"
       - "middleware.ts"
   pull_request:
-    branches: [main]
     paths:
       - "app/**"
       - "components/**"

--- a/app/app/[schemeId]/whatsapp/page.test.tsx
+++ b/app/app/[schemeId]/whatsapp/page.test.tsx
@@ -1,0 +1,149 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const mockUseAuth = vi.hoisted(() => vi.fn());
+const mockGetCached = vi.hoisted(() => vi.fn());
+const mockSetCached = vi.hoisted(() => vi.fn());
+const mockInvalidateCache = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/auth", () => ({
+  useAuth: mockUseAuth,
+}));
+
+vi.mock("next/navigation", () => ({
+  useParams: vi.fn(() => ({ schemeId: "scheme-1" })),
+}));
+
+vi.mock("@/lib/toast", () => ({
+  useToast: vi.fn(() => ({ addToast: vi.fn() })),
+  ToastProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+vi.mock("@/lib/data-cache", () => ({
+  getCached: mockGetCached,
+  setCached: mockSetCached,
+  invalidateCache: mockInvalidateCache,
+}));
+
+const mockDashboard = {
+  resident_thread: null,
+  threads: [
+    {
+      phone_number: "+27128001234",
+      messages: [
+        {
+          maintenance_request_id: "req-12345678",
+          media: [
+            { id: "m1", url: "https://example.com/photo.jpg", content_type: "image/jpeg" },
+          ],
+          id: "msg-1",
+          from: "resident" as const,
+          text: "My tap is leaking in the kitchen.",
+          sent_at: new Date().toISOString(),
+        },
+        {
+          id: "msg-2",
+          from: "bot" as const,
+          media: [],
+          text: "We've logged your maintenance request.",
+          sent_at: new Date().toISOString(),
+        },
+      ],
+      id: "thread-1",
+      unit_id: "unit-1",
+      unit_identifier: "1A",
+      owner_name: "John Doe",
+      connected: true,
+      last_active: new Date().toISOString(),
+      unread: 1,
+    },
+  ],
+  broadcasts: [],
+  maintenance_intakes: [
+    {
+      id: "intake-1",
+      scheme_id: "scheme-1",
+      thread_id: "thread-1",
+      message_id: "msg-1",
+      unit_id: "unit-1",
+      unit_identifier: "1A",
+      owner_name: "John Doe",
+      status: "candidate" as const,
+      category: "plumbing" as const,
+      title: "Leaking tap in kitchen",
+      description: "The kitchen tap has been dripping continuously for 3 days. Water is pooling on the counter.",
+      media_count: 1,
+      created_at: new Date().toISOString(),
+    },
+    {
+      id: "intake-2",
+      scheme_id: "scheme-1",
+      thread_id: "thread-2",
+      message_id: "msg-3",
+      unit_id: "unit-2",
+      unit_identifier: "2B",
+      owner_name: "Jane Smith",
+      status: "ticket_created" as const,
+      category: "electrical" as const,
+      title: "Broken light switch",
+      description: "The light switch in the living room has stopped working.",
+      media_count: 0,
+      maintenance_request_id: "req-99999999",
+      created_at: new Date().toISOString(),
+    },
+  ],
+  role: "trustee",
+  phone_number: "+27128001234",
+  total_residents: 10,
+  connected_count: 5,
+  unread_count: 1,
+};
+
+describe("WhatsAppPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetCached.mockReturnValue(mockDashboard);
+    mockUseAuth.mockReturnValue({ user: { role: "admin" } });
+  });
+
+  it("operator sees Maintenance tab with candidate count", async () => {
+    const { default: WhatsAppPage } = await import("@/app/app/[schemeId]/whatsapp/page");
+    render(<WhatsAppPage />);
+
+    expect(screen.getByText("Maintenance")).toBeInTheDocument();
+  });
+
+  it("candidate card shows Create ticket and Dismiss buttons", async () => {
+    const { default: WhatsAppPage } = await import("@/app/app/[schemeId]/whatsapp/page");
+    render(<WhatsAppPage />);
+
+    fireEvent.click(screen.getByText("Maintenance"));
+
+    expect(screen.getByText("Unit 1A")).toBeInTheDocument();
+    expect(screen.getByText("Leaking tap in kitchen")).toBeInTheDocument();
+    expect(screen.getByText("Create ticket")).toBeInTheDocument();
+    expect(screen.getByText("Dismiss")).toBeInTheDocument();
+  });
+
+  it("ticket-created card shows Ticket created status and reference", async () => {
+    const { default: WhatsAppPage } = await import("@/app/app/[schemeId]/whatsapp/page");
+    render(<WhatsAppPage />);
+
+    fireEvent.click(screen.getByText("Maintenance"));
+
+    expect(screen.getByText("Unit 2B")).toBeInTheDocument();
+    expect(screen.getByText("Broken light switch")).toBeInTheDocument();
+    expect(screen.getByText("Ticket created")).toBeInTheDocument();
+    expect(screen.getByText(/Ref req-9999/)).toBeInTheDocument();
+  });
+
+  it("resident view does not show Maintenance tab", async () => {
+    mockUseAuth.mockReturnValue({ user: { role: "resident" } });
+
+    const { default: WhatsAppPage } = await import("@/app/app/[schemeId]/whatsapp/page");
+    render(<WhatsAppPage />);
+
+    expect(screen.queryByText("Maintenance")).not.toBeInTheDocument();
+    expect(screen.getByText("Connect via WhatsApp")).toBeInTheDocument();
+  });
+});

--- a/app/app/[schemeId]/whatsapp/page.tsx
+++ b/app/app/[schemeId]/whatsapp/page.tsx
@@ -7,11 +7,17 @@ import Modal from '@/components/Modal'
 import { useAuth } from '@/lib/auth'
 import { getCached, invalidateCache, setCached } from '@/lib/data-cache'
 import { useToast } from '@/lib/toast'
-import { createWhatsAppBroadcast, getWhatsAppDashboard } from '@/lib/whatsapp-api'
+import {
+  createMaintenanceRequestFromWhatsAppMessage,
+  createWhatsAppBroadcast,
+  dismissWhatsAppMaintenanceIntake,
+  getWhatsAppDashboard,
+} from '@/lib/whatsapp-api'
 import type {
   WhatsAppBroadcast,
   WhatsAppBroadcastType,
   WhatsAppDashboard,
+  WhatsAppMaintenanceIntake,
   WhatsAppMessage,
   WhatsAppThread,
 } from '@/lib/whatsapp'
@@ -50,7 +56,57 @@ function ChatBubble({ message }: { message: WhatsAppMessage }) {
         ].join(' ')}
       >
         {message.text}
+        {message.media && message.media.length > 0 && (
+          <span className="mt-1 block text-[10px] text-muted">{message.media.length} media item{message.media.length === 1 ? '' : 's'}</span>
+        )}
+        {message.maintenance_request_id && (
+          <span className="mt-1 inline-block rounded-full bg-green-bg px-2 py-[1px] text-[10px] font-semibold text-green">
+            Maintenance ticket {message.maintenance_request_id.slice(0, 8)}
+          </span>
+        )}
         <span className="block text-[10px] text-muted/60 text-right mt-0.5">{messageTime(message.sent_at)}</span>
+      </div>
+    </div>
+  )
+}
+
+function MaintenanceIntakeCard({
+  intake,
+  onCreate,
+  onDismiss,
+}: {
+  intake: WhatsAppMaintenanceIntake
+  onCreate: (intake: WhatsAppMaintenanceIntake) => Promise<void>
+  onDismiss: (intake: WhatsAppMaintenanceIntake) => Promise<void>
+}) {
+  return (
+    <div className="border-b border-border px-5 py-4 last:border-b-0">
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0">
+          <div className="mb-1 flex flex-wrap items-center gap-2">
+            <span className="text-[13px] font-semibold text-ink">Unit {intake.unit_identifier}</span>
+            <span className="rounded-full bg-hover-subtle px-2 py-[2px] text-[10px] text-muted">{intake.category}</span>
+            <span className={intake.status === 'ticket_created' ? 'rounded-full bg-green-bg px-2 py-[2px] text-[10px] text-green' : 'rounded-full bg-yellowbg px-2 py-[2px] text-[10px] text-amber'}>
+              {intake.status === 'ticket_created' ? 'Ticket created' : intake.status}
+            </span>
+          </div>
+          <p className="text-[13px] font-medium text-ink">{intake.title}</p>
+          <p className="mt-1 line-clamp-2 text-[12px] text-muted">{intake.description}</p>
+          <p className="mt-1 text-[11px] text-muted">
+            {intake.owner_name} · {intake.media_count} media item{intake.media_count === 1 ? '' : 's'}
+            {intake.maintenance_request_id ? ` · Ref ${intake.maintenance_request_id.slice(0, 8)}` : ''}
+          </p>
+        </div>
+        {intake.status === 'candidate' && (
+          <div className="flex flex-shrink-0 gap-2">
+            <button onClick={() => onCreate(intake)} className="rounded-lg bg-accent px-3 py-2 text-[12px] font-semibold text-white">
+              Create ticket
+            </button>
+            <button onClick={() => onDismiss(intake)} className="rounded-lg border border-border px-3 py-2 text-[12px] font-medium text-muted">
+              Dismiss
+            </button>
+          </div>
+        )}
       </div>
     </div>
   )
@@ -228,7 +284,7 @@ function OperatorView({
   onReload: () => Promise<void>
 }) {
   const { addToast } = useToast()
-  const [activeTab, setActiveTab] = useState<'inbox' | 'broadcasts'>('inbox')
+  const [activeTab, setActiveTab] = useState<'inbox' | 'maintenance' | 'broadcasts'>('inbox')
   const [broadcastOpen, setBroadcastOpen] = useState(false)
   const [broadcastText, setBroadcastText] = useState('')
   const [broadcastType, setBroadcastType] = useState<WhatsAppBroadcastType>('general')
@@ -256,6 +312,22 @@ function OperatorView({
     } finally {
       setSending(false)
     }
+  }
+
+  async function createTicketFromIntake(intake: WhatsAppMaintenanceIntake) {
+    await createMaintenanceRequestFromWhatsAppMessage(schemeId, intake.message_id, {
+      title: intake.title,
+      description: intake.description,
+      category: intake.category,
+    })
+    await onReload()
+    addToast('Maintenance ticket created from WhatsApp.', 'success')
+  }
+
+  async function dismissIntake(intake: WhatsAppMaintenanceIntake) {
+    await dismissWhatsAppMaintenanceIntake(schemeId, intake.id)
+    await onReload()
+    addToast('WhatsApp maintenance intake dismissed.', 'success')
   }
 
   return (
@@ -288,7 +360,7 @@ function OperatorView({
       </div>
 
       <div className="flex border-b border-border mb-0">
-        {(['inbox', 'broadcasts'] as const).map(tab => (
+        {(['inbox', 'maintenance', 'broadcasts'] as const).map(tab => (
           <button
             key={tab}
             onClick={() => setActiveTab(tab)}
@@ -297,10 +369,15 @@ function OperatorView({
               activeTab === tab ? 'border-ink text-ink' : 'border-transparent text-muted hover:text-ink',
             ].join(' ')}
           >
-            {tab}
+            {tab === 'maintenance' ? 'Maintenance' : tab}
             {tab === 'inbox' && dashboard.unread_count > 0 && (
               <span className="ml-2 w-4 h-4 rounded-full bg-[#25D366] text-white text-[10px] font-bold inline-flex items-center justify-center">
                 {dashboard.unread_count}
+              </span>
+            )}
+            {tab === 'maintenance' && dashboard.maintenance_intakes.filter(item => item.status === 'candidate').length > 0 && (
+              <span className="ml-2 inline-flex h-4 w-4 items-center justify-center rounded-full bg-amber text-[10px] font-bold text-white">
+                {dashboard.maintenance_intakes.filter(item => item.status === 'candidate').length}
               </span>
             )}
           </button>
@@ -321,6 +398,17 @@ function OperatorView({
               <ThreadCard key={thread.id} thread={thread} />
             ))}
           </>
+        ) : activeTab === 'maintenance' ? (
+          dashboard.maintenance_intakes.length === 0 ? (
+            <div className="px-5 py-12 text-center text-[13px] text-muted">No WhatsApp maintenance intakes yet.</div>
+          ) : dashboard.maintenance_intakes.map(intake => (
+            <MaintenanceIntakeCard
+              key={intake.id}
+              intake={intake}
+              onCreate={createTicketFromIntake}
+              onDismiss={dismissIntake}
+            />
+          ))
         ) : (
           <>
             <div className="px-5 py-2 border-b border-border bg-page">

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -112,7 +112,7 @@ func main() {
 
 	whatsAppService := whatsapp.NewServiceWithAudit(db, sender, logger, resourceAuditService)
 	whatsAppBot := whatsapp.NewBot(db)
-	whatsAppWebhook := whatsapp.NewWebhookHandler(db, sender, whatsAppBot, logger, cfg.TwilioAuthToken)
+	whatsAppWebhook := whatsapp.NewWebhookHandler(db, sender, whatsAppBot, whatsAppService, logger, cfg.TwilioAuthToken)
 	billingProvider := billing.NewStripeProvider(cfg.StripeSecretKey, cfg.StripeWebhookSecret, cfg.StripePriceID)
 	billingService := billing.NewService(db, billingProvider, cfg.AppBaseURL)
 	invitationService := invitation.NewServiceWithAudit(db, emailClient, cfg.AppBaseURL, cfg.JWTSecret, cfg.JWTExpiry, cfg.RefreshExpiry, resourceAuditService)

--- a/backend/db/gen/models.go
+++ b/backend/db/gen/models.go
@@ -1140,6 +1140,22 @@ type WhatsappBroadcast struct {
 	CreatedAt      time.Time             `json:"created_at"`
 }
 
+type WhatsappMaintenanceIntake struct {
+	ID                   uuid.UUID           `json:"id"`
+	SchemeID             uuid.UUID           `json:"scheme_id"`
+	ThreadID             uuid.UUID           `json:"thread_id"`
+	MessageID            uuid.UUID           `json:"message_id"`
+	UnitID               uuid.UUID           `json:"unit_id"`
+	MaintenanceRequestID pgtype.UUID         `json:"maintenance_request_id"`
+	Status               string              `json:"status"`
+	Category             MaintenanceCategory `json:"category"`
+	Title                string              `json:"title"`
+	Description          string              `json:"description"`
+	MediaCount           int32               `json:"media_count"`
+	CreatedAt            time.Time           `json:"created_at"`
+	UpdatedAt            time.Time           `json:"updated_at"`
+}
+
 type WhatsappMessage struct {
 	ID                   uuid.UUID             `json:"id"`
 	ThreadID             uuid.UUID             `json:"thread_id"`
@@ -1148,6 +1164,16 @@ type WhatsappMessage struct {
 	MaintenanceRequestID pgtype.UUID           `json:"maintenance_request_id"`
 	NoticeID             pgtype.UUID           `json:"notice_id"`
 	CreatedAt            time.Time             `json:"created_at"`
+}
+
+type WhatsappMessageMedium struct {
+	ID               uuid.UUID   `json:"id"`
+	MessageID        uuid.UUID   `json:"message_id"`
+	Provider         string      `json:"provider"`
+	ProviderMediaSid pgtype.Text `json:"provider_media_sid"`
+	MediaUrl         string      `json:"media_url"`
+	ContentType      pgtype.Text `json:"content_type"`
+	CreatedAt        time.Time   `json:"created_at"`
 }
 
 type WhatsappThread struct {

--- a/backend/db/gen/whatsapp.sql.go
+++ b/backend/db/gen/whatsapp.sql.go
@@ -46,6 +46,19 @@ func (q *Queries) CountConnectedWhatsAppThreadsByScheme(ctx context.Context, sch
 	return count, err
 }
 
+const countWhatsAppMessageMediaByMessage = `-- name: CountWhatsAppMessageMediaByMessage :one
+SELECT COUNT(*)
+FROM whatsapp_message_media
+WHERE message_id = $1
+`
+
+func (q *Queries) CountWhatsAppMessageMediaByMessage(ctx context.Context, messageID uuid.UUID) (int64, error) {
+	row := q.db.QueryRow(ctx, countWhatsAppMessageMediaByMessage, messageID)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
 const createWhatsAppBroadcast = `-- name: CreateWhatsAppBroadcast :one
 INSERT INTO whatsapp_broadcasts (
     scheme_id, sent_by_user_id, type, message, recipient_count
@@ -84,6 +97,87 @@ func (q *Queries) CreateWhatsAppBroadcast(ctx context.Context, arg CreateWhatsAp
 	return i, err
 }
 
+const createWhatsAppMaintenanceIntake = `-- name: CreateWhatsAppMaintenanceIntake :one
+INSERT INTO whatsapp_maintenance_intakes (
+    scheme_id,
+    thread_id,
+    message_id,
+    unit_id,
+    maintenance_request_id,
+    status,
+    category,
+    title,
+    description,
+    media_count
+)
+VALUES (
+    $1,
+    $2,
+    $3,
+    $4,
+    $5,
+    $6,
+    $7,
+    $8,
+    $9,
+    $10
+)
+ON CONFLICT (message_id)
+DO UPDATE SET
+    maintenance_request_id = COALESCE(EXCLUDED.maintenance_request_id, whatsapp_maintenance_intakes.maintenance_request_id),
+    status = EXCLUDED.status,
+    category = EXCLUDED.category,
+    title = EXCLUDED.title,
+    description = EXCLUDED.description,
+    media_count = EXCLUDED.media_count
+RETURNING id, scheme_id, thread_id, message_id, unit_id, maintenance_request_id, status, category, title, description, media_count, created_at, updated_at
+`
+
+type CreateWhatsAppMaintenanceIntakeParams struct {
+	SchemeID             uuid.UUID           `json:"scheme_id"`
+	ThreadID             uuid.UUID           `json:"thread_id"`
+	MessageID            uuid.UUID           `json:"message_id"`
+	UnitID               uuid.UUID           `json:"unit_id"`
+	MaintenanceRequestID pgtype.UUID         `json:"maintenance_request_id"`
+	Status               string              `json:"status"`
+	Category             MaintenanceCategory `json:"category"`
+	Title                string              `json:"title"`
+	Description          string              `json:"description"`
+	MediaCount           int32               `json:"media_count"`
+}
+
+func (q *Queries) CreateWhatsAppMaintenanceIntake(ctx context.Context, arg CreateWhatsAppMaintenanceIntakeParams) (WhatsappMaintenanceIntake, error) {
+	row := q.db.QueryRow(ctx, createWhatsAppMaintenanceIntake,
+		arg.SchemeID,
+		arg.ThreadID,
+		arg.MessageID,
+		arg.UnitID,
+		arg.MaintenanceRequestID,
+		arg.Status,
+		arg.Category,
+		arg.Title,
+		arg.Description,
+		arg.MediaCount,
+	)
+	var i WhatsappMaintenanceIntake
+	err := row.Scan(
+		&i.ID,
+		&i.SchemeID,
+		&i.ThreadID,
+		&i.MessageID,
+		&i.UnitID,
+		&i.MaintenanceRequestID,
+		&i.Status,
+		&i.Category,
+		&i.Title,
+		&i.Description,
+		&i.MediaCount,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
 const createWhatsAppMessage = `-- name: CreateWhatsAppMessage :one
 INSERT INTO whatsapp_messages (
     thread_id, sender, body, maintenance_request_id, notice_id
@@ -116,6 +210,57 @@ func (q *Queries) CreateWhatsAppMessage(ctx context.Context, arg CreateWhatsAppM
 		&i.Body,
 		&i.MaintenanceRequestID,
 		&i.NoticeID,
+		&i.CreatedAt,
+	)
+	return i, err
+}
+
+const createWhatsAppMessageMedia = `-- name: CreateWhatsAppMessageMedia :one
+INSERT INTO whatsapp_message_media (
+    message_id,
+    provider,
+    provider_media_sid,
+    media_url,
+    content_type
+)
+VALUES (
+    $1,
+    $2,
+    $3,
+    $4,
+    $5
+)
+ON CONFLICT (message_id, provider_media_sid) WHERE provider_media_sid IS NOT NULL
+DO UPDATE SET
+    media_url = EXCLUDED.media_url,
+    content_type = EXCLUDED.content_type
+RETURNING id, message_id, provider, provider_media_sid, media_url, content_type, created_at
+`
+
+type CreateWhatsAppMessageMediaParams struct {
+	MessageID        uuid.UUID   `json:"message_id"`
+	Provider         string      `json:"provider"`
+	ProviderMediaSid pgtype.Text `json:"provider_media_sid"`
+	MediaUrl         string      `json:"media_url"`
+	ContentType      pgtype.Text `json:"content_type"`
+}
+
+func (q *Queries) CreateWhatsAppMessageMedia(ctx context.Context, arg CreateWhatsAppMessageMediaParams) (WhatsappMessageMedium, error) {
+	row := q.db.QueryRow(ctx, createWhatsAppMessageMedia,
+		arg.MessageID,
+		arg.Provider,
+		arg.ProviderMediaSid,
+		arg.MediaUrl,
+		arg.ContentType,
+	)
+	var i WhatsappMessageMedium
+	err := row.Scan(
+		&i.ID,
+		&i.MessageID,
+		&i.Provider,
+		&i.ProviderMediaSid,
+		&i.MediaUrl,
+		&i.ContentType,
 		&i.CreatedAt,
 	)
 	return i, err
@@ -168,6 +313,34 @@ func (q *Queries) CreateWhatsAppThread(ctx context.Context, arg CreateWhatsAppTh
 	return i, err
 }
 
+const dismissWhatsAppMaintenanceIntake = `-- name: DismissWhatsAppMaintenanceIntake :one
+UPDATE whatsapp_maintenance_intakes
+SET status = 'dismissed'
+WHERE id = $1
+RETURNING id, scheme_id, thread_id, message_id, unit_id, maintenance_request_id, status, category, title, description, media_count, created_at, updated_at
+`
+
+func (q *Queries) DismissWhatsAppMaintenanceIntake(ctx context.Context, id uuid.UUID) (WhatsappMaintenanceIntake, error) {
+	row := q.db.QueryRow(ctx, dismissWhatsAppMaintenanceIntake, id)
+	var i WhatsappMaintenanceIntake
+	err := row.Scan(
+		&i.ID,
+		&i.SchemeID,
+		&i.ThreadID,
+		&i.MessageID,
+		&i.UnitID,
+		&i.MaintenanceRequestID,
+		&i.Status,
+		&i.Category,
+		&i.Title,
+		&i.Description,
+		&i.MediaCount,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
 const getConnectedWhatsAppThreadByPhone = `-- name: GetConnectedWhatsAppThreadByPhone :many
 SELECT id, scheme_id, unit_id, resident_user_id, phone_number, connected, consented_at, unread_count, last_active_at, created_at, updated_at FROM whatsapp_threads
 WHERE phone_number = $1
@@ -205,6 +378,80 @@ func (q *Queries) GetConnectedWhatsAppThreadByPhone(ctx context.Context, phoneNu
 		return nil, err
 	}
 	return items, nil
+}
+
+const getWhatsAppMaintenanceIntake = `-- name: GetWhatsAppMaintenanceIntake :one
+SELECT id, scheme_id, thread_id, message_id, unit_id, maintenance_request_id, status, category, title, description, media_count, created_at, updated_at
+FROM whatsapp_maintenance_intakes
+WHERE id = $1
+LIMIT 1
+`
+
+func (q *Queries) GetWhatsAppMaintenanceIntake(ctx context.Context, id uuid.UUID) (WhatsappMaintenanceIntake, error) {
+	row := q.db.QueryRow(ctx, getWhatsAppMaintenanceIntake, id)
+	var i WhatsappMaintenanceIntake
+	err := row.Scan(
+		&i.ID,
+		&i.SchemeID,
+		&i.ThreadID,
+		&i.MessageID,
+		&i.UnitID,
+		&i.MaintenanceRequestID,
+		&i.Status,
+		&i.Category,
+		&i.Title,
+		&i.Description,
+		&i.MediaCount,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
+const getWhatsAppMessageWithThread = `-- name: GetWhatsAppMessageWithThread :one
+SELECT
+    wm.id, wm.thread_id, wm.sender, wm.body, wm.maintenance_request_id, wm.notice_id, wm.created_at,
+    wt.scheme_id,
+    wt.unit_id,
+    wt.resident_user_id,
+    wt.phone_number
+FROM whatsapp_messages wm
+JOIN whatsapp_threads wt ON wt.id = wm.thread_id
+WHERE wm.id = $1
+LIMIT 1
+`
+
+type GetWhatsAppMessageWithThreadRow struct {
+	ID                   uuid.UUID             `json:"id"`
+	ThreadID             uuid.UUID             `json:"thread_id"`
+	Sender               WhatsappMessageSender `json:"sender"`
+	Body                 string                `json:"body"`
+	MaintenanceRequestID pgtype.UUID           `json:"maintenance_request_id"`
+	NoticeID             pgtype.UUID           `json:"notice_id"`
+	CreatedAt            time.Time             `json:"created_at"`
+	SchemeID             uuid.UUID             `json:"scheme_id"`
+	UnitID               uuid.UUID             `json:"unit_id"`
+	ResidentUserID       pgtype.UUID           `json:"resident_user_id"`
+	PhoneNumber          pgtype.Text           `json:"phone_number"`
+}
+
+func (q *Queries) GetWhatsAppMessageWithThread(ctx context.Context, messageID uuid.UUID) (GetWhatsAppMessageWithThreadRow, error) {
+	row := q.db.QueryRow(ctx, getWhatsAppMessageWithThread, messageID)
+	var i GetWhatsAppMessageWithThreadRow
+	err := row.Scan(
+		&i.ID,
+		&i.ThreadID,
+		&i.Sender,
+		&i.Body,
+		&i.MaintenanceRequestID,
+		&i.NoticeID,
+		&i.CreatedAt,
+		&i.SchemeID,
+		&i.UnitID,
+		&i.ResidentUserID,
+		&i.PhoneNumber,
+	)
+	return i, err
 }
 
 const getWhatsAppThreadBySchemeAndUnit = `-- name: GetWhatsAppThreadBySchemeAndUnit :one
@@ -288,6 +535,107 @@ func (q *Queries) ListWhatsAppBroadcastsDetailedByScheme(ctx context.Context, sc
 			&i.SentAt,
 			&i.CreatedAt,
 			&i.SentByName,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listWhatsAppMaintenanceIntakesByScheme = `-- name: ListWhatsAppMaintenanceIntakesByScheme :many
+SELECT
+    wmi.id, wmi.scheme_id, wmi.thread_id, wmi.message_id, wmi.unit_id, wmi.maintenance_request_id, wmi.status, wmi.category, wmi.title, wmi.description, wmi.media_count, wmi.created_at, wmi.updated_at,
+    u.identifier AS unit_identifier,
+    u.owner_name
+FROM whatsapp_maintenance_intakes wmi
+JOIN units u ON u.id = wmi.unit_id
+WHERE wmi.scheme_id = $1
+ORDER BY wmi.created_at DESC
+`
+
+type ListWhatsAppMaintenanceIntakesBySchemeRow struct {
+	ID                   uuid.UUID           `json:"id"`
+	SchemeID             uuid.UUID           `json:"scheme_id"`
+	ThreadID             uuid.UUID           `json:"thread_id"`
+	MessageID            uuid.UUID           `json:"message_id"`
+	UnitID               uuid.UUID           `json:"unit_id"`
+	MaintenanceRequestID pgtype.UUID         `json:"maintenance_request_id"`
+	Status               string              `json:"status"`
+	Category             MaintenanceCategory `json:"category"`
+	Title                string              `json:"title"`
+	Description          string              `json:"description"`
+	MediaCount           int32               `json:"media_count"`
+	CreatedAt            time.Time           `json:"created_at"`
+	UpdatedAt            time.Time           `json:"updated_at"`
+	UnitIdentifier       string              `json:"unit_identifier"`
+	OwnerName            string              `json:"owner_name"`
+}
+
+func (q *Queries) ListWhatsAppMaintenanceIntakesByScheme(ctx context.Context, schemeID uuid.UUID) ([]ListWhatsAppMaintenanceIntakesBySchemeRow, error) {
+	rows, err := q.db.Query(ctx, listWhatsAppMaintenanceIntakesByScheme, schemeID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListWhatsAppMaintenanceIntakesBySchemeRow{}
+	for rows.Next() {
+		var i ListWhatsAppMaintenanceIntakesBySchemeRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.SchemeID,
+			&i.ThreadID,
+			&i.MessageID,
+			&i.UnitID,
+			&i.MaintenanceRequestID,
+			&i.Status,
+			&i.Category,
+			&i.Title,
+			&i.Description,
+			&i.MediaCount,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.UnitIdentifier,
+			&i.OwnerName,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listWhatsAppMessageMediaByThread = `-- name: ListWhatsAppMessageMediaByThread :many
+SELECT wmm.id, wmm.message_id, wmm.provider, wmm.provider_media_sid, wmm.media_url, wmm.content_type, wmm.created_at
+FROM whatsapp_message_media wmm
+JOIN whatsapp_messages wm ON wm.id = wmm.message_id
+WHERE wm.thread_id = $1
+ORDER BY wmm.created_at ASC
+`
+
+func (q *Queries) ListWhatsAppMessageMediaByThread(ctx context.Context, threadID uuid.UUID) ([]WhatsappMessageMedium, error) {
+	rows, err := q.db.Query(ctx, listWhatsAppMessageMediaByThread, threadID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []WhatsappMessageMedium{}
+	for rows.Next() {
+		var i WhatsappMessageMedium
+		if err := rows.Scan(
+			&i.ID,
+			&i.MessageID,
+			&i.Provider,
+			&i.ProviderMediaSid,
+			&i.MediaUrl,
+			&i.ContentType,
+			&i.CreatedAt,
 		); err != nil {
 			return nil, err
 		}
@@ -408,5 +756,21 @@ type TouchWhatsAppThreadParams struct {
 
 func (q *Queries) TouchWhatsAppThread(ctx context.Context, arg TouchWhatsAppThreadParams) error {
 	_, err := q.db.Exec(ctx, touchWhatsAppThread, arg.ID, arg.UnreadCount, arg.LastActiveAt)
+	return err
+}
+
+const updateWhatsAppMessageMaintenanceRequest = `-- name: UpdateWhatsAppMessageMaintenanceRequest :exec
+UPDATE whatsapp_messages
+SET maintenance_request_id = $1
+WHERE id = $2
+`
+
+type UpdateWhatsAppMessageMaintenanceRequestParams struct {
+	MaintenanceRequestID pgtype.UUID `json:"maintenance_request_id"`
+	ID                   uuid.UUID   `json:"id"`
+}
+
+func (q *Queries) UpdateWhatsAppMessageMaintenanceRequest(ctx context.Context, arg UpdateWhatsAppMessageMaintenanceRequestParams) error {
+	_, err := q.db.Exec(ctx, updateWhatsAppMessageMaintenanceRequest, arg.MaintenanceRequestID, arg.ID)
 	return err
 }

--- a/backend/db/migrations/00027_whatsapp_maintenance_inbox.sql
+++ b/backend/db/migrations/00027_whatsapp_maintenance_inbox.sql
@@ -1,0 +1,59 @@
+-- +goose Up
+
+CREATE TABLE whatsapp_message_media (
+    id                 UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    message_id         UUID        NOT NULL REFERENCES whatsapp_messages(id) ON DELETE CASCADE,
+    provider           TEXT        NOT NULL DEFAULT 'twilio',
+    provider_media_sid TEXT,
+    media_url          TEXT        NOT NULL,
+    content_type       TEXT,
+    created_at         TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE whatsapp_message_media ENABLE ROW LEVEL SECURITY;
+
+CREATE INDEX idx_whatsapp_message_media_message_id
+    ON whatsapp_message_media (message_id);
+
+CREATE UNIQUE INDEX idx_whatsapp_message_media_message_provider_sid
+    ON whatsapp_message_media (message_id, provider_media_sid)
+    WHERE provider_media_sid IS NOT NULL;
+
+CREATE TABLE whatsapp_maintenance_intakes (
+    id                     UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    scheme_id              UUID        NOT NULL REFERENCES schemes(id) ON DELETE CASCADE,
+    thread_id              UUID        NOT NULL REFERENCES whatsapp_threads(id) ON DELETE CASCADE,
+    message_id             UUID        NOT NULL UNIQUE REFERENCES whatsapp_messages(id) ON DELETE CASCADE,
+    unit_id                UUID        NOT NULL REFERENCES units(id) ON DELETE CASCADE,
+    maintenance_request_id UUID        REFERENCES maintenance_requests(id) ON DELETE SET NULL,
+    status                 TEXT        NOT NULL CHECK (status IN ('candidate', 'ticket_created', 'dismissed')),
+    category               maintenance_category NOT NULL DEFAULT 'other',
+    title                  TEXT        NOT NULL,
+    description            TEXT        NOT NULL,
+    media_count            INTEGER     NOT NULL DEFAULT 0 CHECK (media_count >= 0),
+    created_at             TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at             TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TRIGGER whatsapp_maintenance_intakes_set_updated_at
+    BEFORE UPDATE ON whatsapp_maintenance_intakes
+    FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+ALTER TABLE whatsapp_maintenance_intakes ENABLE ROW LEVEL SECURITY;
+
+CREATE INDEX idx_whatsapp_maintenance_intakes_scheme_status_created
+    ON whatsapp_maintenance_intakes (scheme_id, status, created_at DESC);
+
+CREATE INDEX idx_whatsapp_maintenance_intakes_request
+    ON whatsapp_maintenance_intakes (maintenance_request_id)
+    WHERE maintenance_request_id IS NOT NULL;
+
+-- +goose Down
+
+DROP INDEX IF EXISTS idx_whatsapp_maintenance_intakes_request;
+DROP INDEX IF EXISTS idx_whatsapp_maintenance_intakes_scheme_status_created;
+DROP TRIGGER IF EXISTS whatsapp_maintenance_intakes_set_updated_at ON whatsapp_maintenance_intakes;
+DROP TABLE IF EXISTS whatsapp_maintenance_intakes;
+DROP INDEX IF EXISTS idx_whatsapp_message_media_message_provider_sid;
+DROP INDEX IF EXISTS idx_whatsapp_message_media_message_id;
+DROP TABLE IF EXISTS whatsapp_message_media;

--- a/backend/db/queries/whatsapp.sql
+++ b/backend/db/queries/whatsapp.sql
@@ -76,3 +76,110 @@ SET connected = TRUE,
     phone_number = $2,
     last_active_at = NOW()
 WHERE id = $1;
+
+-- name: CreateWhatsAppMessageMedia :one
+INSERT INTO whatsapp_message_media (
+    message_id,
+    provider,
+    provider_media_sid,
+    media_url,
+    content_type
+)
+VALUES (
+    sqlc.arg(message_id),
+    sqlc.arg(provider),
+    sqlc.arg(provider_media_sid),
+    sqlc.arg(media_url),
+    sqlc.arg(content_type)
+)
+ON CONFLICT (message_id, provider_media_sid) WHERE provider_media_sid IS NOT NULL
+DO UPDATE SET
+    media_url = EXCLUDED.media_url,
+    content_type = EXCLUDED.content_type
+RETURNING *;
+
+-- name: ListWhatsAppMessageMediaByThread :many
+SELECT wmm.*
+FROM whatsapp_message_media wmm
+JOIN whatsapp_messages wm ON wm.id = wmm.message_id
+WHERE wm.thread_id = sqlc.arg(thread_id)
+ORDER BY wmm.created_at ASC;
+
+-- name: CountWhatsAppMessageMediaByMessage :one
+SELECT COUNT(*)
+FROM whatsapp_message_media
+WHERE message_id = sqlc.arg(message_id);
+
+-- name: UpdateWhatsAppMessageMaintenanceRequest :exec
+UPDATE whatsapp_messages
+SET maintenance_request_id = sqlc.arg(maintenance_request_id)
+WHERE id = sqlc.arg(id);
+
+-- name: GetWhatsAppMessageWithThread :one
+SELECT
+    wm.*,
+    wt.scheme_id,
+    wt.unit_id,
+    wt.resident_user_id,
+    wt.phone_number
+FROM whatsapp_messages wm
+JOIN whatsapp_threads wt ON wt.id = wm.thread_id
+WHERE wm.id = sqlc.arg(message_id)
+LIMIT 1;
+
+-- name: CreateWhatsAppMaintenanceIntake :one
+INSERT INTO whatsapp_maintenance_intakes (
+    scheme_id,
+    thread_id,
+    message_id,
+    unit_id,
+    maintenance_request_id,
+    status,
+    category,
+    title,
+    description,
+    media_count
+)
+VALUES (
+    sqlc.arg(scheme_id),
+    sqlc.arg(thread_id),
+    sqlc.arg(message_id),
+    sqlc.arg(unit_id),
+    sqlc.arg(maintenance_request_id),
+    sqlc.arg(status),
+    sqlc.arg(category),
+    sqlc.arg(title),
+    sqlc.arg(description),
+    sqlc.arg(media_count)
+)
+ON CONFLICT (message_id)
+DO UPDATE SET
+    maintenance_request_id = COALESCE(EXCLUDED.maintenance_request_id, whatsapp_maintenance_intakes.maintenance_request_id),
+    status = EXCLUDED.status,
+    category = EXCLUDED.category,
+    title = EXCLUDED.title,
+    description = EXCLUDED.description,
+    media_count = EXCLUDED.media_count
+RETURNING *;
+
+-- name: ListWhatsAppMaintenanceIntakesByScheme :many
+SELECT
+    wmi.*,
+    u.identifier AS unit_identifier,
+    u.owner_name
+FROM whatsapp_maintenance_intakes wmi
+JOIN units u ON u.id = wmi.unit_id
+WHERE wmi.scheme_id = sqlc.arg(scheme_id)
+ORDER BY wmi.created_at DESC;
+
+-- name: GetWhatsAppMaintenanceIntake :one
+SELECT *
+FROM whatsapp_maintenance_intakes
+WHERE id = sqlc.arg(id)
+LIMIT 1;
+
+-- name: DismissWhatsAppMaintenanceIntake :one
+UPDATE whatsapp_maintenance_intakes
+SET status = 'dismissed'
+WHERE id = sqlc.arg(id)
+RETURNING *;

--- a/backend/internal/whatsapp/handler.go
+++ b/backend/internal/whatsapp/handler.go
@@ -23,6 +23,16 @@ type createBroadcastRequest struct {
 	Type    string `json:"type"`
 }
 
+type createMaintenanceFromMessageRequest struct {
+	Title       string `json:"title"`
+	Description string `json:"description"`
+	Category    string `json:"category"`
+}
+
+type dismissMaintenanceIntakeRequest struct {
+	Dismissed bool `json:"dismissed"`
+}
+
 func (h *Handler) Dashboard(w http.ResponseWriter, r *http.Request) {
 	identity, ok := auth.IdentityFromRequest(r)
 	if !ok {
@@ -62,6 +72,48 @@ func (h *Handler) CreateBroadcast(w http.ResponseWriter, r *http.Request) {
 	}
 
 	response.JSON(w, http.StatusCreated, broadcast)
+}
+
+func (h *Handler) CreateMaintenanceFromMessage(w http.ResponseWriter, r *http.Request) {
+	identity, ok := auth.IdentityFromRequest(r)
+	if !ok {
+		response.Error(w, http.StatusUnauthorized, response.CodeUnauthorized, "missing auth context")
+		return
+	}
+
+	var req createMaintenanceFromMessageRequest
+	if err := response.DecodeJSON(r.Body, &req); err != nil {
+		response.Error(w, http.StatusBadRequest, response.CodeBadRequest, "invalid request body")
+		return
+	}
+
+	intake, err := h.service.CreateMaintenanceFromMessage(r.Context(), identity, chi.URLParam(r, "schemeId"), chi.URLParam(r, "messageId"), CreateMaintenanceFromMessageInput{
+		Title:       strings.TrimSpace(req.Title),
+		Description: strings.TrimSpace(req.Description),
+		Category:    strings.TrimSpace(req.Category),
+	})
+	if err != nil {
+		writeWhatsAppError(w, err, "failed to create maintenance request")
+		return
+	}
+
+	response.JSON(w, http.StatusCreated, intake)
+}
+
+func (h *Handler) DismissMaintenanceIntake(w http.ResponseWriter, r *http.Request) {
+	identity, ok := auth.IdentityFromRequest(r)
+	if !ok {
+		response.Error(w, http.StatusUnauthorized, response.CodeUnauthorized, "missing auth context")
+		return
+	}
+
+	intake, err := h.service.DismissMaintenanceIntake(r.Context(), identity, chi.URLParam(r, "schemeId"), chi.URLParam(r, "intakeId"))
+	if err != nil {
+		writeWhatsAppError(w, err, "failed to dismiss maintenance intake")
+		return
+	}
+
+	response.JSON(w, http.StatusOK, intake)
 }
 
 func writeWhatsAppError(w http.ResponseWriter, err error, fallback string) {

--- a/backend/internal/whatsapp/handler.go
+++ b/backend/internal/whatsapp/handler.go
@@ -29,10 +29,6 @@ type createMaintenanceFromMessageRequest struct {
 	Category    string `json:"category"`
 }
 
-type dismissMaintenanceIntakeRequest struct {
-	Dismissed bool `json:"dismissed"`
-}
-
 func (h *Handler) Dashboard(w http.ResponseWriter, r *http.Request) {
 	identity, ok := auth.IdentityFromRequest(r)
 	if !ok {

--- a/backend/internal/whatsapp/routes.go
+++ b/backend/internal/whatsapp/routes.go
@@ -6,5 +6,7 @@ func (h *Handler) Routes() chi.Router {
 	r := chi.NewRouter()
 	r.Get("/{schemeId}", h.Dashboard)
 	r.Post("/{schemeId}/broadcasts", h.CreateBroadcast)
+	r.Post("/{schemeId}/messages/{messageId}/maintenance-request", h.CreateMaintenanceFromMessage)
+	r.Patch("/{schemeId}/maintenance-intakes/{intakeId}", h.DismissMaintenanceIntake)
 	return r
 }

--- a/backend/internal/whatsapp/service.go
+++ b/backend/internal/whatsapp/service.go
@@ -155,10 +155,11 @@ func (s *Service) Dashboard(ctx context.Context, identity auth.Identity, schemeI
 	}
 
 	response := &DashboardResponse{
-		Threads:     []ThreadInfo{},
-		Broadcasts:  []BroadcastInfo{},
-		Role:        access.role,
-		PhoneNumber: schemeWhatsAppNumber,
+		Threads:            []ThreadInfo{},
+		Broadcasts:         []BroadcastInfo{},
+		MaintenanceIntakes: []MaintenanceIntakeInfo{},
+		Role:               access.role,
+		PhoneNumber:        schemeWhatsAppNumber,
 	}
 
 	for _, row := range threadRows {
@@ -630,6 +631,19 @@ func (s *Service) CreateMaintenanceFromMessage(ctx context.Context, identity aut
 	if msg.SchemeID != access.scheme.ID {
 		return nil, ErrForbidden
 	}
+	if msg.MaintenanceRequestID.Valid {
+		intakes, err := s.db.Q.ListWhatsAppMaintenanceIntakesByScheme(ctx, access.scheme.ID)
+		if err != nil {
+			return nil, err
+		}
+		for _, row := range intakes {
+			if row.MessageID == mid {
+				mapped := mapMaintenanceIntake(row)
+				return &mapped, nil
+			}
+		}
+	}
+
 	title := strings.TrimSpace(input.Title)
 	description := strings.TrimSpace(input.Description)
 	category := strings.TrimSpace(input.Category)

--- a/backend/internal/whatsapp/service.go
+++ b/backend/internal/whatsapp/service.go
@@ -487,7 +487,8 @@ func buildMaintenanceIntakeText(body string, mediaCount int) intakeText {
 		titleSource = titleSource[:idx]
 	}
 	if len(titleSource) > 80 {
-		titleSource = titleSource[:80]
+		runes := []rune(titleSource)
+		titleSource = string(runes[:80])
 	}
 	result := intakeText{
 		Title:       "WhatsApp: " + strings.TrimSpace(titleSource),

--- a/backend/internal/whatsapp/service.go
+++ b/backend/internal/whatsapp/service.go
@@ -167,7 +167,12 @@ func (s *Service) Dashboard(ctx context.Context, identity auth.Identity, schemeI
 			return nil, msgErr
 		}
 
-		thread := mapThread(row, messages)
+		mediaRows, mediaErr := s.db.Q.ListWhatsAppMessageMediaByThread(ctx, row.ID)
+		if mediaErr != nil {
+			return nil, mediaErr
+		}
+
+		thread := mapThread(row, messages, mediaRows)
 		response.TotalResidents++
 		if row.Connected {
 			response.ConnectedCount++
@@ -183,6 +188,16 @@ func (s *Service) Dashboard(ctx context.Context, identity auth.Identity, schemeI
 		}
 
 		response.Threads = append(response.Threads, thread)
+	}
+
+	if !auth.IsResidentRole(access.role) {
+		intakes, err := s.db.Q.ListWhatsAppMaintenanceIntakesByScheme(ctx, access.scheme.ID)
+		if err != nil {
+			return nil, err
+		}
+		for _, intake := range intakes {
+			response.MaintenanceIntakes = append(response.MaintenanceIntakes, mapMaintenanceIntake(intake))
+		}
 	}
 
 	broadcastRows, err := s.db.Q.ListWhatsAppBroadcastsDetailedByScheme(ctx, access.scheme.ID)
@@ -382,7 +397,20 @@ func (s *Service) resolveAccess(ctx context.Context, identity auth.Identity, sch
 	return access, nil
 }
 
-func mapThread(row dbgen.ListWhatsAppThreadsDetailedBySchemeRow, messages []dbgen.WhatsappMessage) ThreadInfo {
+func mapThread(row dbgen.ListWhatsAppThreadsDetailedBySchemeRow, messages []dbgen.WhatsappMessage, mediaRows []dbgen.WhatsappMessageMedium) ThreadInfo {
+	mediaByMessage := make(map[uuid.UUID][]MediaInfo)
+	for _, m := range mediaRows {
+		contentType := ""
+		if m.ContentType.Valid {
+			contentType = m.ContentType.String
+		}
+		mediaByMessage[m.MessageID] = append(mediaByMessage[m.MessageID], MediaInfo{
+			ID:          m.ID.String(),
+			URL:         m.MediaUrl,
+			ContentType: contentType,
+		})
+	}
+
 	thread := ThreadInfo{
 		Messages:       make([]MessageInfo, 0, len(messages)),
 		ID:             row.ID.String(),
@@ -398,12 +426,18 @@ func mapThread(row dbgen.ListWhatsAppThreadsDetailedBySchemeRow, messages []dbge
 		thread.PhoneNumber = &phone
 	}
 	for _, message := range messages {
-		thread.Messages = append(thread.Messages, MessageInfo{
+		info := MessageInfo{
 			ID:     message.ID.String(),
 			From:   string(message.Sender),
 			Text:   message.Body,
 			SentAt: message.CreatedAt,
-		})
+			Media:  mediaByMessage[message.ID],
+		}
+		if message.MaintenanceRequestID.Valid {
+			id := uuid.UUID(message.MaintenanceRequestID.Bytes).String()
+			info.MaintenanceRequestID = &id
+		}
+		thread.Messages = append(thread.Messages, info)
 	}
 	return thread
 }
@@ -548,5 +582,190 @@ func whatsAppBroadcastSentAuditEvent(input whatsAppAuditInput, sendErrors int) a
 		Metadata: map[string]any{
 			"send_errors": sendErrors,
 		},
+	}
+}
+
+func mapMaintenanceIntake(row dbgen.ListWhatsAppMaintenanceIntakesBySchemeRow) MaintenanceIntakeInfo {
+	info := MaintenanceIntakeInfo{
+		ID:             row.ID.String(),
+		SchemeID:       row.SchemeID.String(),
+		ThreadID:       row.ThreadID.String(),
+		MessageID:      row.MessageID.String(),
+		UnitID:         row.UnitID.String(),
+		UnitIdentifier: row.UnitIdentifier,
+		OwnerName:      row.OwnerName,
+		Status:         row.Status,
+		Category:       string(row.Category),
+		Title:          row.Title,
+		Description:    row.Description,
+		MediaCount:     int(row.MediaCount),
+		CreatedAt:      row.CreatedAt,
+	}
+	if row.MaintenanceRequestID.Valid {
+		id := uuid.UUID(row.MaintenanceRequestID.Bytes).String()
+		info.MaintenanceRequestID = &id
+	}
+	return info
+}
+
+func (s *Service) CreateMaintenanceFromMessage(ctx context.Context, identity auth.Identity, schemeID, messageID string, input CreateMaintenanceFromMessageInput) (*MaintenanceIntakeInfo, error) {
+	access, err := s.resolveAccess(ctx, identity, schemeID)
+	if err != nil {
+		return nil, err
+	}
+	if auth.IsResidentRole(access.role) {
+		return nil, ErrForbidden
+	}
+	mid, err := uuid.Parse(messageID)
+	if err != nil {
+		return nil, ErrInvalidInput
+	}
+	msg, err := s.db.Q.GetWhatsAppMessageWithThread(ctx, mid)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	if msg.SchemeID != access.scheme.ID {
+		return nil, ErrForbidden
+	}
+	title := strings.TrimSpace(input.Title)
+	description := strings.TrimSpace(input.Description)
+	category := strings.TrimSpace(input.Category)
+	if title == "" || description == "" || !validMaintenanceCategory(category) {
+		return nil, ErrInvalidInput
+	}
+	mediaCount, err := s.db.Q.CountWhatsAppMessageMediaByMessage(ctx, mid)
+	if err != nil {
+		return nil, err
+	}
+	return s.createMaintenanceTicketForMessage(ctx, access.scheme.ID, msg.ThreadID, mid, msg.UnitID, title, description, category, int(mediaCount))
+}
+
+func (s *Service) DismissMaintenanceIntake(ctx context.Context, identity auth.Identity, schemeID, intakeID string) (*MaintenanceIntakeInfo, error) {
+	access, err := s.resolveAccess(ctx, identity, schemeID)
+	if err != nil {
+		return nil, err
+	}
+	if auth.IsResidentRole(access.role) {
+		return nil, ErrForbidden
+	}
+	id, err := uuid.Parse(intakeID)
+	if err != nil {
+		return nil, ErrInvalidInput
+	}
+	intake, err := s.db.Q.GetWhatsAppMaintenanceIntake(ctx, id)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	if intake.SchemeID != access.scheme.ID {
+		return nil, ErrForbidden
+	}
+	dismissed, err := s.db.Q.DismissWhatsAppMaintenanceIntake(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	rows, err := s.db.Q.ListWhatsAppMaintenanceIntakesByScheme(ctx, access.scheme.ID)
+	if err != nil {
+		return nil, err
+	}
+	for _, item := range rows {
+		if item.ID == dismissed.ID {
+			mapped := mapMaintenanceIntake(item)
+			return &mapped, nil
+		}
+	}
+	return nil, ErrNotFound
+}
+
+func (s *Service) createMaintenanceTicketForMessage(ctx context.Context, schemeID, threadID, messageID, unitID uuid.UUID, title, description, category string, mediaCount int) (*MaintenanceIntakeInfo, error) {
+	unit, err := s.db.Q.GetUnit(ctx, unitID)
+	if err != nil {
+		return nil, err
+	}
+	var intake dbgen.WhatsappMaintenanceIntake
+	err = database.WithTxQueries(ctx, s.db, func(q *dbgen.Queries) error {
+		request, txErr := q.CreateMaintenanceRequest(ctx, dbgen.CreateMaintenanceRequestParams{
+			SchemeID:        schemeID,
+			UnitID:          pgtype.UUID{Bytes: unitID, Valid: true},
+			Title:           title,
+			Description:     description,
+			Category:        dbgen.MaintenanceCategory(category),
+			SlaHours:        defaultWhatsAppSLAHours(category),
+			SubmittedByUnit: pgtype.Text{String: unit.Identifier, Valid: true},
+		})
+		if txErr != nil {
+			return txErr
+		}
+		request, txErr = q.UpdateMaintenanceStatus(ctx, dbgen.UpdateMaintenanceStatusParams{
+			ID:     request.ID,
+			Status: dbgen.MaintenanceStatusPendingApproval,
+		})
+		if txErr != nil {
+			return txErr
+		}
+		if txErr = q.UpdateWhatsAppMessageMaintenanceRequest(ctx, dbgen.UpdateWhatsAppMessageMaintenanceRequestParams{
+			ID:                   messageID,
+			MaintenanceRequestID: pgtype.UUID{Bytes: request.ID, Valid: true},
+		}); txErr != nil {
+			return txErr
+		}
+		intake, txErr = q.CreateWhatsAppMaintenanceIntake(ctx, dbgen.CreateWhatsAppMaintenanceIntakeParams{
+			SchemeID:             schemeID,
+			ThreadID:             threadID,
+			MessageID:            messageID,
+			UnitID:               unitID,
+			MaintenanceRequestID: pgtype.UUID{Bytes: request.ID, Valid: true},
+			Status:               "ticket_created",
+			Category:             dbgen.MaintenanceCategory(category),
+			Title:                title,
+			Description:          description,
+			MediaCount:           int32(mediaCount),
+		})
+		return txErr
+	})
+	if err != nil {
+		return nil, err
+	}
+	rows, err := s.db.Q.ListWhatsAppMaintenanceIntakesByScheme(ctx, schemeID)
+	if err != nil {
+		return nil, err
+	}
+	for _, row := range rows {
+		if row.ID == intake.ID {
+			mapped := mapMaintenanceIntake(row)
+			return &mapped, nil
+		}
+	}
+	return nil, ErrNotFound
+}
+
+func validMaintenanceCategory(category string) bool {
+	switch category {
+	case string(dbgen.MaintenanceCategoryPlumbing),
+		string(dbgen.MaintenanceCategoryElectrical),
+		string(dbgen.MaintenanceCategoryStructural),
+		string(dbgen.MaintenanceCategoryGarden),
+		string(dbgen.MaintenanceCategoryPool),
+		string(dbgen.MaintenanceCategoryOther):
+		return true
+	default:
+		return false
+	}
+}
+
+func defaultWhatsAppSLAHours(category string) int32 {
+	switch category {
+	case string(dbgen.MaintenanceCategoryElectrical),
+		string(dbgen.MaintenanceCategoryPlumbing):
+		return 24
+	case string(dbgen.MaintenanceCategoryStructural):
+		return 48
+	default:
+		return 72
 	}
 }

--- a/backend/internal/whatsapp/service.go
+++ b/backend/internal/whatsapp/service.go
@@ -192,9 +192,9 @@ func (s *Service) Dashboard(ctx context.Context, identity auth.Identity, schemeI
 	}
 
 	if !auth.IsResidentRole(access.role) {
-		intakes, err := s.db.Q.ListWhatsAppMaintenanceIntakesByScheme(ctx, access.scheme.ID)
-		if err != nil {
-			return nil, err
+		intakes, intakeErr := s.db.Q.ListWhatsAppMaintenanceIntakesByScheme(ctx, access.scheme.ID)
+		if intakeErr != nil {
+			return nil, intakeErr
 		}
 		for _, intake := range intakes {
 			response.MaintenanceIntakes = append(response.MaintenanceIntakes, mapMaintenanceIntake(intake))
@@ -632,9 +632,9 @@ func (s *Service) CreateMaintenanceFromMessage(ctx context.Context, identity aut
 		return nil, ErrForbidden
 	}
 	if msg.MaintenanceRequestID.Valid {
-		intakes, err := s.db.Q.ListWhatsAppMaintenanceIntakesByScheme(ctx, access.scheme.ID)
-		if err != nil {
-			return nil, err
+		intakes, intakeErr := s.db.Q.ListWhatsAppMaintenanceIntakesByScheme(ctx, access.scheme.ID)
+		if intakeErr != nil {
+			return nil, intakeErr
 		}
 		for _, row := range intakes {
 			if row.MessageID == mid {

--- a/backend/internal/whatsapp/service.go
+++ b/backend/internal/whatsapp/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"strconv"
 	"strings"
 	"time"
 
@@ -27,10 +28,12 @@ var (
 
 //nolint:govet // Keep response DTO fields grouped by meaning rather than field packing.
 type MessageInfo struct {
-	SentAt time.Time `json:"sent_at"`
-	ID     string    `json:"id"`
-	From   string    `json:"from"`
-	Text   string    `json:"text"`
+	SentAt               time.Time   `json:"sent_at"`
+	ID                   string      `json:"id"`
+	From                 string      `json:"from"`
+	Text                 string      `json:"text"`
+	MaintenanceRequestID *string     `json:"maintenance_request_id"`
+	Media                []MediaInfo `json:"media"`
 }
 
 //nolint:govet // Keep response DTO fields grouped by meaning rather than field packing.
@@ -59,19 +62,59 @@ type BroadcastInfo struct {
 
 //nolint:govet // Keep response DTO fields grouped by meaning rather than field packing.
 type DashboardResponse struct {
-	ResidentThread *ThreadInfo     `json:"resident_thread"`
-	Role           string          `json:"role"`
-	PhoneNumber    string          `json:"phone_number"`
-	Threads        []ThreadInfo    `json:"threads"`
-	Broadcasts     []BroadcastInfo `json:"broadcasts"`
-	TotalResidents int             `json:"total_residents"`
-	ConnectedCount int             `json:"connected_count"`
-	UnreadCount    int             `json:"unread_count"`
+	ResidentThread     *ThreadInfo             `json:"resident_thread"`
+	Role               string                  `json:"role"`
+	PhoneNumber        string                  `json:"phone_number"`
+	Threads            []ThreadInfo            `json:"threads"`
+	Broadcasts         []BroadcastInfo         `json:"broadcasts"`
+	TotalResidents     int                     `json:"total_residents"`
+	ConnectedCount     int                     `json:"connected_count"`
+	UnreadCount        int                     `json:"unread_count"`
+	MaintenanceIntakes []MaintenanceIntakeInfo `json:"maintenance_intakes"`
 }
 
 type CreateBroadcastInput struct {
 	Message string
 	Type    string
+}
+
+type MediaInfo struct {
+	ID          string `json:"id"`
+	URL         string `json:"url"`
+	ContentType string `json:"content_type"`
+}
+
+type MaintenanceIntakeInfo struct {
+	CreatedAt            time.Time `json:"created_at"`
+	MaintenanceRequestID *string   `json:"maintenance_request_id"`
+	ID                   string    `json:"id"`
+	SchemeID             string    `json:"scheme_id"`
+	ThreadID             string    `json:"thread_id"`
+	MessageID            string    `json:"message_id"`
+	UnitID               string    `json:"unit_id"`
+	UnitIdentifier       string    `json:"unit_identifier"`
+	OwnerName            string    `json:"owner_name"`
+	Status               string    `json:"status"`
+	Category             string    `json:"category"`
+	Title                string    `json:"title"`
+	Description          string    `json:"description"`
+	MediaCount           int       `json:"media_count"`
+}
+
+type CreateMaintenanceFromMessageInput struct {
+	Title       string
+	Description string
+	Category    string
+}
+
+type maintenanceIntent struct {
+	IsMaintenance bool
+	Category      string
+}
+
+type intakeText struct {
+	Title       string
+	Description string
 }
 
 type accessInfo struct {
@@ -387,6 +430,73 @@ func validBroadcastType(value string) bool {
 	default:
 		return false
 	}
+}
+
+func classifyMaintenanceIntent(body string, mediaCount int) maintenanceIntent {
+	text := strings.ToLower(strings.TrimSpace(body))
+	category := inferMaintenanceCategory(text)
+	intentPrefixes := []string{"2", "request", "maintenance", "repair", "fix", "broken", "leak", "burst", "blocked", "no power", "lights", "plug", "gate", "roof", "crack", "pool", "garden"}
+	for _, prefix := range intentPrefixes {
+		if text == prefix || strings.HasPrefix(text, prefix+" ") {
+			return maintenanceIntent{IsMaintenance: true, Category: category}
+		}
+	}
+	if mediaCount > 0 && category != "other" {
+		return maintenanceIntent{IsMaintenance: true, Category: category}
+	}
+	return maintenanceIntent{IsMaintenance: false, Category: category}
+}
+
+func shouldCreateMaintenanceCandidate(intent maintenanceIntent, mediaCount int) bool {
+	return !intent.IsMaintenance && (mediaCount > 0 || intent.Category != "other")
+}
+
+func inferMaintenanceCategory(text string) string {
+	switch {
+	case containsAny(text, "leak", "water", "tap", "toilet", "drain", "blocked", "burst", "geyser"):
+		return "plumbing"
+	case containsAny(text, "power", "light", "plug", "electric", "gate", "intercom"):
+		return "electrical"
+	case containsAny(text, "roof", "wall", "crack", "ceiling", "door", "window"):
+		return "structural"
+	case containsAny(text, "garden", "tree", "grass", "irrigation"):
+		return "garden"
+	case containsAny(text, "pool", "pump", "chlorine"):
+		return "pool"
+	default:
+		return "other"
+	}
+}
+
+func containsAny(text string, terms ...string) bool {
+	for _, term := range terms {
+		if strings.Contains(text, term) {
+			return true
+		}
+	}
+	return false
+}
+
+func buildMaintenanceIntakeText(body string, mediaCount int) intakeText {
+	clean := strings.TrimSpace(body)
+	if clean == "" && mediaCount > 0 {
+		clean = "Maintenance photo received via WhatsApp"
+	}
+	titleSource := clean
+	if idx := strings.Index(titleSource, "."); idx > 0 {
+		titleSource = titleSource[:idx]
+	}
+	if len(titleSource) > 80 {
+		titleSource = titleSource[:80]
+	}
+	result := intakeText{
+		Title:       "WhatsApp: " + strings.TrimSpace(titleSource),
+		Description: clean,
+	}
+	if mediaCount > 0 {
+		result.Description = strings.TrimSpace(result.Description + "\n\nMedia attached: " + strconv.Itoa(mediaCount) + " item(s)")
+	}
+	return result
 }
 
 type whatsAppAuditInput struct {

--- a/backend/internal/whatsapp/service_test.go
+++ b/backend/internal/whatsapp/service_test.go
@@ -1,6 +1,7 @@
 package whatsapp
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -60,6 +61,40 @@ func TestWhatsAppBroadcastSentAuditEvent(t *testing.T) {
 	}
 	if metadata["send_errors"] != 2 {
 		t.Fatalf("metadata.send_errors = %v, want 2", metadata["send_errors"])
+	}
+}
+
+func TestClassifyMaintenanceIntent(t *testing.T) {
+	tests := []struct {
+		body       string
+		mediaCount int
+		wantIntent bool
+		wantCategory string
+	}{
+		{body: "2 leaking tap in bathroom", wantIntent: true, wantCategory: "plumbing"},
+		{body: "No power at my unit", wantIntent: true, wantCategory: "electrical"},
+		{body: "Crack in the wall", wantIntent: true, wantCategory: "structural"},
+		{body: "Pool pump is broken", wantIntent: true, wantCategory: "pool"},
+		{body: "hello", wantIntent: false, wantCategory: "other"},
+		{body: "photo of broken gate", mediaCount: 1, wantIntent: true, wantCategory: "electrical"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.body, func(t *testing.T) {
+			got := classifyMaintenanceIntent(tt.body, tt.mediaCount)
+			if got.IsMaintenance != tt.wantIntent || got.Category != tt.wantCategory {
+				t.Fatalf("classification = %+v", got)
+			}
+		})
+	}
+}
+
+func TestBuildMaintenanceIntakeText(t *testing.T) {
+	result := buildMaintenanceIntakeText("Leaking pipe in bathroom. Please help", 2)
+	if result.Title != "WhatsApp: Leaking pipe in bathroom" {
+		t.Fatalf("title = %q", result.Title)
+	}
+	if !strings.Contains(result.Description, "Media attached: 2 item(s)") {
+		t.Fatalf("description missing media summary: %q", result.Description)
 	}
 }
 

--- a/backend/internal/whatsapp/webhook.go
+++ b/backend/internal/whatsapp/webhook.go
@@ -105,14 +105,15 @@ func (h *WebhookHandler) Inbound(w http.ResponseWriter, r *http.Request) {
 	body := r.FormValue("Body")
 	profileName := r.FormValue("ProfileName")
 
-	if from == "" || body == "" {
+	media := parseInboundMedia(r.Form)
+
+	if from == "" || (body == "" && len(media) == 0) {
 		w.WriteHeader(http.StatusOK)
 		return
 	}
 
 	phoneNumber := strings.TrimPrefix(from, "whatsapp:")
 
-	media := parseInboundMedia(r.Form)
 	go h.processMessage(phoneNumber, body, profileName, media)
 
 	w.WriteHeader(http.StatusOK)

--- a/backend/internal/whatsapp/webhook.go
+++ b/backend/internal/whatsapp/webhook.go
@@ -2,8 +2,11 @@ package whatsapp
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"net/http"
+	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -19,19 +22,25 @@ type WebhookHandler struct {
 	db            *database.Pool
 	sender        MessageSender
 	bot           *Bot
+	service       *Service
 	logger        *slog.Logger
 	authToken     string
 	skipSigVerify bool
 }
 
-func NewWebhookHandler(db *database.Pool, sender MessageSender, bot *Bot, logger *slog.Logger, authToken string) *WebhookHandler {
+func NewWebhookHandler(db *database.Pool, sender MessageSender, bot *Bot, service *Service, logger *slog.Logger, authToken string) *WebhookHandler {
 	return &WebhookHandler{
 		db:        db,
 		sender:    sender,
 		bot:       bot,
+		service:   service,
 		logger:    logger,
 		authToken: authToken,
 	}
+}
+
+func (h *WebhookHandler) SetSkipSigVerify(v bool) {
+	h.skipSigVerify = v
 }
 
 func (h *WebhookHandler) Routes() *chi.Mux {
@@ -103,12 +112,13 @@ func (h *WebhookHandler) Inbound(w http.ResponseWriter, r *http.Request) {
 
 	phoneNumber := strings.TrimPrefix(from, "whatsapp:")
 
-	go h.processMessage(phoneNumber, body, profileName)
+	media := parseInboundMedia(r.Form)
+	go h.processMessage(phoneNumber, body, profileName, media)
 
 	w.WriteHeader(http.StatusOK)
 }
 
-func (h *WebhookHandler) processMessage(phoneNumber, body, profileName string) {
+func (h *WebhookHandler) processMessage(phoneNumber, body, profileName string, media []inboundMedia) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
@@ -124,25 +134,81 @@ func (h *WebhookHandler) processMessage(phoneNumber, body, profileName string) {
 		return
 	}
 
-	if _, saveErr := h.db.Q.CreateWhatsAppMessage(ctx, dbgen.CreateWhatsAppMessageParams{
+	incoming, saveErr := h.db.Q.CreateWhatsAppMessage(ctx, dbgen.CreateWhatsAppMessageParams{
 		ThreadID:             thread.ID,
 		Sender:               dbgen.WhatsappMessageSenderResident,
 		Body:                 body,
 		MaintenanceRequestID: pgtype.UUID{},
 		NoticeID:             pgtype.UUID{},
-	}); saveErr != nil {
+	})
+	if saveErr != nil {
 		h.logger.Error("failed to save incoming message", "error", saveErr)
 		return
+	}
+
+	for _, item := range media {
+		if _, err := h.db.Q.CreateWhatsAppMessageMedia(ctx, dbgen.CreateWhatsAppMessageMediaParams{
+			MessageID:        incoming.ID,
+			Provider:         "twilio",
+			ProviderMediaSid: item.ProviderMediaSID,
+			MediaUrl:         item.URL,
+			ContentType:      item.ContentType,
+		}); err != nil {
+			h.logger.Error("failed to save whatsapp media", "error", err)
+		}
 	}
 
 	if incrErr := h.db.Q.IncrementWhatsAppThreadUnread(ctx, thread.ID); incrErr != nil {
 		h.logger.Error("failed to increment unread count", "error", incrErr)
 	}
 
-	reply, botErr := h.bot.Respond(ctx, thread.SchemeID, thread.UnitID, body)
-	if botErr != nil {
-		h.logger.Error("failed to generate bot response", "error", botErr)
-		return
+	var reply string
+
+	classification := classifyMaintenanceIntent(body, len(media))
+	if classification.IsMaintenance {
+		text := buildMaintenanceIntakeText(body, len(media))
+		intake, err := h.service.createMaintenanceTicketForMessage(
+			ctx,
+			thread.SchemeID,
+			thread.ID,
+			incoming.ID,
+			thread.UnitID,
+			text.Title,
+			text.Description,
+			classification.Category,
+			len(media),
+		)
+		if err != nil {
+			h.logger.Error("failed to create whatsapp maintenance ticket", "message_id", incoming.ID, "error", err)
+			reply = "I received your maintenance message, but could not create the ticket automatically. Please try again or contact your managing agent."
+		} else if intake.MaintenanceRequestID != nil {
+			reply = fmt.Sprintf("Thanks. I've logged a maintenance request from your WhatsApp message.\n\nRef: %s\nStatus: Pending approval", (*intake.MaintenanceRequestID)[:8])
+		}
+	} else if shouldCreateMaintenanceCandidate(classification, len(media)) {
+		text := buildMaintenanceIntakeText(body, len(media))
+		if _, err := h.db.Q.CreateWhatsAppMaintenanceIntake(ctx, dbgen.CreateWhatsAppMaintenanceIntakeParams{
+			SchemeID:             thread.SchemeID,
+			ThreadID:             thread.ID,
+			MessageID:            incoming.ID,
+			UnitID:               thread.UnitID,
+			MaintenanceRequestID: pgtype.UUID{},
+			Status:               "candidate",
+			Category:             dbgen.MaintenanceCategory(classification.Category),
+			Title:                text.Title,
+			Description:          text.Description,
+			MediaCount:           int32(len(media)),
+		}); err != nil {
+			h.logger.Error("failed to create whatsapp maintenance candidate", "message_id", incoming.ID, "error", err)
+		}
+	}
+
+	if reply == "" {
+		var botErr error
+		reply, botErr = h.bot.Respond(ctx, thread.SchemeID, thread.UnitID, body)
+		if botErr != nil {
+			h.logger.Error("failed to generate bot response", "error", botErr)
+			return
+		}
 	}
 
 	if _, replyErr := h.db.Q.CreateWhatsAppMessage(ctx, dbgen.CreateWhatsAppMessageParams{
@@ -172,4 +238,30 @@ func findBestThread(threads []dbgen.WhatsappThread) *dbgen.WhatsappThread {
 		}
 	}
 	return best
+}
+
+type inboundMedia struct {
+	ProviderMediaSID pgtype.Text
+	ContentType      pgtype.Text
+	URL              string
+}
+
+func parseInboundMedia(form url.Values) []inboundMedia {
+	count, _ := strconv.Atoi(form.Get("NumMedia"))
+	media := make([]inboundMedia, 0, count)
+	for i := 0; i < count; i++ {
+		urlValue := strings.TrimSpace(form.Get(fmt.Sprintf("MediaUrl%d", i)))
+		if urlValue == "" {
+			continue
+		}
+		item := inboundMedia{URL: urlValue}
+		if sid := strings.TrimSpace(form.Get(fmt.Sprintf("MediaSid%d", i))); sid != "" {
+			item.ProviderMediaSID = pgtype.Text{String: sid, Valid: true}
+		}
+		if contentType := strings.TrimSpace(form.Get(fmt.Sprintf("MediaContentType%d", i))); contentType != "" {
+			item.ContentType = pgtype.Text{String: contentType, Valid: true}
+		}
+		media = append(media, item)
+	}
+	return media
 }

--- a/backend/internal/whatsapp/webhook_test.go
+++ b/backend/internal/whatsapp/webhook_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestInboundRejectsMissingTwilioSignature(t *testing.T) {
-	handler := NewWebhookHandler(nil, nil, nil, slog.Default(), "twilio-token")
+	handler := NewWebhookHandler(nil, nil, nil, nil, slog.Default(), "twilio-token")
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/whatsapp/webhooks", strings.NewReader("From=whatsapp%3A%2B27123456789&Body=hello"))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -24,7 +24,7 @@ func TestInboundRejectsMissingTwilioSignature(t *testing.T) {
 }
 
 func TestInboundRejectsInvalidTwilioSignature(t *testing.T) {
-	handler := NewWebhookHandler(nil, nil, nil, slog.Default(), "twilio-token")
+	handler := NewWebhookHandler(nil, nil, nil, nil, slog.Default(), "twilio-token")
 
 	form := url.Values{}
 	form.Set("From", "whatsapp:+27123456789")

--- a/backend/tests/integration/whatsapp_test.go
+++ b/backend/tests/integration/whatsapp_test.go
@@ -8,6 +8,8 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"strings"
 	"testing"
 	"time"
 
@@ -152,6 +154,122 @@ func TestWhatsAppDashboardAndBroadcast(t *testing.T) {
 	h.CreateBroadcast(w, req)
 	if w.Code != http.StatusForbidden {
 		t.Fatalf("resident create broadcast should be forbidden: status=%d body=%s", w.Code, w.Body)
+	}
+}
+
+func newWhatsAppWebhookHandler(t *testing.T) *whatsapp.WebhookHandler {
+	t.Helper()
+	svc := whatsapp.NewService(testPool, whatsapp.NewNoOpSender(), slog.Default())
+	bot := whatsapp.NewBot(testPool)
+	h := whatsapp.NewWebhookHandler(testPool, whatsapp.NewNoOpSender(), bot, svc, slog.Default(), "twilio-token")
+	h.SetSkipSigVerify(true)
+	return h
+}
+
+func TestWhatsAppWebhookCreatesMaintenanceTicketWithMedia(t *testing.T) {
+	h := newWhatsAppWebhookHandler(t)
+	accessToken, orgID := setupAgent(t)
+	schemeID := setupScheme(t, accessToken)
+
+	unitID := createUnitRecord(t, schemeID, "5A")
+	residentEmail := uniqueEmail(t)
+	residentUserID := createMemberRecord(t, orgID, schemeID, residentEmail, "Resident User", string(auth.RoleResident), &unitID)
+
+	schemeUUID := mustParseUUID(schemeID)
+	residentUnitUUID := mustParseUUID(unitID)
+	residentUserUUID := mustParseUUID(residentUserID)
+	now := time.Now().UTC()
+
+	if _, err := testQ.CreateWhatsAppThread(t.Context(), dbgen.CreateWhatsAppThreadParams{
+		SchemeID:       schemeUUID,
+		UnitID:         residentUnitUUID,
+		ResidentUserID: pgtype.UUID{Bytes: residentUserUUID, Valid: true},
+		PhoneNumber:    pgtype.Text{String: "+27715550404", Valid: true},
+		Connected:      true,
+		ConsentedAt:    pgtype.Timestamptz{Time: now.Add(-24 * time.Hour), Valid: true},
+		UnreadCount:    0,
+		LastActiveAt:   now,
+	}); err != nil {
+		t.Fatalf("create connected thread: %v", err)
+	}
+
+	threads, err := testQ.GetConnectedWhatsAppThreadByPhone(t.Context(), pgtype.Text{String: "+27715550404", Valid: true})
+	if err != nil || len(threads) == 0 {
+		t.Fatalf("find thread by phone: err=%v count=%d", err, len(threads))
+	}
+	threadID := threads[0].ID
+
+	form := url.Values{}
+	form.Set("From", "whatsapp:+27715550404")
+	form.Set("Body", "leaking tap in bathroom")
+	form.Set("NumMedia", "1")
+	form.Set("MediaUrl0", "https://api.twilio.com/media/ME123")
+	form.Set("MediaContentType0", "image/jpeg")
+	form.Set("MediaSid0", "ME123")
+
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/whatsapp/webhooks", strings.NewReader(form.Encode()))
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	h.Inbound(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("webhook: status=%d body=%s", w.Code, w.Body)
+	}
+
+	time.Sleep(200 * time.Millisecond)
+
+	requests, err := testQ.ListMaintenanceRequestsByScheme(t.Context(), schemeUUID)
+	if err != nil {
+		t.Fatalf("list maintenance requests: %v", err)
+	}
+	var pending *dbgen.MaintenanceRequest
+	for i := range requests {
+		if requests[i].Status == dbgen.MaintenanceStatusPendingApproval {
+			pending = &requests[i]
+			break
+		}
+	}
+	if pending == nil {
+		t.Fatalf("expected pending maintenance request, got %d total requests", len(requests))
+	}
+
+	messages, err := testQ.ListWhatsAppMessagesByThread(t.Context(), threadID)
+	if err != nil {
+		t.Fatalf("list messages: %v", err)
+	}
+	var linkedMsg *dbgen.WhatsappMessage
+	for i := range messages {
+		msg := &messages[i]
+		if msg.MaintenanceRequestID.Valid {
+			linkedMsg = msg
+			break
+		}
+	}
+	if linkedMsg == nil {
+		t.Fatalf("expected message with maintenance_request_id, got %d messages", len(messages))
+	}
+
+	mediaCount, err := testQ.CountWhatsAppMessageMediaByMessage(t.Context(), linkedMsg.ID)
+	if err != nil {
+		t.Fatalf("count media: %v", err)
+	}
+	if mediaCount != 1 {
+		t.Fatalf("expected 1 media row, got %d", mediaCount)
+	}
+
+	intakes, err := testQ.ListWhatsAppMaintenanceIntakesByScheme(t.Context(), schemeUUID)
+	if err != nil {
+		t.Fatalf("list intakes: %v", err)
+	}
+	var ticketIntake *dbgen.ListWhatsAppMaintenanceIntakesBySchemeRow
+	for i := range intakes {
+		if intakes[i].Status == "ticket_created" {
+			ticketIntake = &intakes[i]
+			break
+		}
+	}
+	if ticketIntake == nil {
+		t.Fatalf("expected intake with ticket_created status, got %d intakes", len(intakes))
 	}
 }
 

--- a/backend/tests/integration/whatsapp_test.go
+++ b/backend/tests/integration/whatsapp_test.go
@@ -154,3 +154,137 @@ func TestWhatsAppDashboardAndBroadcast(t *testing.T) {
 		t.Fatalf("resident create broadcast should be forbidden: status=%d body=%s", w.Code, w.Body)
 	}
 }
+
+func TestWhatsAppMaintenanceInboxManualCreateAndDismiss(t *testing.T) {
+	h := newWhatsAppHandler(t)
+	accessToken, orgID := setupAgent(t)
+	schemeID := setupScheme(t, accessToken)
+
+	unitResidentID := createUnitRecord(t, schemeID, "3C")
+	residentEmail := uniqueEmail(t)
+	residentUserID := createMemberRecord(t, orgID, schemeID, residentEmail, "Resident User", string(auth.RoleResident), &unitResidentID)
+	trusteeEmail := uniqueEmail(t)
+	trusteeUserID := createMemberRecord(t, orgID, schemeID, trusteeEmail, "Trustee User", string(auth.RoleTrustee), nil)
+
+	schemeUUID := mustParseUUID(schemeID)
+	residentUnitUUID := mustParseUUID(unitResidentID)
+	residentUserUUID := mustParseUUID(residentUserID)
+	now := time.Now().UTC()
+
+	thread, err := testQ.CreateWhatsAppThread(t.Context(), dbgen.CreateWhatsAppThreadParams{
+		SchemeID:       schemeUUID,
+		UnitID:         residentUnitUUID,
+		ResidentUserID: pgtype.UUID{Bytes: residentUserUUID, Valid: true},
+		PhoneNumber:    pgtype.Text{String: "+27715550405", Valid: true},
+		Connected:      true,
+		ConsentedAt:    pgtype.Timestamptz{Time: now.Add(-24 * time.Hour), Valid: true},
+		UnreadCount:    1,
+		LastActiveAt:   now,
+	})
+	if err != nil {
+		t.Fatalf("create resident whatsapp thread: %v", err)
+	}
+
+	msg, err := testQ.CreateWhatsAppMessage(t.Context(), dbgen.CreateWhatsAppMessageParams{
+		ThreadID:             thread.ID,
+		Sender:               dbgen.WhatsappMessageSenderResident,
+		Body:                 "my tap is leaking in the kitchen",
+		MaintenanceRequestID: pgtype.UUID{},
+		NoticeID:             pgtype.UUID{},
+	})
+	if err != nil {
+		t.Fatalf("create resident whatsapp message: %v", err)
+	}
+	msgID := msg.ID.String()
+
+	adminDashboardReq := httptest.NewRequest(http.MethodGet, "/whatsapp/"+schemeID, nil)
+	adminDashboardReq = withRouteParams(adminDashboardReq, map[string]string{"schemeId": schemeID})
+	adminDashboardReq = withAuthContext(adminDashboardReq, accessToken, testJWTSigningKey)
+	adminW := httptest.NewRecorder()
+	h.Dashboard(adminW, adminDashboardReq)
+	if adminW.Code != http.StatusOK {
+		t.Fatalf("admin dashboard: status=%d body=%s", adminW.Code, adminW.Body)
+	}
+
+	adminDashboard := decodeSuccess[whatsapp.DashboardResponse](t, adminW)
+	if len(adminDashboard.Threads) != 1 {
+		t.Fatalf("expected 1 thread in admin dashboard, got %d", len(adminDashboard.Threads))
+	}
+
+	createBody, _ := json.Marshal(map[string]string{
+		"title":       "Fix leaking tap",
+		"description": "Kitchen tap is leaking water continuously",
+		"category":    "plumbing",
+	})
+	createReq := httptest.NewRequest(http.MethodPost, "/whatsapp/"+schemeID+"/messages/"+msgID+"/maintenance-request", bytes.NewReader(createBody))
+	createReq = withRouteParams(createReq, map[string]string{"schemeId": schemeID, "messageId": msgID})
+	createReq = createReq.WithContext(auth.ContextWithIdentity(createReq.Context(), trusteeUserID, orgID, string(auth.RoleTrustee)))
+	createW := httptest.NewRecorder()
+	h.CreateMaintenanceFromMessage(createW, createReq)
+	if createW.Code != http.StatusCreated {
+		t.Fatalf("trustee create maintenance from message: status=%d body=%s", createW.Code, createW.Body)
+	}
+
+	created := decodeSuccess[whatsapp.MaintenanceIntakeInfo](t, createW)
+	if created.Status != "ticket_created" {
+		t.Fatalf("expected ticket_created status, got %q", created.Status)
+	}
+	if created.Category != "plumbing" {
+		t.Fatalf("expected plumbing category, got %q", created.Category)
+	}
+	if created.MaintenanceRequestID == nil {
+		t.Fatalf("expected maintenance_request_id to be set: %+v", created)
+	}
+
+	adminDashboardReq = httptest.NewRequest(http.MethodGet, "/whatsapp/"+schemeID, nil)
+	adminDashboardReq = withRouteParams(adminDashboardReq, map[string]string{"schemeId": schemeID})
+	adminDashboardReq = withAuthContext(adminDashboardReq, accessToken, testJWTSigningKey)
+	adminW = httptest.NewRecorder()
+	h.Dashboard(adminW, adminDashboardReq)
+	if adminW.Code != http.StatusOK {
+		t.Fatalf("admin dashboard after create: status=%d body=%s", adminW.Code, adminW.Body)
+	}
+
+	adminDashboard = decodeSuccess[whatsapp.DashboardResponse](t, adminW)
+	if len(adminDashboard.MaintenanceIntakes) != 1 {
+		t.Fatalf("expected 1 maintenance intake in dashboard, got %d", len(adminDashboard.MaintenanceIntakes))
+	}
+	if adminDashboard.MaintenanceIntakes[0].ID != created.ID {
+		t.Fatalf("dashboard intake id mismatch: %q vs %q", adminDashboard.MaintenanceIntakes[0].ID, created.ID)
+	}
+	if adminDashboard.Threads[0].Messages[0].MaintenanceRequestID == nil {
+		t.Fatalf("expected message to have maintenance_request_id set: %+v", adminDashboard.Threads[0].Messages[0])
+	}
+
+	dismissReq := httptest.NewRequest(http.MethodPatch, "/whatsapp/"+schemeID+"/maintenance-intakes/"+created.ID, nil)
+	dismissReq = withRouteParams(dismissReq, map[string]string{"schemeId": schemeID, "intakeId": created.ID})
+	dismissReq = dismissReq.WithContext(auth.ContextWithIdentity(dismissReq.Context(), trusteeUserID, orgID, string(auth.RoleTrustee)))
+	dismissW := httptest.NewRecorder()
+	h.DismissMaintenanceIntake(dismissW, dismissReq)
+	if dismissW.Code != http.StatusOK {
+		t.Fatalf("trustee dismiss maintenance intake: status=%d body=%s", dismissW.Code, dismissW.Body)
+	}
+
+	dismissed := decodeSuccess[whatsapp.MaintenanceIntakeInfo](t, dismissW)
+	if dismissed.Status != "dismissed" {
+		t.Fatalf("expected dismissed status, got %q", dismissed.Status)
+	}
+
+	createReq = httptest.NewRequest(http.MethodPost, "/whatsapp/"+schemeID+"/messages/"+msgID+"/maintenance-request", bytes.NewReader(createBody))
+	createReq = withRouteParams(createReq, map[string]string{"schemeId": schemeID, "messageId": msgID})
+	createReq = createReq.WithContext(auth.ContextWithIdentity(createReq.Context(), residentUserID, orgID, string(auth.RoleResident)))
+	createW = httptest.NewRecorder()
+	h.CreateMaintenanceFromMessage(createW, createReq)
+	if createW.Code != http.StatusForbidden {
+		t.Fatalf("resident create maintenance from message should be forbidden: status=%d body=%s", createW.Code, createW.Body)
+	}
+
+	dismissReq = httptest.NewRequest(http.MethodPatch, "/whatsapp/"+schemeID+"/maintenance-intakes/"+created.ID, nil)
+	dismissReq = withRouteParams(dismissReq, map[string]string{"schemeId": schemeID, "intakeId": created.ID})
+	dismissReq = dismissReq.WithContext(auth.ContextWithIdentity(dismissReq.Context(), residentUserID, orgID, string(auth.RoleResident)))
+	dismissW = httptest.NewRecorder()
+	h.DismissMaintenanceIntake(dismissW, dismissReq)
+	if dismissW.Code != http.StatusForbidden {
+		t.Fatalf("resident dismiss maintenance intake should be forbidden: status=%d body=%s", dismissW.Code, dismissW.Body)
+	}
+}

--- a/backend/tests/migrations/rls_migration_test.go
+++ b/backend/tests/migrations/rls_migration_test.go
@@ -28,3 +28,27 @@ func TestSupabaseRLSHardeningMigrationExists(t *testing.T) {
 		}
 	}
 }
+
+func TestWhatsAppMaintenanceInboxRLS(t *testing.T) {
+	path := "../../db/migrations/00027_whatsapp_maintenance_inbox.sql"
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read migration: %v", err)
+	}
+
+	sql := string(content)
+
+	required := []string{
+		"CREATE TABLE whatsapp_message_media",
+		"ALTER TABLE whatsapp_message_media ENABLE ROW LEVEL SECURITY",
+		"CREATE TABLE whatsapp_maintenance_intakes",
+		"ALTER TABLE whatsapp_maintenance_intakes ENABLE ROW LEVEL SECURITY",
+	}
+
+	for _, token := range required {
+		if !strings.Contains(sql, token) {
+			t.Fatalf("missing expected SQL token: %q", token)
+		}
+	}
+}

--- a/lib/whatsapp-api.ts
+++ b/lib/whatsapp-api.ts
@@ -6,6 +6,7 @@ import type {
   WhatsAppBroadcast,
   WhatsAppBroadcastType,
   WhatsAppDashboard,
+  WhatsAppMaintenanceIntake,
 } from "@/lib/whatsapp";
 
 async function parse<T>(response: Response, fallback: string): Promise<T> {
@@ -37,5 +38,36 @@ export async function createWhatsAppBroadcast(
       body: JSON.stringify(input),
     }),
     "Failed to send WhatsApp broadcast",
+  );
+}
+
+export async function createMaintenanceRequestFromWhatsAppMessage(
+  schemeId: string,
+  messageId: string,
+  input: {
+    title: string;
+    description: string;
+    category: WhatsAppMaintenanceIntake["category"];
+  },
+): Promise<WhatsAppMaintenanceIntake> {
+  return parse(
+    await apiFetch(`/api/v1/whatsapp/${schemeId}/messages/${messageId}/maintenance-request`, {
+      method: "POST",
+      body: JSON.stringify(input),
+    }),
+    "Failed to create maintenance request from WhatsApp message",
+  );
+}
+
+export async function dismissWhatsAppMaintenanceIntake(
+  schemeId: string,
+  intakeId: string,
+): Promise<WhatsAppMaintenanceIntake> {
+  return parse(
+    await apiFetch(`/api/v1/whatsapp/${schemeId}/maintenance-intakes/${intakeId}`, {
+      method: "PATCH",
+      body: JSON.stringify({ status: "dismissed" }),
+    }),
+    "Failed to dismiss WhatsApp maintenance intake",
   );
 }

--- a/lib/whatsapp.ts
+++ b/lib/whatsapp.ts
@@ -1,7 +1,32 @@
 export type WhatsAppSender = "resident" | "bot" | "operator";
 export type WhatsAppBroadcastType = "general" | "agm" | "levy" | "maintenance";
 
+export interface WhatsAppMedia {
+  id: string;
+  url: string;
+  content_type: string;
+}
+
+export interface WhatsAppMaintenanceIntake {
+  maintenance_request_id?: string | null;
+  created_at: string;
+  id: string;
+  scheme_id: string;
+  thread_id: string;
+  message_id: string;
+  unit_id: string;
+  unit_identifier: string;
+  owner_name: string;
+  status: "candidate" | "ticket_created" | "dismissed";
+  category: "plumbing" | "electrical" | "structural" | "garden" | "pool" | "other";
+  title: string;
+  description: string;
+  media_count: number;
+}
+
 export interface WhatsAppMessage {
+  maintenance_request_id?: string | null;
+  media: WhatsAppMedia[];
   id: string;
   from: WhatsAppSender;
   text: string;
@@ -34,6 +59,7 @@ export interface WhatsAppDashboard {
   resident_thread?: WhatsAppThread | null;
   threads: WhatsAppThread[];
   broadcasts: WhatsAppBroadcast[];
+  maintenance_intakes: WhatsAppMaintenanceIntake[];
   role: string;
   phone_number: string;
   total_residents: number;


### PR DESCRIPTION
## Summary

- Turns WhatsApp from a general resident chat channel into a **maintenance intake workflow**: residents can send a description and photo by WhatsApp, StrataHQ records the conversation, creates or queues a maintenance ticket, and operators can review the intake from a dedicated Maintenance tab in the WhatsApp dashboard.

## What changed

- **Persistence**: Added `whatsapp_message_media` and `whatsapp_maintenance_intakes` tables with RLS, indexes, and sqlc queries
- **Classification**: Deterministic intent detection (prefix matching + keyword/category inference) for inbound WhatsApp messages
- **Webhook**: Parses Twilio media metadata (`MediaUrl`, `MediaContentType`, `MediaSid`), stores media rows, auto-creates pending maintenance requests for clear maintenance messages, creates candidates for ambiguous messages
- **API**: `POST .../messages/{messageId}/maintenance-request` and `PATCH .../maintenance-intakes/{intakeId}` for operator actions
- **UI**: New `Maintenance` tab in operator WhatsApp page with intake cards (Create ticket / Dismiss actions), media badges and maintenance ticket links in chat bubbles

## Files

17 files changed, 1666 insertions, 32 deletions across backend (Go) and frontend (TypeScript/React)