### PR TITLE
feat: predictive levy analytics — 12-month reserve forecast and levy recommendation

### DIFF
--- a/app/app/[schemeId]/financials/page.test.tsx
+++ b/app/app/[schemeId]/financials/page.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockUseAuth = vi.hoisted(() => vi.fn());
+const mockUseAuthenticatedQuery = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/auth", () => ({ useAuth: mockUseAuth }));
+vi.mock("next/navigation", () => ({ useParams: vi.fn(() => ({ schemeId: "scheme-1" })) }));
+vi.mock("@/hooks/useAuthenticatedQuery", () => ({ useAuthenticatedQuery: mockUseAuthenticatedQuery }));
+vi.mock("@/lib/toast", () => ({ useToast: vi.fn(() => ({ addToast: vi.fn() })) }));
+
+const dashboard = {
+  reserve_fund: { scheme_id: "scheme-1", balance_cents: 1000000, target_cents: 2500000, last_updated: new Date().toISOString() },
+  levy_summary: { period_label: "March 2026", total_billed_cents: 2500000, total_collected_cents: 2000000, collection_rate_pct: 80, overdue_count: 2 },
+  budget_lines: [],
+  available_periods: ["2026"],
+  role: "admin",
+  selected_period: "2026",
+  total_budgeted_cents: 0,
+  total_actual_cents: 0,
+  surplus_cents: 0,
+  levy_forecast: {
+    status: "shortfall_risk",
+    confidence: "medium",
+    months_projected: 12,
+    current_monthly_levy_cents: 250000,
+    average_collection_rate_pct: 81,
+    average_monthly_income_cents: 2033333,
+    average_monthly_expense_cents: 2266667,
+    projected_reserve_balance_cents: -1800000,
+    projected_shortfall_cents: 4300000,
+    recommended_monthly_increase_cents: 36000,
+    recommended_increase_pct: 14,
+    data_points: [{ period_label: "March 2026", billed_cents: 2500000, collected_cents: 2000000, collection_rate_pct: 80, expense_cents: 2300000 }],
+    notes: ["Projection uses 3 historical levy periods."],
+  },
+};
+
+describe("FinancialsPage predictive levy analytics", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseAuthenticatedQuery.mockReturnValue({ data: dashboard, isLoading: false });
+  });
+
+  it("shows predictive levy outlook to admins", async () => {
+    mockUseAuth.mockReturnValue({ user: { role: "admin" } });
+    const { default: FinancialsPage } = await import("@/app/app/[schemeId]/financials/page");
+
+    render(<FinancialsPage />);
+
+    expect(screen.getByText("Predictive levy outlook")).toBeInTheDocument();
+    expect(screen.getByText("Shortfall risk")).toBeInTheDocument();
+    expect(screen.getByText(/recommended levy increase/i)).toBeInTheDocument();
+  });
+
+  it("does not show predictive levy outlook to residents", async () => {
+    mockUseAuth.mockReturnValue({ user: { role: "resident" } });
+    const { default: FinancialsPage } = await import("@/app/app/[schemeId]/financials/page");
+
+    render(<FinancialsPage />);
+
+    expect(screen.queryByText("Predictive levy outlook")).not.toBeInTheDocument();
+  });
+});

--- a/app/app/[schemeId]/financials/page.tsx
+++ b/app/app/[schemeId]/financials/page.tsx
@@ -18,6 +18,31 @@ function formatRand(cents: number): string {
   return `R ${(cents / 100).toLocaleString('en-ZA', { minimumFractionDigits: 0 })}`
 }
 
+function forecastStatusLabel(status: string): string {
+  switch (status) {
+    case 'shortfall_risk':
+      return 'Shortfall risk'
+    case 'insufficient_data':
+      return 'Insufficient data'
+    case 'watch':
+      return 'Watch'
+    default:
+      return 'Healthy'
+  }
+}
+
+function forecastStatusClass(status: string): string {
+  switch (status) {
+    case 'shortfall_risk':
+      return 'bg-red-bg text-red'
+    case 'watch':
+    case 'insufficient_data':
+      return 'bg-yellowbg text-amber'
+    default:
+      return 'bg-green-bg text-green'
+  }
+}
+
 export default function FinancialsPage() {
   const { user } = useAuth()
   const { addToast } = useToast()
@@ -273,6 +298,82 @@ export default function FinancialsPage() {
           </div>
         ))}
       </div>
