### PR TITLE
fix: avoid forcing json content-type for form uploads

### DIFF
--- a/lib/api.test.ts
+++ b/lib/api.test.ts
@@ -17,7 +17,12 @@ describe("apiFetch", () => {
 
     expect(response.status).toBe(401);
     expect(fetchMock).toHaveBeenCalledTimes(1);
-    const requestInit = fetchMock.mock.calls[0][1] as RequestInit;
+    const firstCall = fetchMock.mock.calls[0] as [string, RequestInit] | undefined;
+    expect(firstCall).toBeDefined();
+    if (!firstCall) {
+      throw new Error("apiFetch should call fetch");
+    }
+    const [, requestInit] = firstCall;
     const headers = new Headers(requestInit.headers);
     expect(headers.get("x-skip-auth")).toBe("true");
   });
@@ -42,7 +47,12 @@ describe("apiFetch", () => {
       expect.anything(),
     );
 
-    const requestInit = fetchMock.mock.calls[0][1] as RequestInit;
+    const firstCall = fetchMock.mock.calls[0] as [string, RequestInit] | undefined;
+    expect(firstCall).toBeDefined();
+    if (!firstCall) {
+      throw new Error("apiFetch should call fetch");
+    }
+    const [, requestInit] = firstCall;
     const headers = new Headers(requestInit.headers);
     expect(headers.get("x-csrf-token")).toBe("test-csrf-token");
     expect(headers.get("Content-Type")).toBe("application/json");
@@ -62,8 +72,12 @@ describe("apiFetch", () => {
       body: form,
     });
 
-    const callArgs = fetchMock.mock.calls[0];
-    const requestInit = callArgs[1] as RequestInit;
+    const firstCall = fetchMock.mock.calls[0] as [string, RequestInit] | undefined;
+    expect(firstCall).toBeDefined();
+    if (!firstCall) {
+      throw new Error("apiFetch should call fetch");
+    }
+    const [, requestInit] = firstCall;
     const headers = new Headers(requestInit.headers);
 
     expect(headers.has("Content-Type")).toBe(false);

--- a/lib/api.test.ts
+++ b/lib/api.test.ts
@@ -17,14 +17,9 @@ describe("apiFetch", () => {
 
     expect(response.status).toBe(401);
     expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(fetchMock).toHaveBeenCalledWith(
-      "/api/proxy/api/v1/invitations/verify/token-123",
-      expect.objectContaining({
-        headers: expect.objectContaining({
-          "x-skip-auth": "true",
-        }),
-      }),
-    );
+    const requestInit = fetchMock.mock.calls[0][1] as RequestInit;
+    const headers = new Headers(requestInit.headers);
+    expect(headers.get("x-skip-auth")).toBe("true");
   });
 
   it("adds the csrf header to mutating proxy requests", async () => {
@@ -44,11 +39,33 @@ describe("apiFetch", () => {
 
     expect(fetchMock).toHaveBeenCalledWith(
       "/api/proxy/api/v1/schemes/scheme-1",
-      expect.objectContaining({
-        headers: expect.objectContaining({
-          "x-csrf-token": "test-csrf-token",
-        }),
-      }),
+      expect.anything(),
     );
+
+    const requestInit = fetchMock.mock.calls[0][1] as RequestInit;
+    const headers = new Headers(requestInit.headers);
+    expect(headers.get("x-csrf-token")).toBe("test-csrf-token");
+    expect(headers.get("Content-Type")).toBe("application/json");
+  });
+
+  it("does not set JSON content type for multipart body uploads", async () => {
+    const fetchMock = vi.fn(async () => new Response(null, { status: 204 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const form = new FormData();
+    form.append("bank", "chase");
+    form.append("file", new File(["abc"], "statement.csv", { type: "text/csv" }));
+
+    const { apiFetch } = await import("./api");
+    await apiFetch("/api/v1/levies/scheme-1/reconcile/imports", {
+      method: "POST",
+      body: form,
+    });
+
+    const callArgs = fetchMock.mock.calls[0];
+    const requestInit = callArgs[1] as RequestInit;
+    const headers = new Headers(requestInit.headers);
+
+    expect(headers.has("Content-Type")).toBe(false);
   });
 });

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -9,14 +9,23 @@ export async function apiFetch(path: string, options: ApiFetchOptions = {}) {
   const csrfToken = isSafeMethod(requestOptions.method)
     ? null
     : readBrowserCSRFToken();
+  const isFormData = requestOptions.body instanceof FormData;
+  const headers = new Headers(requestOptions.headers);
+
+  if (!isFormData && !headers.has("Content-Type")) {
+    headers.set("Content-Type", "application/json");
+  }
+
+  if (csrfToken) {
+    headers.set("x-csrf-token", csrfToken);
+  }
+
+  if (auth === false) {
+    headers.set("x-skip-auth", "true");
+  }
 
   return fetch(`/api/proxy${path}`, {
     ...requestOptions,
-    headers: {
-      "Content-Type": "application/json",
-      ...(requestOptions.headers ?? {}),
-      ...(csrfToken ? { "x-csrf-token": csrfToken } : {}),
-      ...(auth === false ? { "x-skip-auth": "true" } : {}),
-    },
+    headers,
   });
 }


### PR DESCRIPTION
## Summary
- Make apiFetch infer multipart/form-data headers when request body is FormData.
- Keep JSON Content-Type for JSON bodies.
- Add regression coverage for multipart uploads preserving browser boundaries.

Closes #126
