### PR TITLE
fix: harden backend request handling

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,6 +1,7 @@
 # Binary
 bin/
-/server
+server/
+worker/
 
 # Environment
 .env

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -155,6 +155,18 @@ func (c *Config) validate() error {
 		return fmt.Errorf("missing required environment variables: %s", strings.Join(missing, ", "))
 	}
 
+	if c.TwilioAuthToken != "" || c.TwilioAccountSID != "" || c.TwilioWhatsAppNumber != "" {
+		if strings.TrimSpace(c.TwilioAuthToken) == "" {
+			return fmt.Errorf("TWILIO_AUTH_TOKEN must be set when Twilio integration is configured")
+		}
+		if strings.TrimSpace(c.TwilioAccountSID) == "" {
+			return fmt.Errorf("TWILIO_ACCOUNT_SID must be set when TWILIO_AUTH_TOKEN is configured")
+		}
+		if strings.TrimSpace(c.TwilioWhatsAppNumber) == "" {
+			return fmt.Errorf("TWILIO_WHATSAPP_NUMBER must be set when TWILIO_AUTH_TOKEN is configured")
+		}
+	}
+
 	return nil
 }
 

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -118,3 +118,61 @@ func TestLoad_MissingRequired(t *testing.T) {
 		t.Fatal("expected error for missing required fields, got nil")
 	}
 }