+
+      {dashboard?.levy_forecast && (
+        <div className="bg-surface border border-border rounded-lg px-6 py-5 mb-6">
+          <div className="flex flex-wrap items-start justify-between gap-3 mb-4">
+            <div>
+              <div className="flex items-center gap-2 mb-1">
+                <span className="text-[13px] font-semibold text-ink">Predictive levy outlook</span>
+                <span className={`rounded-full px-2 py-[2px] text-[10px] font-semibold ${forecastStatusClass(dashboard.levy_forecast.status)}`}>
+                  {forecastStatusLabel(dashboard.levy_forecast.status)}
+                </span>
+              </div>
+              <p className="text-[12px] text-muted">
+                {dashboard.levy_forecast.months_projected}-month projection using {dashboard.levy_forecast.data_points.length} historical period{dashboard.levy_forecast.data_points.length === 1 ? '' : 's'}.
+              </p>
+            </div>
+            <span className="rounded-full bg-page px-2 py-[2px] text-[10px] font-semibold text-muted">
+              {dashboard.levy_forecast.confidence} confidence
+            </span>
+          </div>
+
+          <p className="text-[13px] text-ink leading-relaxed mb-4">
+            At the current collection rate of <strong>{dashboard.levy_forecast.average_collection_rate_pct}%</strong>,
+            the reserve fund is projected to be <strong>{formatRand(Math.max(dashboard.levy_forecast.projected_reserve_balance_cents, 0))}</strong> in {dashboard.levy_forecast.months_projected} months.
+            {dashboard.levy_forecast.projected_shortfall_cents > 0 ? (
+              <> This is <strong className="text-red">{formatRand(dashboard.levy_forecast.projected_shortfall_cents)}</strong> below target.</>
+            ) : (
+              <> This remains on or above the current reserve target.</>
+            )}
+          </p>
+
+          {dashboard.levy_forecast.recommended_monthly_increase_cents > 0 && (
+            <div className="bg-page/60 border border-border rounded-lg px-4 py-3 mb-4">
+              <div className="text-[11px] font-semibold text-muted uppercase tracking-wide mb-1">Recommended levy increase</div>
+              <div className="text-[18px] font-semibold text-ink font-serif">
+                {formatRand(dashboard.levy_forecast.recommended_monthly_increase_cents)} per unit/month
+                <span className="ml-2 text-[12px] font-sans text-muted">({dashboard.levy_forecast.recommended_increase_pct}%)</span>
+              </div>
+            </div>
+          )}
+
+          <div className="mb-4">
+            <div className="mb-2 flex items-center justify-between text-[11px] text-muted">
+              <span>Projected reserve</span>
+              <span>Target: {formatRand(reserveFund?.target_cents ?? 0)}</span>
+            </div>
+            <div className="h-3 overflow-hidden rounded-full bg-border">
+              <div
+                className={dashboard.levy_forecast.projected_shortfall_cents > 0 ? 'h-full rounded-full bg-red' : 'h-full rounded-full bg-green'}
+                style={{
+                  width: `${Math.min(
+                    100,
+                    reserveFund && reserveFund.target_cents > 0
+                      ? Math.max(0, Math.round((dashboard.levy_forecast.projected_reserve_balance_cents / reserveFund.target_cents) * 100))
+                      : 0,
+                  )}%`,
+                }}
+              />
+            </div>
+          </div>
+
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 text-[13px]">
+            <div className="bg-page/50 border border-border rounded-lg px-4 py-3">
+              <div className="text-muted text-[11px] mb-1">Avg monthly income</div>
+              <div className="font-semibold text-ink">{formatRand(dashboard.levy_forecast.average_monthly_income_cents)}</div>
+            </div>
+            <div className="bg-page/50 border border-border rounded-lg px-4 py-3">
+              <div className="text-muted text-[11px] mb-1">Avg monthly expense</div>
+              <div className="font-semibold text-ink">{formatRand(dashboard.levy_forecast.average_monthly_expense_cents)}</div>
+            </div>
+            <div className="bg-page/50 border border-border rounded-lg px-4 py-3">
+              <div className="text-muted text-[11px] mb-1">Current levy</div>
+              <div className="font-semibold text-ink">{formatRand(dashboard.levy_forecast.current_monthly_levy_cents)}</div>
+            </div>
+          </div>
+        </div>
+      )}
 
       {/* Reserve fund bar */}
       <div className="bg-surface border border-border rounded-lg px-6 py-5 mb-6">

