### PR TITLE
fix: align JWT issuer and audience config

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -81,7 +81,7 @@ func main() {
 	emailClient := notification.NewEmailClient(cfg.ResendAPIKey, cfg.EmailFrom)
 
 	// Services
-	authService := auth.NewService(db, rdb, emailClient, cfg.JWTSecret, cfg.AppBaseURL, cfg.JWTExpiry, cfg.RefreshExpiry)
+	authService := auth.NewService(db, rdb, emailClient, cfg.JWTSecret, cfg.AppBaseURL, cfg.JWTIssuer, cfg.JWTAudience, cfg.JWTExpiry, cfg.RefreshExpiry)
 	auditService := audit.NewService(db)
 	resourceAuditService := audit.NewResourceService(db.Q)
 	agmService := agm.NewServiceWithAudit(db, resourceAuditService)
@@ -118,7 +118,7 @@ func main() {
 	defer whatsAppWebhook.Close()
 	billingProvider := billing.NewStripeProvider(cfg.StripeSecretKey, cfg.StripeWebhookSecret, cfg.StripePriceID)
 	billingService := billing.NewService(db, billingProvider, cfg.AppBaseURL)
-	invitationService := invitation.NewServiceWithAudit(db, emailClient, cfg.AppBaseURL, cfg.JWTSecret, cfg.JWTExpiry, cfg.RefreshExpiry, resourceAuditService)
+	invitationService := invitation.NewServiceWithAudit(db, emailClient, cfg.AppBaseURL, cfg.JWTSecret, cfg.JWTIssuer, cfg.JWTAudience, cfg.JWTExpiry, cfg.RefreshExpiry, resourceAuditService)
 	earlyAccessService := earlyaccess.NewService(db.Q, authService, emailClient, cfg.BackendBaseURL, cfg.AppBaseURL, cfg.AdminEmail, cfg.AdminSecret)
 	integrationsService := integrations.NewService(db)
 	contractorService := contractors.NewService(db)

--- a/backend/internal/auth/service.go
+++ b/backend/internal/auth/service.go
@@ -113,17 +113,22 @@ type Service struct {
 	sender        notification.Sender
 	appBaseURL    string
 	jwtSecret     string
+	jwtIssuer     string
+	jwtAudience   string
 	jwtExpiry     time.Duration
 	refreshExpiry time.Duration
 }
 
-func NewService(db *database.Pool, cache *redis.Client, sender notification.Sender, jwtSecret, appBaseURL string, jwtExpiry, refreshExpiry time.Duration) *Service {
+func NewService(db *database.Pool, cache *redis.Client, sender notification.Sender, jwtSecret, appBaseURL, jwtIssuer, jwtAudience string, jwtExpiry, refreshExpiry time.Duration) *Service {
+	issuer, audience := ResolveJWTConfig(appBaseURL, jwtIssuer, jwtAudience)
 	return &Service{
 		db:            db,
 		cache:         cache,
 		sender:        sender,
 		jwtSecret:     jwtSecret,
 		appBaseURL:    appBaseURL,
+		jwtIssuer:     issuer,
+		jwtAudience:   audience,
 		jwtExpiry:     jwtExpiry,
 		refreshExpiry: refreshExpiry,
 	}
@@ -239,7 +244,7 @@ func (s *Service) Refresh(ctx context.Context, refreshToken string) (*RefreshRes
 		return nil, err
 	}
 
-	accessToken, err := GenerateAccessToken(user.ID.String(), membership.OrgID.String(), membership.Role, s.appBaseURL, "stratahq-api", s.jwtSecret, s.jwtExpiry)
+	accessToken, err := GenerateAccessToken(user.ID.String(), membership.OrgID.String(), membership.Role, s.jwtIssuer, s.jwtAudience, s.jwtSecret, s.jwtExpiry)
 	if err != nil {
 		return nil, err
 	}
@@ -555,7 +560,7 @@ func (s *Service) ResetPassword(ctx context.Context, token, password string) err
 
 // issueTokens creates a token pair and persists the refresh token.
 func (s *Service) issueTokens(ctx context.Context, user dbgen.User, orgID, role string) (*AuthResponse, error) {
-	accessToken, err := GenerateAccessToken(user.ID.String(), orgID, role, s.appBaseURL, "stratahq-api", s.jwtSecret, s.jwtExpiry)
+	accessToken, err := GenerateAccessToken(user.ID.String(), orgID, role, s.jwtIssuer, s.jwtAudience, s.jwtSecret, s.jwtExpiry)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/auth/tokens.go
+++ b/backend/internal/auth/tokens.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"errors"
+	"strings"
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
@@ -24,6 +25,23 @@ type Claims struct {
 	OrgID string `json:"org_id"`
 	Role  string `json:"role"`
 	jwt.RegisteredClaims
+}
+
+const defaultJWTAudience = "stratahq-api"
+
+// ResolveJWTConfig normalizes JWT issuer/audience defaults for token creation.
+func ResolveJWTConfig(appBaseURL, issuer, audience string) (string, string) {
+	resolvedIssuer := strings.TrimSpace(issuer)
+	if resolvedIssuer == "" {
+		resolvedIssuer = strings.TrimSpace(appBaseURL)
+	}
+
+	resolvedAudience := strings.TrimSpace(audience)
+	if resolvedAudience == "" {
+		resolvedAudience = defaultJWTAudience
+	}
+
+	return resolvedIssuer, resolvedAudience
 }
 
 // GenerateAccessToken creates a signed HS256 JWT for the given user.

--- a/backend/internal/auth/tokens_test.go
+++ b/backend/internal/auth/tokens_test.go
@@ -30,6 +30,24 @@ func TestGenerateAccessToken_ValidClaims(t *testing.T) {
 	}
 }
 
+func TestResolveJWTConfig(t *testing.T) {
+	issuer, audience := ResolveJWTConfig("https://app.local", "", "")
+	if issuer != "https://app.local" {
+		t.Errorf("issuer = %q, want %q", issuer, "https://app.local")
+	}
+	if audience != "stratahq-api" {
+		t.Errorf("audience = %q, want %q", audience, "stratahq-api")
+	}
+
+	issuer, audience = ResolveJWTConfig("https://app.local", "https://issuer.local", "aud.test")
+	if issuer != "https://issuer.local" {
+		t.Errorf("issuer override = %q, want %q", issuer, "https://issuer.local")
+	}
+	if audience != "aud.test" {
+		t.Errorf("audience override = %q, want %q", audience, "aud.test")
+	}
+}
+
 func TestValidateAccessToken_WrongSecret(t *testing.T) {
 	tok, _ := GenerateAccessToken("user-1", "org-1", "admin", "https://localhost:3000", "stratahq-api", "secret-a", 15*time.Minute)
 	_, err := ValidateAccessToken(tok, "secret-b", "", "")

--- a/backend/internal/invitation/service.go
+++ b/backend/internal/invitation/service.go
@@ -92,16 +92,19 @@ type Service struct {
 	sender        notification.Sender
 	appBaseURL    string
 	jwtSecret     string
+	jwtIssuer     string
+	jwtAudience   string
 	jwtExpiry     time.Duration
 	refreshExpiry time.Duration
 	auditor       resourceAuditor
 }
 
-func NewService(db *database.Pool, sender notification.Sender, appBaseURL, jwtSecret string, jwtExpiry, refreshExpiry time.Duration) *Service {
-	return NewServiceWithAudit(db, sender, appBaseURL, jwtSecret, jwtExpiry, refreshExpiry, nil)
+func NewService(db *database.Pool, sender notification.Sender, appBaseURL, jwtSecret, jwtIssuer, jwtAudience string, jwtExpiry, refreshExpiry time.Duration) *Service {
+	return NewServiceWithAudit(db, sender, appBaseURL, jwtSecret, jwtIssuer, jwtAudience, jwtExpiry, refreshExpiry, nil)
 }
 
-func NewServiceWithAudit(db *database.Pool, sender notification.Sender, appBaseURL, jwtSecret string, jwtExpiry, refreshExpiry time.Duration, auditor resourceAuditor) *Service {
+func NewServiceWithAudit(db *database.Pool, sender notification.Sender, appBaseURL, jwtSecret, jwtIssuer, jwtAudience string, jwtExpiry, refreshExpiry time.Duration, auditor resourceAuditor) *Service {
+	issuer, audience := auth.ResolveJWTConfig(appBaseURL, jwtIssuer, jwtAudience)
 	return &Service{
 		q: db.Q,
 		withTx: func(ctx context.Context, fn func(q txStore) error) error {
@@ -113,6 +116,8 @@ func NewServiceWithAudit(db *database.Pool, sender notification.Sender, appBaseU
 		sender:        sender,
 		appBaseURL:    appBaseURL,
 		jwtSecret:     jwtSecret,
+		jwtIssuer:     issuer,
+		jwtAudience:   audience,
 		jwtExpiry:     jwtExpiry,
 		refreshExpiry: refreshExpiry,
 		auditor:       auditor,
@@ -399,7 +404,7 @@ func (s *Service) Accept(ctx context.Context, token, password string) (*auth.Aut
 		return nil, err
 	}
 
-	accessToken, err := auth.GenerateAccessToken(user.ID.String(), inv.OrgID.String(), inv.Role, s.appBaseURL, "stratahq-api", s.jwtSecret, s.jwtExpiry)
+	accessToken, err := auth.GenerateAccessToken(user.ID.String(), inv.OrgID.String(), inv.Role, s.jwtIssuer, s.jwtAudience, s.jwtSecret, s.jwtExpiry)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/invitation/service_test.go
+++ b/backend/internal/invitation/service_test.go
@@ -214,6 +214,56 @@ func TestServiceCreateRejectsForeignScheme(t *testing.T) {
 	}
 }
 
+func TestServiceAcceptUsesConfiguredJWTClaims(t *testing.T) {
+	orgID := uuid.New()
+	schemeID := uuid.New()
+	store := &fakeInvitationStore{
+		invitationByToken: &dbgen.Invitation{
+			ID:        uuid.New(),
+			OrgID:     orgID,
+			SchemeID:  schemeID,
+			UnitID:    pgtype.UUID{},
+			Email:     "trustee@example.com",
+			FullName:  "Trustee User",
+			Role:      "trustee",
+			Token:     "accept-token",
+			Status:    "pending",
+			ExpiresAt: time.Now().Add(time.Hour),
+		},
+		getUserByEmailErr: pgx.ErrNoRows,
+		createdUser: &dbgen.User{
+			ID:       uuid.New(),
+			Email:    "trustee@example.com",
+			FullName: "Trustee User",
+		},
+	}
+	svc := &Service{
+		q:           store,
+		withTx:      func(ctx context.Context, fn func(q txStore) error) error { return fn(store) },
+		sender:      &notification.NoopSender{},
+		jwtSecret:   "unit-test-secret",
+		jwtIssuer:   "https://issuer.test",
+		jwtAudience: "tenant-aud",
+		jwtExpiry:   15 * time.Minute,
+	}
+
+	resp, err := svc.Accept(context.Background(), "accept-token", "StrongPassword!123")
+	if err != nil {
+		t.Fatalf("Accept() error = %v", err)
+	}
+
+	claims, err := auth.ValidateAccessToken(resp.AccessToken, svc.jwtSecret, svc.jwtIssuer, svc.jwtAudience)
+	if err != nil {
+		t.Fatalf("access token should validate with configured issuer/audience: %v", err)
+	}
+	if claims.Issuer != svc.jwtIssuer {
+		t.Fatalf("access token issuer = %q, want %q", claims.Issuer, svc.jwtIssuer)
+	}
+	if claims.Audience[0] != svc.jwtAudience {
+		t.Fatalf("access token audience = %q, want %q", claims.Audience[0], svc.jwtAudience)
+	}
+}
+
 func TestServiceCreateRejectsUnitOutsideScheme(t *testing.T) {
 	orgID := uuid.New()
 	schemeID := uuid.New()

--- a/backend/tests/integration/auth_test.go
+++ b/backend/tests/integration/auth_test.go
@@ -26,7 +26,7 @@ const (
 func newAuthHandler(t *testing.T) *auth.Handler {
 	t.Helper()
 	sender := &notification.NoopSender{}
-	svc := auth.NewService(testPool, testRedis, sender, testJWTSigningKey, "http://localhost:3000", 15*time.Minute, 7*24*time.Hour)
+	svc := auth.NewService(testPool, testRedis, sender, testJWTSigningKey, "http://localhost:3000", "http://localhost:3000", "stratahq-api", 15*time.Minute, 7*24*time.Hour)
 	return auth.NewHandler(svc)
 }
 
@@ -332,7 +332,17 @@ func TestAuth_SetupOnboarding(t *testing.T) {
 func TestAuth_ForgotResetPassword(t *testing.T) {
 	h := newAuthHandler(t)
 	sender := notification.NoopSender{}
-	svc := auth.NewService(testPool, testRedis, &sender, testJWTSigningKey, "http://localhost:3000", 15*time.Minute, 7*24*time.Hour)
+	svc := auth.NewService(
+		testPool,
+		testRedis,
+		&sender,
+		testJWTSigningKey,
+		"http://localhost:3000",
+		"http://localhost:3000",
+		"stratahq-api",
+		15*time.Minute,
+		7*24*time.Hour,
+	)
 	h = auth.NewHandler(svc)
 
 	email := uniqueEmail(t)

--- a/backend/tests/integration/earlyaccess_test.go
+++ b/backend/tests/integration/earlyaccess_test.go
@@ -31,6 +31,8 @@ func newEarlyAccessHandler(t *testing.T, adminEmail, adminSecret string) *earlya
 		sender,
 		testJWTSigningKey,
 		"http://localhost:3000",
+		"http://localhost:3000",
+		"stratahq-api",
 		15*time.Minute,
 		7*24*time.Hour,
 	)

--- a/backend/tests/integration/invitation_test.go
+++ b/backend/tests/integration/invitation_test.go
@@ -22,7 +22,7 @@ import (
 func newInvitationHandler(t *testing.T) (*invitation.Handler, *notification.NoopSender) {
 	t.Helper()
 	sender := &notification.NoopSender{}
-	svc := invitation.NewService(testPool, sender, "http://localhost:3000", testJWTSigningKey, 15*time.Minute, 7*24*time.Hour)
+	svc := invitation.NewService(testPool, sender, "http://localhost:3000", testJWTSigningKey, "http://localhost:3000", "stratahq-api", 15*time.Minute, 7*24*time.Hour)
 	return invitation.NewHandler(svc, "http://localhost:3000"), sender
 }
 


### PR DESCRIPTION
## Summary
- Resolve JWT issuer/audience configuration for token creation to match validation settings.
- Default issuer/audience are normalized from app config (including defaults already defined in config envs).
- Wire issuer/audience through auth and invitation services and constructor callsites.

Closes #127
