### PR TITLE
fix: make production load test gate runnable

### DIFF
--- a/backend/tests/load/auth-and-dashboard-config.js
+++ b/backend/tests/load/auth-and-dashboard-config.js
@@ -1,0 +1,62 @@
+function envFlag(value) {
+  return ["1", "true", "yes", "on"].includes(String(value || "").toLowerCase());
+}
+
+function positiveInt(value, fallback) {
+  const parsed = Number.parseInt(String(value || ""), 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+export function emailForVU(baseEmail, vu, env = {}) {
+  if (!envFlag(env.UNIQUE_TEST_USERS)) {
+    return baseEmail;
+  }
+
+  if (!baseEmail.includes("@")) {
+    return baseEmail;
+  }
+
+  return baseEmail.replace("@", `+${vu}@`);
+}
+
+export function protectedEndpointPaths(schemeID) {
+  const endpoints = [
+    "/api/v1/auth/me",
+    "/api/v1/schemes",
+    "/api/v1/levies/attention",
+  ];
+
+  if (schemeID) {
+    endpoints.push(`/api/v1/levies/${schemeID}`);
+    endpoints.push(`/api/v1/maintenance/${schemeID}`);
+  }
+
+  return endpoints;
+}
+
+export function buildLoadOptions(env = {}) {
+  const vus = positiveInt(env.LOAD_VUS || env.VUS, 10);
+  const duration = env.LOAD_DURATION || env.DURATION || "2m";
+
+  return {
+    scenarios: {
+      auth_and_dashboard: {
+        executor: "constant-vus",
+        vus,
+        duration,
+        tags: { scenario: `${vus}_users` },
+      },
+    },
+    thresholds: {
+      login_success: ["rate>0.99"],
+      refresh_blocked: ["rate==0"],
+      repeat_login_fail: ["rate==0"],
+      get_endpoints_fail: ["rate<0.01"],
+      http_req_duration: ["p(95)<1000"],
+    },
+  };
+}
+
+export function shouldPostSummary(env = {}) {
+  return Boolean(env.SUMMARY_URL);
+}

--- a/backend/tests/load/auth-and-dashboard.js
+++ b/backend/tests/load/auth-and-dashboard.js
@@ -1,6 +1,12 @@
 import http from 'k6/http';
 import { check, sleep, group } from 'k6';
 import { Rate } from 'k6/metrics';
+import {
+  buildLoadOptions,
+  emailForVU,
+  protectedEndpointPaths,
+  shouldPostSummary,
+} from './auth-and-dashboard-config.js';
 
 const BASE_URL = __ENV.BASE_URL || 'http://localhost:8080';
 const TEST_EMAIL = __ENV.TEST_EMAIL || 'demo@stratahq.com';
@@ -11,35 +17,7 @@ const refreshBlockedRate = new Rate('refresh_blocked');
 const repeatLoginFailRate = new Rate('repeat_login_fail');
 const getEndpointsFailRate = new Rate('get_endpoints_fail');
 
-export const options = {
-  scenarios: {
-    ten_users: {
-      executor: 'constant-vus',
-      vus: 10,
-      duration: '2m',
-      tags: { scenario: '10_users' },
-    },
-    twentyfive_users: {
-      executor: 'constant-vus',
-      vus: 25,
-      duration: '2m',
-      tags: { scenario: '25_users' },
-    },
-    fifty_users: {
-      executor: 'constant-vus',
-      vus: 50,
-      duration: '2m',
-      tags: { scenario: '50_users' },
-    },
-  },
-  thresholds: {
-    login_success: ['rate>0.99'],
-    refresh_blocked: ['rate==0'],
-    repeat_login_fail: ['rate==0'],
-    get_endpoints_fail: ['rate<0.01'],
-    http_req_duration: ['p(95)<1000'],
-  },
-};
+export const options = buildLoadOptions(__ENV);
 
 function login(email, password) {
   const url = `${BASE_URL}/api/v1/auth/login`;
@@ -97,13 +75,22 @@ function getWithAuth(url, accessToken) {
   return res;
 }
 
+function firstSchemeID(accessToken) {
+  const res = getWithAuth(`${BASE_URL}/api/v1/schemes`, accessToken);
+  if (res.status < 200 || res.status >= 300) {
+    return '';
+  }
+
+  try {
+    const schemes = JSON.parse(res.body).data;
+    return Array.isArray(schemes) && schemes.length > 0 ? schemes[0].id || '' : '';
+  } catch {
+    return '';
+  }
+}
+
 function testProtectedEndpoints(accessToken) {
-  const endpoints = [
-    `/api/v1/auth/me`,
-    `/api/v1/schemes`,
-    `/api/v1/levies`,
-    `/api/v1/maintenance`,
-  ];
+  const endpoints = protectedEndpointPaths(firstSchemeID(accessToken));
 
   let failures = 0;
 
@@ -156,7 +143,7 @@ function testTokenExpiryScenario(email, password) {
 
 export default function () {
   group('Auth and Dashboard Flow', () => {
-    const email = `${TEST_EMAIL.replace('@', `+${__VU}@`)}`;
+    const email = emailForVU(TEST_EMAIL, __VU, __ENV);
     const password = TEST_PASSWORD;
 
     const loginRes = login(email, password);
@@ -202,19 +189,21 @@ export default function () {
 }
 
 export function handleSummary(data) {
-  const summary = {
-    'auth-load-test-summary': http.post(`${__ENV.SUMMARY_URL || 'http://localhost:8081'}/metrics`, JSON.stringify({
+  const output = {
+    stdout: textSummary(data, { indent: ' ', enableColors: true }),
+  };
+
+  if (shouldPostSummary(__ENV)) {
+    http.post(`${__ENV.SUMMARY_URL}/metrics`, JSON.stringify({
       timestamp: new Date().toISOString(),
       vus: __VU,
       data,
     }), {
       headers: { 'Content-Type': 'application/json' },
-    }),
-  };
+    });
+  }
 
-  return {
-    stdout: textSummary(data, { indent: ' ', enableColors: true }),
-  };
+  return output;
 }
 
 function textSummary(data, opts) {

--- a/docs/production-reliability-runbook.md
+++ b/docs/production-reliability-runbook.md
@@ -6,9 +6,22 @@ This document defines the production readiness gates for StrataHQ, focusing on l
 
 ### Tool: k6
 
-Load tests are written in JavaScript using [k6](https://k6.io/docs/). Install k6 locally:
+Load tests are written in JavaScript using [k6](https://k6.io/docs/). Use the
+Docker image when k6 is not installed locally, or install k6 on the workstation:
 
 ```bash
+# Docker, from the repository root
+docker run --rm -i \
+  --network host \
+  -v "$PWD:/work" \
+  grafana/k6 run \
+    -e BASE_URL=http://localhost:8080 \
+    -e TEST_EMAIL=demo@stratahq.com \
+    -e TEST_PASSWORD=Demo2024! \
+    -e LOAD_VUS=10 \
+    -e LOAD_DURATION=2m \
+    /work/backend/tests/load/auth-and-dashboard.js
+
 # macOS
 brew install k6
 
@@ -22,6 +35,10 @@ sudo apt-get update && sudo apt-get install k6
 ### Test Script: auth-and-dashboard.js
 
 The load test script is located at `backend/tests/load/auth-and-dashboard.js`.
+Each invocation runs one load level. Set `LOAD_VUS` and `LOAD_DURATION` for the
+target load. The script uses the documented seeded user by default; set
+`UNIQUE_TEST_USERS=true` only when the target database has matching plus-address
+users seeded for every VU.
 
 It exercises:
 - Login endpoint (`POST /api/v1/auth/login`)
@@ -55,13 +72,30 @@ It exercises:
 
 ```bash
 # 10 concurrent users
-k6 run --vus 10 --duration 2m backend/tests/load/auth-and-dashboard.js
+LOAD_VUS=10 LOAD_DURATION=2m k6 run backend/tests/load/auth-and-dashboard.js
 
 # 25 concurrent users
-k6 run --vus 25 --duration 2m backend/tests/load/auth-and-dashboard.js
+LOAD_VUS=25 LOAD_DURATION=2m k6 run backend/tests/load/auth-and-dashboard.js
 
 # 50 concurrent users
-k6 run --vus 50 --duration 2m backend/tests/load/auth-and-dashboard.js
+LOAD_VUS=50 LOAD_DURATION=2m k6 run backend/tests/load/auth-and-dashboard.js
+```
+
+Docker equivalent:
+
+```bash
+for vus in 10 25 50; do
+  docker run --rm -i \
+    --network host \
+    -v "$PWD:/work" \
+    grafana/k6 run \
+      -e BASE_URL="$BASE_URL" \
+      -e TEST_EMAIL="$TEST_EMAIL" \
+      -e TEST_PASSWORD="$TEST_PASSWORD" \
+      -e LOAD_VUS="$vus" \
+      -e LOAD_DURATION=2m \
+      /work/backend/tests/load/auth-and-dashboard.js
+done
 ```
 
 ### Pass/Fail Thresholds
@@ -163,9 +197,9 @@ npm test
 npm run build
 cd backend && go test ./internal/... -v -race
 cd backend && go test ./tests/integration/... -v -race -tags=integration
-k6 run --vus 10 --duration 2m backend/tests/load/auth-and-dashboard.js
-k6 run --vus 25 --duration 2m backend/tests/load/auth-and-dashboard.js
-k6 run --vus 50 --duration 2m backend/tests/load/auth-and-dashboard.js
+LOAD_VUS=10 LOAD_DURATION=2m k6 run backend/tests/load/auth-and-dashboard.js
+LOAD_VUS=25 LOAD_DURATION=2m k6 run backend/tests/load/auth-and-dashboard.js
+LOAD_VUS=50 LOAD_DURATION=2m k6 run backend/tests/load/auth-and-dashboard.js
 ```
 
 After the aggregated portfolio summary query is deployed, include a dedicated pass through `/agent` portfolio overview during staging verification to confirm summary counts and collection percentage remain correct under load.

--- a/lib/load-test-harness.test.ts
+++ b/lib/load-test-harness.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildLoadOptions,
+  emailForVU,
+  protectedEndpointPaths,
+  shouldPostSummary,
+} from "../backend/tests/load/auth-and-dashboard-config";
+
+describe("production load test harness config", () => {
+  it("uses one documented seeded user by default", () => {
+    expect(emailForVU("demo@stratahq.com", 25, {})).toBe("demo@stratahq.com");
+  });
+
+  it("uses unique per-VU emails only when explicitly enabled", () => {
+    expect(emailForVU("demo@stratahq.com", 25, { UNIQUE_TEST_USERS: "true" })).toBe(
+      "demo+25@stratahq.com",
+    );
+  });
+
+  it("runs one configurable load level per invocation", () => {
+    expect(
+      buildLoadOptions({
+        LOAD_VUS: "25",
+        LOAD_DURATION: "2m",
+      }).scenarios.auth_and_dashboard,
+    ).toMatchObject({
+      executor: "constant-vus",
+      vus: 25,
+      duration: "2m",
+    });
+  });
+
+  it("posts summaries only when SUMMARY_URL is configured", () => {
+    expect(shouldPostSummary({})).toBe(false);
+    expect(shouldPostSummary({ SUMMARY_URL: "http://localhost:8081" })).toBe(true);
+  });
+
+  it("builds scheme-scoped dashboard endpoints from a discovered scheme id", () => {
+    expect(protectedEndpointPaths("scheme-123")).toEqual([
+      "/api/v1/auth/me",
+      "/api/v1/schemes",
+      "/api/v1/levies/attention",
+      "/api/v1/levies/scheme-123",
+      "/api/v1/maintenance/scheme-123",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- make the auth/dashboard k6 load test run one configurable load level per invocation
- use the documented seeded test user by default, with explicit UNIQUE_TEST_USERS opt-in for per-VU users
- discover a scheme ID and hit current scheme-scoped levy and maintenance routes
- disable summary POST unless SUMMARY_URL is explicitly configured
- document Docker-based k6 commands for environments without local k6

## Verification
- npm test -- lib/load-test-harness.test.ts
- npm run lint
- npm run typecheck
- npm test
- npm run build
- node --check backend/tests/load/auth-and-dashboard-config.js
- node --check backend/tests/load/auth-and-dashboard.js
- docker run --rm -i -v "/home/nyasha-hama/projects/stratahq-nextjs-app/stratahq-app:/work" grafana/k6 inspect /work/backend/tests/load/auth-and-dashboard.js
- docker run --rm -i -v "/home/nyasha-hama/projects/stratahq-nextjs-app/stratahq-app:/work" grafana/k6 inspect -e LOAD_VUS=25 -e LOAD_DURATION=2m /work/backend/tests/load/auth-and-dashboard.js