--- a/backend/internal/financials/forecast_test.go
+++ b/backend/internal/financials/forecast_test.go
@@ -1,0 +1,116 @@
+package financials
+
+import "testing"
+
+func TestBuildLevyForecastShortfallRisk(t *testing.T) {
+	forecast := buildLevyForecast(levyForecastInput{
+		MonthsProjected: 12,
+		CurrentReserveBalanceCents: 10_000_00,
+		ReserveTargetCents:         25_000_00,
+		CurrentMonthlyLevyCents:    2_500_00,
+		LatestUnitCount:            10,
+		Points: []levyForecastPointInput{
+			{PeriodLabel: "January 2026", BilledCents: 25_000_00, CollectedCents: 20_000_00, ExpenseCents: 22_000_00, HasExpense: true},
+			{PeriodLabel: "February 2026", BilledCents: 25_000_00, CollectedCents: 21_000_00, ExpenseCents: 23_000_00, HasExpense: true},
+			{PeriodLabel: "March 2026", BilledCents: 25_000_00, CollectedCents: 20_000_00, ExpenseCents: 23_000_00, HasExpense: true},
+		},
+	})
+
+	if forecast == nil {
+		t.Fatal("expected forecast")
+	}
+	if forecast.Status != "shortfall_risk" {
+		t.Fatalf("status = %q", forecast.Status)
+	}
+	if forecast.Confidence != "medium" {
+		t.Fatalf("confidence = %q", forecast.Confidence)
+	}
+	if forecast.AverageCollectionRatePct != 81 {
+		t.Fatalf("average collection pct = %d", forecast.AverageCollectionRatePct)
+	}
+	if forecast.ProjectedShortfallCents <= 0 {
+		t.Fatalf("expected shortfall, got %d", forecast.ProjectedShortfallCents)
+	}
+	if forecast.RecommendedMonthlyIncreaseCents == 0 {
+		t.Fatalf("expected recommended increase: %+v", forecast)
+	}
+}
+
+func TestBuildLevyForecastHealthy(t *testing.T) {
+	forecast := buildLevyForecast(levyForecastInput{
+		MonthsProjected: 12,
+		CurrentReserveBalanceCents: 30_000_00,
+		ReserveTargetCents:         25_000_00,
+		CurrentMonthlyLevyCents:    2_500_00,
+		LatestUnitCount:            10,
+		Points: []levyForecastPointInput{
+			{PeriodLabel: "January 2026", BilledCents: 25_000_00, CollectedCents: 25_000_00, ExpenseCents: 20_000_00, HasExpense: true},
+			{PeriodLabel: "February 2026", BilledCents: 25_000_00, CollectedCents: 25_000_00, ExpenseCents: 20_000_00, HasExpense: true},
+			{PeriodLabel: "March 2026", BilledCents: 25_000_00, CollectedCents: 25_000_00, ExpenseCents: 20_000_00, HasExpense: true},
+		},
+	})
+
+	if forecast == nil {
+		t.Fatal("expected forecast")
+	}
+	if forecast.Status != "healthy" {
+		t.Fatalf("status = %q", forecast.Status)
+	}
+	if forecast.ProjectedShortfallCents != 0 {
+		t.Fatalf("shortfall = %d", forecast.ProjectedShortfallCents)
+	}
+	if forecast.RecommendedMonthlyIncreaseCents != 0 {
+		t.Fatalf("recommended increase = %d", forecast.RecommendedMonthlyIncreaseCents)
+	}
+}
+
+func TestBuildLevyForecastWatch(t *testing.T) {
+	forecast := buildLevyForecast(levyForecastInput{
+		MonthsProjected: 12,
+		CurrentReserveBalanceCents: 40_000_00,
+		ReserveTargetCents:         25_000_00,
+		CurrentMonthlyLevyCents:    2_500_00,
+		LatestUnitCount:            10,
+		Points: []levyForecastPointInput{
+			{PeriodLabel: "January 2026", BilledCents: 25_000_00, CollectedCents: 22_000_00, ExpenseCents: 23_000_00, HasExpense: true},
+			{PeriodLabel: "February 2026", BilledCents: 25_000_00, CollectedCents: 22_000_00, ExpenseCents: 23_000_00, HasExpense: true},
+			{PeriodLabel: "March 2026", BilledCents: 25_000_00, CollectedCents: 22_000_00, ExpenseCents: 23_000_00, HasExpense: true},
+		},
+	})
+
+	if forecast == nil {
+		t.Fatal("expected forecast")
+	}
+	if forecast.Status != "watch" {
+		t.Fatalf("status = %q", forecast.Status)
+	}
+	if forecast.ProjectedShortfallCents != 0 {
+		t.Fatalf("shortfall = %d", forecast.ProjectedShortfallCents)
+	}
+}
+
+func TestBuildLevyForecastInsufficientData(t *testing.T) {
+	forecast := buildLevyForecast(levyForecastInput{
+		MonthsProjected: 12,
+		CurrentReserveBalanceCents: 0,
+		ReserveTargetCents:         10_000_00,
+		CurrentMonthlyLevyCents:    2_000_00,
+		LatestUnitCount:            5,
+		Points: []levyForecastPointInput{
+			{PeriodLabel: "March 2026", BilledCents: 10_000_00, CollectedCents: 8_000_00},
+		},
+	})
+
+	if forecast == nil {
+		t.Fatal("expected forecast")
+	}
+	if forecast.Status != "insufficient_data" {
+		t.Fatalf("status = %q", forecast.Status)
+	}
+	if forecast.Confidence != "low" {
+		t.Fatalf("confidence = %q", forecast.Confidence)
+	}
+	if len(forecast.Notes) == 0 {
+		t.Fatalf("expected explanatory notes")
+	}
+}