+
+func TestLoad_TwilioAuthTokenMustBeConfiguredWithOtherTwilioSettings(t *testing.T) {
+	base := map[string]string{
+		"DATABASE_URL":          "postgres://user:pass@localhost:5432/db",
+		"REDIS_URL":             "redis://localhost:6379",
+		"JWT_SECRET":            "test-secret-that-is-long-enough-32ch",
+		"STRIPE_SECRET_KEY":     "sk_test_123",
+		"STRIPE_WEBHOOK_SECRET": "whsec_123",
+		"RESEND_API_KEY":        "re_123",
+		"AI_BASE_URL":           "https://api.deepseek.com/v1",
+		"AI_API_KEY":            "sk-ai-123",
+		"AI_MODEL":              "deepseek-chat",
+		"APP_BASE_URL":          "http://localhost:3000",
+	}
+
+	defer func() {
+		for k := range base {
+			os.Unsetenv(k)
+		}
+		os.Unsetenv("TWILIO_AUTH_TOKEN")
+		os.Unsetenv("TWILIO_ACCOUNT_SID")
+		os.Unsetenv("TWILIO_WHATSAPP_NUMBER")
+	}()
+
+	for k, v := range base {
+		os.Setenv(k, v)
+	}
+
+	t.Run("missing auth token", func(t *testing.T) {
+		os.Setenv("TWILIO_ACCOUNT_SID", "AC123")
+		os.Setenv("TWILIO_WHATSAPP_NUMBER", "whatsapp:+2782")
+		os.Unsetenv("TWILIO_AUTH_TOKEN")
+
+		if _, err := Load(); err == nil {
+			t.Fatal("expected error when TWILIO_AUTH_TOKEN is missing")
+		}
+	})
+
+	t.Run("missing account sid", func(t *testing.T) {
+		os.Setenv("TWILIO_AUTH_TOKEN", "token")
+		os.Setenv("TWILIO_WHATSAPP_NUMBER", "whatsapp:+2782")
+		os.Unsetenv("TWILIO_ACCOUNT_SID")
+
+		if _, err := Load(); err == nil {
+			t.Fatal("expected error when TWILIO_ACCOUNT_SID is missing")
+		}
+	})
+
+	t.Run("complete configuration passes", func(t *testing.T) {
+		os.Setenv("TWILIO_AUTH_TOKEN", "token")
+		os.Setenv("TWILIO_ACCOUNT_SID", "AC123")
+		os.Setenv("TWILIO_WHATSAPP_NUMBER", "whatsapp:+2782")
+
+		if _, err := Load(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}

--- a/backend/internal/earlyaccess/handler.go
+++ b/backend/internal/earlyaccess/handler.go
@@ -22,23 +22,42 @@ func NewHandler(service Servicer) *Handler {
 
 func (h *Handler) Submit(w http.ResponseWriter, r *http.Request) {
 	var req struct {
-		FullName   string `json:"full_name"`
-		Email      string `json:"email"`
-		SchemeName string `json:"scheme_name"`
-		UnitCount  int32  `json:"unit_count"`
+		FullName      string `json:"full_name"`
+		Email         string `json:"email"`
+		SchemeName    string `json:"scheme_name"`
+		UnitCount     int32  `json:"unit_count"`
+		HoneypotField string `json:"website"`
 	}
 	if err := response.DecodeJSON(r.Body, &req); err != nil {
 		response.Error(w, http.StatusBadRequest, response.CodeBadRequest, "invalid request body")
 		return
 	}
-	if req.FullName == "" || req.Email == "" || req.SchemeName == "" || req.UnitCount <= 0 {
+
+	fullName := strings.TrimSpace(req.FullName)
+	email := strings.ToLower(strings.TrimSpace(req.Email))
+	schemeName := strings.TrimSpace(req.SchemeName)
+
+	if fullName == "" || email == "" || schemeName == "" || req.UnitCount <= 0 {
 		response.Error(w, http.StatusBadRequest, response.CodeBadRequest, "full_name, email, scheme_name, and unit_count are required")
 		return
 	}
+	if len(fullName) > 120 || len(schemeName) > 180 || len(email) > 254 || req.UnitCount > 100000 {
+		response.Error(w, http.StatusBadRequest, response.CodeBadRequest, "full_name, email, scheme_name, and unit_count are required")
+		return
+	}
+	if !auth.ValidateEmail(email) {
+		response.Error(w, http.StatusBadRequest, response.CodeBadRequest, "invalid email format")
+		return
+	}
+	if req.HoneypotField != "" {
+		response.Error(w, http.StatusBadRequest, response.CodeBadRequest, "invalid request")
+		return
+	}
+
 	result, err := h.service.Submit(r.Context(), SubmitParams{
-		FullName:   req.FullName,
-		Email:      req.Email,
-		SchemeName: req.SchemeName,
+		FullName:   fullName,
+		Email:      email,
+		SchemeName: schemeName,
 		UnitCount:  req.UnitCount,
 	})
 	if err != nil {

--- a/backend/internal/earlyaccess/handler_test.go
+++ b/backend/internal/earlyaccess/handler_test.go
@@ -2,22 +2,29 @@ package earlyaccess
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"strconv"
 	"strings"
+	"strconv"
 	"testing"
 	"time"
 )
 
 type stubService struct {
+	submitFn         func(params SubmitParams)
+	submitCalls      int
 	approveByTokenFn    func(id, sig string, exp int64) (*RequestResponse, error)
 	rejectByTokenFn     func(id, sig string, exp int64) (*RequestResponse, error)
 	approveByTokenCalls int
 	rejectByTokenCalls  int
 }
 
-func (s *stubService) Submit(_ context.Context, _ SubmitParams) (*RequestResponse, error) {
+func (s *stubService) Submit(_ context.Context, params SubmitParams) (*RequestResponse, error) {
+	s.submitCalls++
+	if s.submitFn != nil {
+		s.submitFn(params)
+	}
 	return nil, nil
 }
 
@@ -97,5 +104,108 @@ func TestPublicRoutes_ApprovePageHasNoInlineStyles(t *testing.T) {
 
 	if strings.Contains(w.Body.String(), "style=") {
 		t.Fatalf("approve page should not render inline styles: %s", w.Body.String())
+	}
+}
+
+func TestPublicRoutes_RejectsInvalidEarlyAccessSubmission(t *testing.T) {
+	svc := &stubService{}
+	router := NewHandler(svc).PublicRoutes()
+
+	t.Run("invalid email format", func(t *testing.T) {
+		body, _ := json.Marshal(map[string]interface{}{
+			"full_name":   "Person Example",
+			"email":       "not-an-email",
+			"scheme_name": "Green View Estate",
+			"unit_count":  12,
+		})
+		req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(string(body)))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("status=%d, want 400", w.Code)
+		}
+		if svc.submitCalls != 0 {
+			t.Fatalf("submitCalls=%d, want 0", svc.submitCalls)
+		}
+	})
+
+	t.Run("too long fields are rejected", func(t *testing.T) {
+		body, _ := json.Marshal(map[string]interface{}{
+			"full_name":   strings.Repeat("A", 121),
+			"email":       "person@example.com",
+			"scheme_name": strings.Repeat("B", 181),
+			"unit_count":  12,
+		})
+		req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(string(body)))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("status=%d, want 400", w.Code)
+		}
+		if svc.submitCalls != 0 {
+			t.Fatalf("submitCalls=%d, want 0", svc.submitCalls)
+		}
+	})
+
+	t.Run("honeypot field triggers rejection", func(t *testing.T) {
+		body, _ := json.Marshal(map[string]interface{}{
+			"full_name":   "Person Example",
+			"email":       "person@example.com",
+			"scheme_name": "Green View Estate",
+			"unit_count":  12,
+			"website":     "https://spam.example",
+		})
+		req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(string(body)))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("status=%d, want 400", w.Code)
+		}
+		if svc.submitCalls != 0 {
+			t.Fatalf("submitCalls=%d, want 0", svc.submitCalls)
+		}
+	})
+}
+
+func TestPublicRoutes_AcceptsValidEarlyAccessSubmission(t *testing.T) {
+	svc := &stubService{}
+	var captured SubmitParams
+	svc.submitFn = func(params SubmitParams) {
+		captured = params
+	}
+	router := NewHandler(svc).PublicRoutes()
+
+	body, _ := json.Marshal(map[string]interface{}{
+		"full_name":   "Person Example",
+		"email":       "  Person@Example.COM  ",
+		"scheme_name": "  Green View Estate  ",
+		"unit_count":  12,
+	})
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status=%d, want 201", w.Code)
+	}
+	if svc.submitCalls != 1 {
+		t.Fatalf("submitCalls=%d, want 1", svc.submitCalls)
+	}
+	if captured.FullName != "Person Example" {
+		t.Fatalf("fullName=%q, want trimmed value", captured.FullName)
+	}
+	if captured.Email != "person@example.com" {
+		t.Fatalf("email=%q, want normalized lower-case value", captured.Email)
+	}
+	if captured.SchemeName != "Green View Estate" {
+		t.Fatalf("schemeName=%q, want trimmed value", captured.SchemeName)
 	}
 }

