### PR TITLE
fix: keep frontend health check public

### DIFF
--- a/lib/middleware.test.ts
+++ b/lib/middleware.test.ts
@@ -159,6 +159,15 @@ describe("proxy", () => {
     );
   });
 
+  it("allows frontend health checks without a session", () => {
+    const request = new NextRequest("http://localhost/api/health");
+
+    const response = proxy(request);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("location")).toBeNull();
+  });
+
   it("sets content security policy header", () => {
     const request = new NextRequest("http://localhost/agent", {
       headers: {

--- a/proxy.ts
+++ b/proxy.ts
@@ -10,6 +10,7 @@ const PUBLIC_PATHS = [
   "/auth/invite",
   "/auth/pending",
   "/early-access",
+  "/api/health",
   "/api/session",
   "/api/proxy",
 ];


### PR DESCRIPTION
## Summary
- allow unauthenticated GET requests to the frontend /api/health route through proxy middleware
- add middleware coverage so health checks do not regress into login redirects

## Verification
- npm test -- lib/middleware.test.ts
- npm run lint
- npm run typecheck
- npm test
- npm run build