--- a/backend/internal/financials/forecast_test.go
+++ b/backend/internal/financials/forecast_test.go
@@ -4,7 +4,7 @@ import "testing"
 
 func TestBuildLevyForecastShortfallRisk(t *testing.T) {
 	forecast := buildLevyForecast(levyForecastInput{
-		MonthsProjected: 12,
+		MonthsProjected:            12,
 		CurrentReserveBalanceCents: 10_000_00,
 		ReserveTargetCents:         25_000_00,
 		CurrentMonthlyLevyCents:    2_500_00,
@@ -38,7 +38,7 @@ func TestBuildLevyForecastShortfallRisk(t *testing.T) {
 
 func TestBuildLevyForecastHealthy(t *testing.T) {
 	forecast := buildLevyForecast(levyForecastInput{
-		MonthsProjected: 12,
+		MonthsProjected:            12,
 		CurrentReserveBalanceCents: 30_000_00,
 		ReserveTargetCents:         25_000_00,
 		CurrentMonthlyLevyCents:    2_500_00,
@@ -66,7 +66,7 @@ func TestBuildLevyForecastHealthy(t *testing.T) {
 
 func TestBuildLevyForecastWatch(t *testing.T) {
 	forecast := buildLevyForecast(levyForecastInput{
-		MonthsProjected: 12,
+		MonthsProjected:            12,
 		CurrentReserveBalanceCents: 40_000_00,
 		ReserveTargetCents:         25_000_00,
 		CurrentMonthlyLevyCents:    2_500_00,
@@ -91,7 +91,7 @@ func TestBuildLevyForecastWatch(t *testing.T) {
 
 func TestBuildLevyForecastInsufficientData(t *testing.T) {
 	forecast := buildLevyForecast(levyForecastInput{
-		MonthsProjected: 12,
+		MonthsProjected:            12,
 		CurrentReserveBalanceCents: 0,
 		ReserveTargetCents:         10_000_00,
 		CurrentMonthlyLevyCents:    2_000_00,

--- a/backend/internal/financials/service.go
+++ b/backend/internal/financials/service.go
@@ -52,16 +52,43 @@ type LevySummaryInfo struct {
 }
 
 //nolint:govet // Keep response DTO fields grouped by API meaning rather than field packing.
+type LevyForecastPointInfo struct {
+	PeriodLabel       string `json:"period_label"`
+	BilledCents       int64  `json:"billed_cents"`
+	CollectedCents    int64  `json:"collected_cents"`
+	CollectionRatePct int    `json:"collection_rate_pct"`
+	ExpenseCents      int64  `json:"expense_cents"`
+}
+
+//nolint:govet // Keep response DTO fields grouped by API meaning rather than field packing.
+type LevyForecastInfo struct {
+	DataPoints                    []LevyForecastPointInfo `json:"data_points"`
+	Notes                         []string                `json:"notes"`
+	Status                        string                  `json:"status"`
+	Confidence                    string                  `json:"confidence"`
+	MonthsProjected               int                     `json:"months_projected"`
+	CurrentMonthlyLevyCents       int64                   `json:"current_monthly_levy_cents"`
+	AverageCollectionRatePct      int                     `json:"average_collection_rate_pct"`
+	AverageMonthlyIncomeCents     int64                   `json:"average_monthly_income_cents"`
+	AverageMonthlyExpenseCents    int64                   `json:"average_monthly_expense_cents"`
+	ProjectedReserveBalanceCents  int64                   `json:"projected_reserve_balance_cents"`
+	ProjectedShortfallCents       int64                   `json:"projected_shortfall_cents"`
+	RecommendedMonthlyIncreaseCents int64                 `json:"recommended_monthly_increase_cents"`
+	RecommendedIncreasePct        int                     `json:"recommended_increase_pct"`
+}
+
+//nolint:govet // Keep response DTO fields grouped by API meaning rather than field packing.
 type DashboardResponse struct {
-	ReserveFund        *ReserveFundInfo `json:"reserve_fund"`
-	LevySummary        *LevySummaryInfo `json:"levy_summary"`
-	BudgetLines        []BudgetLineInfo `json:"budget_lines"`
-	AvailablePeriods   []string         `json:"available_periods"`
-	Role               string           `json:"role"`
-	SelectedPeriod     string           `json:"selected_period"`
-	TotalBudgetedCents int64            `json:"total_budgeted_cents"`
-	TotalActualCents   int64            `json:"total_actual_cents"`
-	SurplusCents       int64            `json:"surplus_cents"`
+	LevyForecast        *LevyForecastInfo `json:"levy_forecast"`
+	ReserveFund        *ReserveFundInfo  `json:"reserve_fund"`
+	LevySummary        *LevySummaryInfo  `json:"levy_summary"`
+	BudgetLines        []BudgetLineInfo  `json:"budget_lines"`
+	AvailablePeriods   []string          `json:"available_periods"`
+	Role               string            `json:"role"`
+	SelectedPeriod     string            `json:"selected_period"`
+	TotalBudgetedCents int64             `json:"total_budgeted_cents"`
+	TotalActualCents   int64             `json:"total_actual_cents"`
+	SurplusCents       int64             `json:"surplus_cents"`
 }
 
 //nolint:govet // Keep input DTO fields grouped by domain meaning rather than field packing.
@@ -75,6 +102,23 @@ type UpsertBudgetLineInput struct {
 type UpdateReserveFundInput struct {
 	BalanceCents int64
 	TargetCents  int64
+}
+
+type levyForecastPointInput struct {
+	PeriodLabel    string
+	BilledCents    int64
+	CollectedCents int64
+	ExpenseCents   int64
+	HasExpense     bool
+}
+
+type levyForecastInput struct {
+	Points                     []levyForecastPointInput
+	MonthsProjected            int
+	CurrentReserveBalanceCents int64
+	ReserveTargetCents         int64
+	CurrentMonthlyLevyCents    int64
+	LatestUnitCount            int
 }
 
 type Service struct {
@@ -323,4 +367,108 @@ func levyStatusFor(paidCents, amountCents int64, dueDate pgtype.Date) string {
 
 func startOfDay(value time.Time) time.Time {
 	return time.Date(value.Year(), value.Month(), value.Day(), 0, 0, 0, 0, value.Location())
+}
+
+func buildLevyForecast(input levyForecastInput) *LevyForecastInfo {
+	if len(input.Points) == 0 {
+		return nil
+	}
+	months := input.MonthsProjected
+	if months <= 0 {
+		months = 12
+	}
+
+	forecast := &LevyForecastInfo{
+		Status:                  "healthy",
+		Confidence:              "low",
+		MonthsProjected:         months,
+		CurrentMonthlyLevyCents: input.CurrentMonthlyLevyCents,
+		DataPoints:              make([]LevyForecastPointInfo, 0, len(input.Points)),
+		Notes:                   []string{},
+	}
+
+	var totalBilled, totalCollected, totalExpense int64
+	expensePoints := 0
+	for _, point := range input.Points {
+		if point.BilledCents <= 0 {
+			continue
+		}
+		totalBilled += point.BilledCents
+		totalCollected += minInt64(point.CollectedCents, point.BilledCents)
+		if point.HasExpense {
+			totalExpense += point.ExpenseCents
+			expensePoints++
+		}
+		collectionPct := int(math.Round(float64(minInt64(point.CollectedCents, point.BilledCents)) * 100 / float64(point.BilledCents)))
+		forecast.DataPoints = append(forecast.DataPoints, LevyForecastPointInfo{
+			PeriodLabel:       point.PeriodLabel,
+			BilledCents:       point.BilledCents,
+			CollectedCents:    minInt64(point.CollectedCents, point.BilledCents),
+			CollectionRatePct: collectionPct,
+			ExpenseCents:      point.ExpenseCents,
+		})
+	}
+
+	if totalBilled == 0 || len(forecast.DataPoints) == 0 {
+		return nil
+	}
+
+	forecast.AverageCollectionRatePct = int(math.Round(float64(totalCollected) * 100 / float64(totalBilled)))
+	forecast.AverageMonthlyIncomeCents = int64(math.Round(float64(totalCollected) / float64(len(forecast.DataPoints))))
+	if expensePoints > 0 {
+		forecast.AverageMonthlyExpenseCents = int64(math.Round(float64(totalExpense) / float64(expensePoints)))
+	} else {
+		forecast.Notes = append(forecast.Notes, "No matching budget expense periods were found; expense projection uses R0.")
+	}
+
+	monthlyNet := forecast.AverageMonthlyIncomeCents - forecast.AverageMonthlyExpenseCents
+	forecast.ProjectedReserveBalanceCents = input.CurrentReserveBalanceCents + monthlyNet*int64(months)
+	if input.ReserveTargetCents > forecast.ProjectedReserveBalanceCents {
+		forecast.ProjectedShortfallCents = input.ReserveTargetCents - forecast.ProjectedReserveBalanceCents
+	}
+
+	switch {
+	case len(forecast.DataPoints) < 2 || expensePoints == 0:
+		forecast.Status = "insufficient_data"
+	case forecast.ProjectedShortfallCents > 0:
+		forecast.Status = "shortfall_risk"
+	case monthlyNet < 0:
+		forecast.Status = "watch"
+	default:
+		forecast.Status = "healthy"
+	}
+
+	switch {
+	case len(forecast.DataPoints) >= 6 && expensePoints >= 3:
+		forecast.Confidence = "high"
+	case len(forecast.DataPoints) >= 3 && expensePoints >= 1:
+		forecast.Confidence = "medium"
+	default:
+		forecast.Confidence = "low"
+	}
+
+	if len(forecast.DataPoints) < 2 {
+		forecast.Notes = append(forecast.Notes, "Projection uses fewer than 2 historical levy periods.")
+	}
+	if input.ReserveTargetCents == 0 {
+		forecast.Notes = append(forecast.Notes, "No reserve target is set; shortfall is calculated against R0.")
+	}
+	if forecast.ProjectedShortfallCents > 0 && input.LatestUnitCount > 0 {
+		rawIncrease := int64(math.Ceil(float64(forecast.ProjectedShortfallCents) / float64(months*input.LatestUnitCount)))
+		forecast.RecommendedMonthlyIncreaseCents = roundUpToNearest(rawIncrease, 1000)
+		if input.CurrentMonthlyLevyCents > 0 {
+			forecast.RecommendedIncreasePct = int(math.Round(float64(forecast.RecommendedMonthlyIncreaseCents) * 100 / float64(input.CurrentMonthlyLevyCents)))
+		}
+	} else if forecast.ProjectedShortfallCents > 0 {
+		forecast.Notes = append(forecast.Notes, "No levy accounts were found in the latest period, so no per-unit increase is recommended.")
+	}
+
+	return forecast
+}
+
+func roundUpToNearest(value, nearest int64) int64 {
+	if value <= 0 || nearest <= 0 {
+		return 0
+	}
+	return ((value + nearest - 1) / nearest) * nearest
 }

--- a/backend/internal/financials/service.go
+++ b/backend/internal/financials/service.go
@@ -178,10 +178,12 @@ func (s *Service) Dashboard(ctx context.Context, identity auth.Identity, schemeI
 		resp.SurplusCents = resp.TotalBudgetedCents - resp.TotalActualCents
 	}
 
+	var reserveInfo *ReserveFundInfo
 	reserve, reserveErr := s.db.Q.GetReserveFund(ctx, scheme.ID)
 	if reserveErr == nil {
 		mapped := mapReserveFund(reserve)
-		resp.ReserveFund = &mapped
+		reserveInfo = &mapped
+		resp.ReserveFund = reserveInfo
 	} else if !errors.Is(reserveErr, pgx.ErrNoRows) {
 		return nil, reserveErr
 	}
@@ -191,6 +193,14 @@ func (s *Service) Dashboard(ctx context.Context, identity auth.Identity, schemeI
 		return nil, levyErr
 	}
 	resp.LevySummary = levySummary
+
+	if role != string(auth.RoleResident) {
+		forecast, forecastErr := s.buildLevyForecastForScheme(ctx, scheme.ID, reserveInfo, allLines)
+		if forecastErr != nil {
+			return nil, forecastErr
+		}
+		resp.LevyForecast = forecast
+	}
 
 	return resp, nil
 }
@@ -320,6 +330,59 @@ func (s *Service) buildLevySummary(ctx context.Context, schemeID uuid.UUID) (*Le
 		summary.CollectionRatePct = int(math.Round(float64(summary.TotalCollectedCents) * 100 / float64(summary.TotalBilledCents)))
 	}
 	return summary, nil
+}
+
+func (s *Service) buildLevyForecastForScheme(ctx context.Context, schemeID uuid.UUID, reserve *ReserveFundInfo, budgetLines []dbgen.BudgetLine) (*LevyForecastInfo, error) {
+	periods, err := s.db.Q.ListLevyPeriodsByScheme(ctx, schemeID)
+	if err != nil {
+		return nil, err
+	}
+	if len(periods) == 0 {
+		return nil, nil
+	}
+	if len(periods) > 12 {
+		periods = periods[:12]
+	}
+
+	expenseByPeriod := make(map[string]int64)
+	for _, line := range budgetLines {
+		expenseByPeriod[line.PeriodLabel] += line.ActualCents
+	}
+
+	input := levyForecastInput{
+		MonthsProjected:         12,
+		CurrentMonthlyLevyCents: periods[0].AmountCents,
+	}
+	if reserve != nil {
+		input.CurrentReserveBalanceCents = reserve.BalanceCents
+		input.ReserveTargetCents = reserve.TargetCents
+	}
+
+	for index, period := range periods {
+		accounts, accountErr := s.db.Q.ListLevyAccountsByPeriod(ctx, period.ID)
+		if accountErr != nil {
+			return nil, accountErr
+		}
+		if index == 0 {
+			input.LatestUnitCount = len(accounts)
+		}
+		point := levyForecastPointInput{PeriodLabel: period.Label}
+		for _, account := range accounts {
+			point.BilledCents += account.AmountCents
+			point.CollectedCents += minInt64(account.PaidCents, account.AmountCents)
+		}
+		if expense, ok := expenseByPeriod[period.Label]; ok {
+			point.ExpenseCents = expense
+			point.HasExpense = true
+		}
+		input.Points = append(input.Points, point)
+	}
+
+	forecast := buildLevyForecast(input)
+	if forecast != nil && reserve == nil {
+		forecast.Notes = append(forecast.Notes, "No reserve fund is set; projection starts from R0.")
+	}
+	return forecast, nil
 }
 
 func mapBudgetLine(line dbgen.BudgetLine) BudgetLineInfo {

--- a/backend/internal/financials/service.go
+++ b/backend/internal/financials/service.go
@@ -62,24 +62,24 @@ type LevyForecastPointInfo struct {
 
 //nolint:govet // Keep response DTO fields grouped by API meaning rather than field packing.
 type LevyForecastInfo struct {
-	DataPoints                    []LevyForecastPointInfo `json:"data_points"`
-	Notes                         []string                `json:"notes"`
-	Status                        string                  `json:"status"`
-	Confidence                    string                  `json:"confidence"`
-	MonthsProjected               int                     `json:"months_projected"`
-	CurrentMonthlyLevyCents       int64                   `json:"current_monthly_levy_cents"`
-	AverageCollectionRatePct      int                     `json:"average_collection_rate_pct"`
-	AverageMonthlyIncomeCents     int64                   `json:"average_monthly_income_cents"`
-	AverageMonthlyExpenseCents    int64                   `json:"average_monthly_expense_cents"`
-	ProjectedReserveBalanceCents  int64                   `json:"projected_reserve_balance_cents"`
-	ProjectedShortfallCents       int64                   `json:"projected_shortfall_cents"`
-	RecommendedMonthlyIncreaseCents int64                 `json:"recommended_monthly_increase_cents"`
-	RecommendedIncreasePct        int                     `json:"recommended_increase_pct"`
+	DataPoints                      []LevyForecastPointInfo `json:"data_points"`
+	Notes                           []string                `json:"notes"`
+	Status                          string                  `json:"status"`
+	Confidence                      string                  `json:"confidence"`
+	MonthsProjected                 int                     `json:"months_projected"`
+	CurrentMonthlyLevyCents         int64                   `json:"current_monthly_levy_cents"`
+	AverageCollectionRatePct        int                     `json:"average_collection_rate_pct"`
+	AverageMonthlyIncomeCents       int64                   `json:"average_monthly_income_cents"`
+	AverageMonthlyExpenseCents      int64                   `json:"average_monthly_expense_cents"`
+	ProjectedReserveBalanceCents    int64                   `json:"projected_reserve_balance_cents"`
+	ProjectedShortfallCents         int64                   `json:"projected_shortfall_cents"`
+	RecommendedMonthlyIncreaseCents int64                   `json:"recommended_monthly_increase_cents"`
+	RecommendedIncreasePct          int                     `json:"recommended_increase_pct"`
 }
 
 //nolint:govet // Keep response DTO fields grouped by API meaning rather than field packing.
 type DashboardResponse struct {
-	LevyForecast        *LevyForecastInfo `json:"levy_forecast"`
+	LevyForecast       *LevyForecastInfo `json:"levy_forecast"`
 	ReserveFund        *ReserveFundInfo  `json:"reserve_fund"`
 	LevySummary        *LevySummaryInfo  `json:"levy_summary"`
 	BudgetLines        []BudgetLineInfo  `json:"budget_lines"`

--- a/backend/tests/integration/financials_test.go
+++ b/backend/tests/integration/financials_test.go
@@ -103,6 +103,16 @@ func TestFinancials_DashboardAndUpdates(t *testing.T) {
 		t.Fatalf("unexpected levy summary: %+v", dashboard.LevySummary)
 	}
 
+	if dashboard.LevyForecast == nil {
+		t.Fatalf("expected admin dashboard to include levy forecast")
+	}
+	if dashboard.LevyForecast.MonthsProjected != 12 {
+		t.Fatalf("forecast months = %d", dashboard.LevyForecast.MonthsProjected)
+	}
+	if len(dashboard.LevyForecast.DataPoints) != 1 {
+		t.Fatalf("expected 1 forecast point, got %d", len(dashboard.LevyForecast.DataPoints))
+	}
+
 	req = httptest.NewRequest(http.MethodGet, "/financials/"+schemeID, nil)
 	req = withRouteParams(req, map[string]string{"schemeId": schemeID})
 	req = req.WithContext(auth.ContextWithIdentity(req.Context(), residentUserID, orgID, string(auth.RoleResident)))
@@ -114,6 +124,9 @@ func TestFinancials_DashboardAndUpdates(t *testing.T) {
 	residentDashboard := decodeSuccess[financials.DashboardResponse](t, w)
 	if residentDashboard.Role != string(auth.RoleResident) || len(residentDashboard.BudgetLines) != 1 {
 		t.Fatalf("unexpected resident dashboard: %+v", residentDashboard)
+	}
+	if residentDashboard.LevyForecast != nil {
+		t.Fatalf("resident dashboard should not include levy forecast: %+v", residentDashboard.LevyForecast)
 	}
 
 	req = httptest.NewRequest(http.MethodPut, "/financials/"+schemeID+"/budget-lines", bytes.NewReader(budgetBody))

--- a/lib/financials.ts
+++ b/lib/financials.ts
@@ -25,6 +25,30 @@ export interface LevySummaryInfo {
   overdue_count: number;
 }
 
+export interface LevyForecastPointInfo {
+  period_label: string;
+  billed_cents: number;
+  collected_cents: number;
+  collection_rate_pct: number;
+  expense_cents: number;
+}
+
+export interface LevyForecastInfo {
+  data_points: LevyForecastPointInfo[];
+  notes: string[];
+  status: "healthy" | "watch" | "shortfall_risk" | "insufficient_data";
+  confidence: "low" | "medium" | "high";
+  months_projected: number;
+  current_monthly_levy_cents: number;
+  average_collection_rate_pct: number;
+  average_monthly_income_cents: number;
+  average_monthly_expense_cents: number;
+  projected_reserve_balance_cents: number;
+  projected_shortfall_cents: number;
+  recommended_monthly_increase_cents: number;
+  recommended_increase_pct: number;
+}
+
 export interface FinancialDashboard {
   reserve_fund?: ReserveFundInfo | null;
   levy_summary?: LevySummaryInfo | null;
@@ -35,4 +59,5 @@ export interface FinancialDashboard {
   total_budgeted_cents: number;
   total_actual_cents: number;
   surplus_cents: number;
+  levy_forecast?: LevyForecastInfo | null;
 }


### PR DESCRIPTION
## Summary

- Adds a deterministic 12-month levy and reserve forecast to the financial dashboard for admins and trustees. Computes projected reserve balance, identifies shortfall risk, and recommends a per-unit monthly levy increase to close the gap.

## What changed

- **Backend**: Pure `buildLevyForecast` calculator with healthy/watch/shortfall_risk/insufficient_data statuses and 3 confidence levels. Wired into `Dashboard` for non-resident roles via `buildLevyForecastForScheme` that feeds from levy periods, accounts, budget lines, and reserve fund.
- **API**: `GET /api/v1/financials/{schemeId}` now includes `levy_forecast` for admins/trustees (null for residents).
- **UI**: New "Predictive levy outlook" section on the financials page with status badge, projection sentence, recommended levy increase call-out, reserve bar, and income/expense/current-levy stat cards. Resident view unchanged.

## Files

6 files changed, 540 insertions, 10 deletions across backend (Go) and frontend (TypeScript/React)