--- a/backend/internal/middleware/maxbody.go
+++ b/backend/internal/middleware/maxbody.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stratahq/backend/internal/platform/response"
 )
 
-const maxBodyBytes = 1 << 20 // 1 MiB
+const maxBodyBytes = 10 << 20 // 10 MiB
 
 func MaxBody(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/backend/internal/middleware/maxbody_test.go
+++ b/backend/internal/middleware/maxbody_test.go
@@ -1,0 +1,43 @@
+package middleware
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestMaxBodyHandler_AllowsRequestsWithinLimit(t *testing.T) {
+	handler := MaxBodyHandler()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	body := bytes.Repeat([]byte("a"), maxBodyBytes-1)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/early-access", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d, want 200", w.Code)
+	}
+}
+
+func TestMaxBodyHandler_RejectsRequestsOverLimit(t *testing.T) {
+	handler := MaxBodyHandler()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	body := bytes.Repeat([]byte("a"), maxBodyBytes+1)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/levies/123/statements/import", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status=%d, want 413", w.Code)
+	}
+}
+

--- a/backend/internal/platform/response/json.go
+++ b/backend/internal/platform/response/json.go
@@ -65,8 +65,11 @@ func DecodeJSON(r io.Reader, dst any) error {
 	if err := dec.Decode(dst); err != nil {
 		return err
 	}
-	if dec.More() {
-		return errors.New("trailing tokens after JSON value")
+	if err := dec.Decode(&struct{}{}); err != io.EOF {
+		if err == nil {
+			return errors.New("trailing tokens after JSON value")
+		}
+		return err
 	}
 	return nil
 }

--- a/backend/internal/platform/response/json_test.go
+++ b/backend/internal/platform/response/json_test.go
@@ -2,6 +2,7 @@ package response
 
 import (
 	"encoding/json"
+	"strings"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -82,5 +83,26 @@ func TestError(t *testing.T) {
 	}
 	if resp.Err.Message != "invalid email" {
 		t.Errorf("error.message = %q, want %q", resp.Err.Message, "invalid email")
+	}
+}
+
+func TestDecodeJSONRejectsTrailingTokens(t *testing.T) {
+	payload := strings.NewReader(`{"name":"ok"} {"extra": "value"}`)
+
+	var out map[string]string
+	err := DecodeJSON(payload, &out)
+	if err == nil {
+		t.Fatal("expected error for trailing JSON tokens")
+	}
+}
+
+func TestDecodeJSONRejectsUnknownFields(t *testing.T) {
+	payload := strings.NewReader(` {"name":"ok", "unexpected":"x"}`)
+	var out struct {
+		Name string `json:"name"`
+	}
+	err := DecodeJSON(payload, &out)
+	if err == nil {
+		t.Fatal("expected error for unknown field")
 	}
 }

--- a/backend/internal/server/router.go
+++ b/backend/internal/server/router.go
@@ -111,8 +111,10 @@ func NewRouter(cfg *config.Config, logger *slog.Logger, rdb *redis.Client, audit
 				r.Mount("/billing/webhooks", h.Billing.WebhookRoutes())
 			})
 			r.Group(func(r chi.Router) {
-				r.Use(middleware.PerEndpointRateLimit(rdb, "twilio-webhook", 120, 1*time.Minute))
-				r.Mount("/whatsapp/webhooks", h.WhatsAppWebhook.Routes())
+				if h.WhatsAppWebhook != nil && h.WhatsAppWebhook.HasAuthToken() {
+					r.Use(middleware.PerEndpointRateLimit(rdb, "twilio-webhook", 120, 1*time.Minute))
+					r.Mount("/whatsapp/webhooks", h.WhatsAppWebhook.Routes())
+				}
 			})
 			r.Group(func(r chi.Router) {
 				r.Use(middleware.AuditEvents(auditRecorder, logger))

--- a/backend/internal/server/router_rate_limit_test.go
+++ b/backend/internal/server/router_rate_limit_test.go
@@ -13,7 +13,9 @@ import (
 
 	"github.com/stratahq/backend/internal/audit"
 	"github.com/stratahq/backend/internal/config"
+	"github.com/stratahq/backend/internal/billing"
 	"github.com/stratahq/backend/internal/integrations"
+	"github.com/stratahq/backend/internal/whatsapp"
 )
 
 func newTestRedis(t *testing.T) *redis.Client {
@@ -33,8 +35,12 @@ func newTestRedis(t *testing.T) *redis.Client {
 }
 
 func testHandlers() Handlers {
+	billingService := billing.NewService(nil, nil, "")
+	billingHandler := billing.NewHandler(billingService)
 	return Handlers{
 		Integrations: integrations.NewHandler(integrations.NewService(nil)),
+		Billing:      billingHandler,
+		WhatsAppWebhook: whatsapp.NewWebhookHandler(nil, nil, nil, nil, slog.Default(), "twilio-token"),
 	}
 }
 

--- a/backend/internal/whatsapp/webhook.go
+++ b/backend/internal/whatsapp/webhook.go
@@ -58,6 +58,10 @@ func (h *WebhookHandler) Close() {
 	}
 }
 
+func (h *WebhookHandler) HasAuthToken() bool {
+	return strings.TrimSpace(h.authToken) != ""
+}
+
 func (h *WebhookHandler) Routes() *chi.Mux {
 	r := chi.NewRouter()
 	r.Post("/", h.Inbound)

--- a/backend/internal/whatsapp/webhook_test.go
+++ b/backend/internal/whatsapp/webhook_test.go
@@ -63,3 +63,15 @@ func TestInboundReturnsServiceUnavailableWhenWorkerQueueIsFull(t *testing.T) {
 		t.Fatalf("status = %d, want %d", w.Code, http.StatusServiceUnavailable)
 	}
 }
+
+func TestWebhookHandlerHasAuthToken(t *testing.T) {
+	handlerWithToken := NewWebhookHandler(nil, nil, nil, nil, slog.Default(), "twilio-token")
+	if !handlerWithToken.HasAuthToken() {
+		t.Fatal("expected HasAuthToken to return true when token is configured")
+	}
+
+	handlerWithoutToken := NewWebhookHandler(nil, nil, nil, nil, slog.Default(), "")
+	if handlerWithoutToken.HasAuthToken() {
+		t.Fatal("expected HasAuthToken to return false when token is missing")
+	}
+}


### PR DESCRIPTION
## Summary
- ignore generated backend binaries
- tighten early-access submission validation and honeypot rejection
- reject trailing JSON tokens in decoded API payloads
- raise the API request body limit to 10 MiB with explicit tests
- require complete Twilio webhook configuration before startup enables webhook handling

## Verification
- cd backend && go test ./internal/... -v -race