### PR TITLE
fix: harden frontend proxy boundary

### DIFF
--- a/app/api/proxy/[...path]/route.test.ts
+++ b/app/api/proxy/[...path]/route.test.ts
@@ -159,10 +159,24 @@ describe("proxyRequest", () => {
   it("reuses the original request body for a retry after refresh", async () => {
     let callCount = 0;
     const bodies: string[] = [];
+    const readBody = async (body: RequestInit["body"]): Promise<string> => {
+      if (!body) return "";
+      if (typeof body === "string") return body;
+      if (body instanceof Blob) return await body.text();
+      if (body instanceof URLSearchParams) return body.toString();
+      if (body instanceof ArrayBuffer) return Buffer.from(body).toString();
+      if (ArrayBuffer.isView(body)) return Buffer.from(body.buffer).toString();
+      if (body instanceof ReadableStream) {
+        return await new Response(body).text();
+      }
+      return String(body);
+    };
 
     vi.stubGlobal("fetch", vi.fn(async (_url: string, options: RequestInit) => {
       callCount++;
-      if (options.body) bodies.push(Buffer.from(options.body as Uint8Array).toString());
+      if (options.body) {
+        bodies.push(await readBody(options.body));
+      }
       if (callCount === 1) return new Response(null, { status: 401 });
       return new Response(JSON.stringify({ data: { ok: true } }), {
         status: 200,

--- a/app/api/proxy/[...path]/route.ts
+++ b/app/api/proxy/[...path]/route.ts
@@ -100,7 +100,7 @@ async function forwardRequest(args: {
   backendPath: string
   method: string
   headers: Record<string, string>
-  body?: Uint8Array
+  body?: BodyInit
   signal?: AbortSignal
 }) {
   return fetch(`${BACKEND()}${args.backendPath}`, {
@@ -155,10 +155,13 @@ async function proxyRequest(request: NextRequest, pathSegments: string[]) {
     return new Response(null, { status: 404 });
   }
 
-  const bufferedBody =
-    request.method !== "GET" && request.method !== "HEAD"
-      ? await request.bytes()
-      : undefined;
+  let requestBody: BodyInit | undefined;
+  let requestBodyRetry: BodyInit | undefined;
+  if (request.method !== "GET" && request.method !== "HEAD" && request.body) {
+    const [firstBody, secondBody] = request.body.tee();
+    requestBody = firstBody;
+    requestBodyRetry = secondBody;
+  }
 
   const proxyHeaders: Record<string, string> = {
     "x-request-id": requestId,
@@ -185,7 +188,7 @@ async function proxyRequest(request: NextRequest, pathSegments: string[]) {
       backendPath,
       method: request.method,
       headers: proxyHeaders,
-      body: bufferedBody,
+      body: requestBody,
       signal: controller.signal,
     });
   } catch (error) {
@@ -222,7 +225,7 @@ async function proxyRequest(request: NextRequest, pathSegments: string[]) {
           backendPath,
           method: request.method,
           headers: proxyHeaders,
-          body: bufferedBody,
+          body: requestBodyRetry,
           signal: retryController.signal,
         });
         clearTimeout(retryTimeout);
@@ -260,7 +263,7 @@ async function proxyRequest(request: NextRequest, pathSegments: string[]) {
       backendPath,
       method: request.method,
       headers: updatedHeaders,
-      body: bufferedBody,
+      body: requestBodyRetry ?? requestBody,
       signal: refreshRetryController.signal,
     });
   } catch (error) {

--- a/lib/middleware.test.ts
+++ b/lib/middleware.test.ts
@@ -4,6 +4,48 @@ import { NextRequest } from "next/server";
 import { proxy } from "@/proxy";
 
 describe("proxy", () => {
+  it("blocks mutating requests when both Origin and Referer are missing", () => {
+    const request = new NextRequest("http://localhost/agent", {
+      headers: {
+        cookie: "sh_session=fake-session",
+      },
+      method: "POST",
+    });
+
+    const response = proxy(request);
+
+    expect(response.status).toBe(403);
+  });
+
+  it("allows mutating requests when Referer is valid and Origin is missing", () => {
+    const request = new NextRequest("http://localhost/agent", {
+      method: "POST",
+      headers: {
+        cookie: "sh_session=fake-session",
+        referer: "http://localhost/account",
+      },
+    });
+
+    const response = proxy(request);
+
+    expect(response.status).toBe(200);
+  });
+
+  it("blocks mutating requests when Origin and Referer are untrusted", () => {
+    const request = new NextRequest("http://localhost/agent", {
+      method: "POST",
+      headers: {
+        cookie: "sh_session=fake-session",
+        origin: "https://evil.com",
+        referer: "https://evil.com/phish",
+      },
+    });
+
+    const response = proxy(request);
+
+    expect(response.status).toBe(403);
+  });
+
   it("allows protected pages when session cookie exists (API handles token refresh)", () => {
     const request = new NextRequest("http://localhost/agent", {
       headers: {

--- a/lib/middleware.test.ts
+++ b/lib/middleware.test.ts
@@ -3,7 +3,39 @@ import { NextRequest } from "next/server";
 
 import { proxy } from "@/proxy";
 
+function base64Url(value: string): string {
+  return Buffer.from(value)
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=/g, "");
+}
+
+function mintJwt(subject: string, expSeconds: number): string {
+  const header = base64Url(JSON.stringify({ alg: "HS256", typ: "JWT" }));
+  const payload = base64Url(JSON.stringify({ sub: subject, exp: expSeconds }));
+  return `${header}.${payload}.sig`;
+}
+
+function encodedSessionCookie(session: Record<string, unknown>): string {
+  return `sh_session=${encodeURIComponent(JSON.stringify(session))}`;
+}
+
+function getSetCookieValue(headers: Headers): string {
+  return headers.get("set-cookie") ?? "";
+}
+
 describe("proxy", () => {
+  const validSession = {
+    id: "user-1",
+    email: "user@example.com",
+    full_name: "User One",
+    role: "admin",
+    wizard_complete: false,
+    scheme_memberships: [],
+  };
+  const validSessionCookie = encodedSessionCookie(validSession);
+
   it("blocks mutating requests when both Origin and Referer are missing", () => {
     const request = new NextRequest("http://localhost/agent", {
       headers: {
@@ -21,7 +53,10 @@ describe("proxy", () => {
     const request = new NextRequest("http://localhost/agent", {
       method: "POST",
       headers: {
-        cookie: "sh_session=fake-session",
+        cookie: `${validSessionCookie}; sh_access=${mintJwt(
+          "user-1",
+          Math.floor(Date.now() / 1000) + 120,
+        )}; sh_csrf=token`,
         referer: "http://localhost/account",
       },
     });
@@ -46,10 +81,65 @@ describe("proxy", () => {
     expect(response.status).toBe(403);
   });
 
-  it("allows protected pages when session cookie exists (API handles token refresh)", () => {
+  it("clears auth cookies when session cookie is missing", () => {
     const request = new NextRequest("http://localhost/agent", {
       headers: {
-        cookie: "sh_session=fake-session",
+        referer: "http://localhost/account",
+      },
+      method: "POST",
+    });
+
+    const response = proxy(request);
+
+    expect(response.status).toBe(307);
+    const setCookie = getSetCookieValue(response.headers);
+    expect(setCookie).toContain("sh_session=;");
+    expect(setCookie).toContain("sh_access=;");
+    expect(setCookie).toContain("sh_refresh=;");
+    expect(setCookie).toContain("sh_csrf=;");
+  });
+
+  it("clears auth cookies when access token is missing", () => {
+    const request = new NextRequest("http://localhost/agent", {
+      headers: {
+        referer: "http://localhost/account",
+        cookie:
+          `${validSessionCookie}; sh_csrf=token`,
+      },
+      method: "POST",
+    });
+
+    const response = proxy(request);
+
+    expect(response.status).toBe(307);
+    const setCookie = getSetCookieValue(response.headers);
+    expect(setCookie).toContain("sh_session=;");
+  });
+
+  it("clears auth cookies when access token is expired", () => {
+    const expiredAccess = mintJwt("user-1", Math.floor(Date.now() / 1000) - 60);
+    const request = new NextRequest("http://localhost/agent", {
+      headers: {
+        origin: "http://localhost",
+        cookie:
+          `${validSessionCookie}; sh_access=${expiredAccess}; sh_csrf=token`,
+      },
+      method: "POST",
+    });
+
+    const response = proxy(request);
+
+    expect(response.status).toBe(307);
+    const setCookie = getSetCookieValue(response.headers);
+    expect(setCookie).toContain("sh_session=;");
+    expect(setCookie).toContain("sh_access=");
+  });
+
+  it("allows protected pages when session cookie exists (API handles token refresh)", () => {
+    const accessToken = mintJwt("user-1", Math.floor(Date.now() / 1000) + 60);
+    const request = new NextRequest("http://localhost/agent", {
+      headers: {
+        cookie: `${validSessionCookie}; sh_access=${accessToken}; sh_csrf=token`,
       },
     });
 

--- a/lib/middleware.test.ts
+++ b/lib/middleware.test.ts
@@ -158,4 +158,21 @@ describe("proxy", () => {
       "http://localhost/auth/login?redirect=%2Fagent",
     );
   });
+
+  it("sets content security policy header", () => {
+    const request = new NextRequest("http://localhost/agent", {
+      headers: {
+        cookie: `${validSessionCookie}; sh_access=${mintJwt(
+          "user-1",
+          Math.floor(Date.now() / 1000) + 120,
+        )}; sh_csrf=token`,
+      },
+    });
+    const response = proxy(request);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-security-policy")).toBe(
+      "default-src 'self'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'",
+    );
+  });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@tanstack/react-query": "^5.99.1",
-        "next": "16.2.4",
+        "next": "^16.2.6",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
       },
@@ -1308,15 +1308,15 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.4.tgz",
-      "integrity": "sha512-dKkkOzOSwFYe5RX6y26fZgkSpVAlIOJKQHIiydQcrWH6y/97+RceSOAdjZ14Qa3zLduVUy0TXcn+EiM6t4rPgw==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.6.tgz",
+      "integrity": "sha512-gd8HoHN4ufj73WmR3JmVolrpJR47ILK6LouP5xElPglaVxir6e1a7VzvTvDWkOoPXT9rkkTzyCxBu4yeZfZwcw==",
       "license": "MIT"
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.4.tgz",
-      "integrity": "sha512-OXTFFox5EKN1Ym08vfrz+OXxmCcEjT4SFMbNRsWZE99dMqt2Kcusl5MqPXcW232RYkMLQTy0hqgAMEsfEd/l2A==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.6.tgz",
+      "integrity": "sha512-ZJGkkcNfYgrrMkqOdZ7zoLa1TOy0qpcMfk/z4Mh/FKUz40gVO+HNQWqmLxf67Z5WB64DRp0dhEbyHfel+6sJUg==",
       "cpu": [
         "arm64"
       ],
@@ -1330,9 +1330,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.4.tgz",
-      "integrity": "sha512-XhpVnUfmYWvD3YrXu55XdcAkQtOnvaI6wtQa8fuF5fGoKoxIUZ0kWPtcOfqJEWngFF/lOS9l3+O9CcownhiQxQ==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.6.tgz",
+      "integrity": "sha512-v/YLBHIY132Ced3puBJ7YJKw1lqsCrgcNo2aRJlCEyQrrCeRJlvGlnmxhPxNQI3KE3N1DN5r9TPNPvka3nq5RQ==",
       "cpu": [
         "x64"
       ],
@@ -1346,11 +1346,14 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.4.tgz",
-      "integrity": "sha512-Mx/tjlNA3G8kg14QvuGAJ4xBwPk1tUHq56JxZ8CXnZwz1Etz714soCEzGQQzVMz4bEnGPowzkV6Xrp6wAkEWOQ==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.6.tgz",
+      "integrity": "sha512-RPOvqlYBbcQjkz9VQQDZ2T2bARIjXZV1KFlt+V2Mr6SW/e4I9fcKsaA0hdyf2FHoTlsV2xnBd5Y912rP/1Ce6w==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -1362,11 +1365,14 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.4.tgz",
-      "integrity": "sha512-iVMMp14514u7Nup2umQS03nT/bN9HurK8ufylC3FZNykrwjtx7V1A7+4kvhbDSCeonTVqV3Txnv0Lu+m2oDXNg==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.6.tgz",
+      "integrity": "sha512-URUTu1+dMkxJsPFgm+OeEvq9wf5sujw0EvgYy80TDGHTSLTnIHeqb0Eu8A3sC95IRgjejQL+kC4mw+4yPxiAXA==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1378,11 +1384,14 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.4.tgz",
-      "integrity": "sha512-EZOvm1aQWgnI/N/xcWOlnS3RQBk0VtVav5Zo7n4p0A7UKyTDx047k8opDbXgBpHl4CulRqRfbw3QrX2w5UOXMQ==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.6.tgz",
+      "integrity": "sha512-DOj182mPV8G3UkrayLoREM5YEYI+Dk5wv7Ox9xl1fFibAELEsFD0lDPfHIeILlutMMfdyhlzYPELG3peuKaurw==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -1394,11 +1403,14 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.4.tgz",
-      "integrity": "sha512-h9FxsngCm9cTBf71AR4fGznDEDx1hS7+kSEiIRjq5kO1oXWm07DxVGZjCvk0SGx7TSjlUqhI8oOyz7NfwAdPoA==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.6.tgz",
+      "integrity": "sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1410,9 +1422,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.4.tgz",
-      "integrity": "sha512-3NdJV5OXMSOeJYijX+bjaLge3mJBlh4ybydbT4GFoB/2hAojWHtMhl3CYlYoMrjPuodp0nzFVi4Tj2+WaMg+Ow==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.6.tgz",
+      "integrity": "sha512-LZXpTlPyS5v7HhSmnvsLGP3iIYgYOBnc8r8ArlT55sGHV89bR2HlDdBjWQ+PY6SJMmk8TuVGFuxalnP3k/0Dwg==",
       "cpu": [
         "arm64"
       ],
@@ -1426,9 +1438,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.4.tgz",
-      "integrity": "sha512-kMVGgsqhO5YTYODD9IPGGhA6iprWidQckK3LmPeW08PIFENRmgfb4MjXHO+p//d+ts2rpjvK5gXWzXSMrPl9cw==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.6.tgz",
+      "integrity": "sha512-F0+4i0h9J6C4eE3EAPWsoCk7UW/dbzOjyzxY0qnDUOYFu6FFmdZ6l97/XdV3/Nz3VYyO7UWjyEJUXkGqcoXfMA==",
       "cpu": [
         "x64"
       ],
@@ -3978,12 +3990,12 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.2.4.tgz",
-      "integrity": "sha512-kPvz56wF5frc+FxlHI5qnklCzbq53HTwORaWBGdT0vNoKh1Aya9XC8aPauH4NJxqtzbWsS5mAbctm4cr+EkQ2Q==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.2.6.tgz",
+      "integrity": "sha512-qOVgKJg1+At15NpeUP+eJgCHvTCgXsogweq87Ri/Ix7PkqQHg4sdaXmSFqKlgaIXE4kW0g25LE68W87UANlHtw==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "16.2.4",
+        "@next/env": "16.2.6",
         "@swc/helpers": "0.5.15",
         "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
@@ -3997,14 +4009,14 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.2.4",
-        "@next/swc-darwin-x64": "16.2.4",
-        "@next/swc-linux-arm64-gnu": "16.2.4",
-        "@next/swc-linux-arm64-musl": "16.2.4",
-        "@next/swc-linux-x64-gnu": "16.2.4",
-        "@next/swc-linux-x64-musl": "16.2.4",
-        "@next/swc-win32-arm64-msvc": "16.2.4",
-        "@next/swc-win32-x64-msvc": "16.2.4",
+        "@next/swc-darwin-arm64": "16.2.6",
+        "@next/swc-darwin-x64": "16.2.6",
+        "@next/swc-linux-arm64-gnu": "16.2.6",
+        "@next/swc-linux-arm64-musl": "16.2.6",
+        "@next/swc-linux-x64-gnu": "16.2.6",
+        "@next/swc-linux-x64-musl": "16.2.6",
+        "@next/swc-win32-arm64-msvc": "16.2.6",
+        "@next/swc-win32-x64-msvc": "16.2.6",
         "sharp": "^0.34.5"
       },
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^5.99.1",
-    "next": "16.2.4",
+    "next": "^16.2.6",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/proxy.ts
+++ b/proxy.ts
@@ -121,6 +121,10 @@ export function proxy(request: NextRequest) {
     "Permissions-Policy",
     "camera=(), microphone=(), geolocation=()",
   );
+  response.headers.set(
+    "Content-Security-Policy",
+    "default-src 'self'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'",
+  );
 
   if (process.env.NODE_ENV === "production") {
     response.headers.set(

--- a/proxy.ts
+++ b/proxy.ts
@@ -52,10 +52,14 @@ function isValidAccessToken(token: string, sessionId: string): boolean {
   if (parts.length !== 3) {
     return false;
   }
+  const payload = parts[1];
+  if (!payload) {
+    return false;
+  }
 
   let claims: Record<string, unknown>;
   try {
-    claims = JSON.parse(decodeBase64URL(parts[1])) as Record<string, unknown>;
+    claims = JSON.parse(decodeBase64URL(payload)) as Record<string, unknown>;
   } catch {
     return false;
   }

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 
+import { parseSessionCookie } from "@/lib/session";
+
 const PUBLIC_PATHS = [
   "/auth/login",
   "/auth/register",
@@ -37,6 +39,53 @@ function isAllowedOrigin(rawOrigin: string | null, request: NextRequest): boolea
   }
 }
 
+function decodeBase64URL(input: string): string {
+  const normalized = input
+    .replace(/-/g, "+")
+    .replace(/_/g, "/")
+    .padEnd(input.length + ((4 - (input.length % 4)) % 4), "=");
+  return Buffer.from(normalized, "base64").toString("utf8");
+}
+
+function isValidAccessToken(token: string, sessionId: string): boolean {
+  const parts = token.split(".");
+  if (parts.length !== 3) {
+    return false;
+  }
+
+  let claims: Record<string, unknown>;
+  try {
+    claims = JSON.parse(decodeBase64URL(parts[1])) as Record<string, unknown>;
+  } catch {
+    return false;
+  }
+
+  const tokenSub = claims.sub;
+  if (typeof tokenSub === "string" && tokenSub !== sessionId) {
+    return false;
+  }
+
+  const rawExp = claims.exp;
+  if (typeof rawExp !== "number" || !Number.isFinite(rawExp)) {
+    return false;
+  }
+
+  const nowEpoch = Math.floor(Date.now() / 1000);
+  if (rawExp <= nowEpoch) {
+    return false;
+  }
+
+  return true;
+}
+
+function clearStaleSessionCookies(response: NextResponse): NextResponse {
+  response.cookies.delete("sh_session");
+  response.cookies.delete("sh_access");
+  response.cookies.delete("sh_refresh");
+  response.cookies.delete("sh_csrf");
+  return response;
+}
+
 export function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
@@ -52,10 +101,14 @@ export function proxy(request: NextRequest) {
 
   if (!isPublicPath(pathname)) {
     const sessionCookie = request.cookies.get("sh_session");
-    if (!sessionCookie) {
+    const accessToken = request.cookies.get("sh_access")?.value;
+    const session = parseSessionCookie(sessionCookie?.value);
+
+    if (!sessionCookie || !session || !accessToken || !isValidAccessToken(accessToken, session.id)) {
       const loginUrl = new URL("/auth/login", request.url);
       loginUrl.searchParams.set("redirect", pathname);
-      return NextResponse.redirect(loginUrl);
+
+      return clearStaleSessionCookies(NextResponse.redirect(loginUrl));
     }
   }
 

--- a/proxy.ts
+++ b/proxy.ts
@@ -19,6 +19,24 @@ function isPublicPath(pathname: string): boolean {
   return PUBLIC_PATHS.some((p) => pathname.startsWith(p));
 }
 
+function isAllowedOrigin(rawOrigin: string | null, request: NextRequest): boolean {
+  if (!rawOrigin) {
+    return false;
+  }
+
+  const allowedOrigins = [
+    request.nextUrl.origin,
+    ...(process.env.NEXT_PUBLIC_APP_URL ? [process.env.NEXT_PUBLIC_APP_URL] : []),
+  ];
+
+  try {
+    const parsed = new URL(rawOrigin);
+    return allowedOrigins.includes(parsed.origin);
+  } catch {
+    return false;
+  }
+}
+
 export function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
@@ -26,19 +44,9 @@ export function proxy(request: NextRequest) {
   if (method !== "GET" && method !== "HEAD" && method !== "OPTIONS") {
     const origin = request.headers.get("origin");
     const referer = request.headers.get("referer");
-    if (!origin && !referer) {
+
+    if (!isAllowedOrigin(origin, request) && !isAllowedOrigin(referer, request)) {
       return new NextResponse("Forbidden", { status: 403 });
-    }
-    if (origin) {
-      const allowedOrigins = [
-        request.nextUrl.origin,
-        ...(process.env.NEXT_PUBLIC_APP_URL
-          ? [process.env.NEXT_PUBLIC_APP_URL]
-          : []),
-      ];
-      if (!allowedOrigins.includes(origin)) {
-        return new NextResponse("Forbidden", { status: 403 });
-      }
     }
   }
 


### PR DESCRIPTION
## Summary
- validate same-origin referer fallback for unsafe requests when Origin is absent
- reject stale or mismatched proxy sessions before protected routes load
- stream proxy request bodies instead of buffering JSON-only payloads
- add baseline frontend security headers including CSP
- upgrade Next.js to 16.2.6 to clear the production dependency audit gate

## Verification
- npm audit --omit=dev --audit-level=high
- npm run lint
- npm run typecheck
- npm test
- npm run build