### PR TITLE
fix: make auth rate limits configurable

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -20,6 +20,8 @@ REDIS_URL=redis://localhost:6379
 JWT_SECRET=change-me-in-production           # min 32 characters in production
 JWT_EXPIRY=15m                               # access token TTL
 REFRESH_EXPIRY=168h                          # refresh token TTL (7 days)
+AUTH_LOGIN_RATE_LIMIT=5                      # requests per minute per client IP
+AUTH_REFRESH_RATE_LIMIT=30                   # requests per minute per client IP
 
 # Stripe (use test keys for development)
 STRIPE_SECRET_KEY=sk_test_...

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -50,8 +50,10 @@ type ConfigDurations struct {
 }
 
 type ConfigInts struct {
-	WorkerBatchSize   int32
-	WorkerMaxAttempts int32
+	WorkerBatchSize      int32
+	WorkerMaxAttempts    int32
+	AuthLoginRateLimit   int
+	AuthRefreshRateLimit int
 }
 
 func Load() (*Config, error) {
@@ -105,6 +107,14 @@ func Load() (*Config, error) {
 		return nil, err
 	}
 	cfg.ConfigInts.WorkerMaxAttempts, err = parseInt32("WORKER_MAX_ATTEMPTS", 5)
+	if err != nil {
+		return nil, err
+	}
+	cfg.ConfigInts.AuthLoginRateLimit, err = parseInt("AUTH_LOGIN_RATE_LIMIT", 5)
+	if err != nil {
+		return nil, err
+	}
+	cfg.ConfigInts.AuthRefreshRateLimit, err = parseInt("AUTH_REFRESH_RATE_LIMIT", 30)
 	if err != nil {
 		return nil, err
 	}
@@ -187,6 +197,21 @@ func parseDuration(key string, fallback time.Duration) (time.Duration, error) {
 		return 0, fmt.Errorf("invalid duration for %s: %w", key, err)
 	}
 	return d, nil
+}
+
+func parseInt(key string, fallback int) (int, error) {
+	val := os.Getenv(key)
+	if val == "" {
+		return fallback, nil
+	}
+	i, err := strconv.Atoi(val)
+	if err != nil {
+		return 0, fmt.Errorf("invalid integer for %s: %w", key, err)
+	}
+	if i <= 0 {
+		return 0, fmt.Errorf("invalid integer for %s: must be greater than zero", key)
+	}
+	return i, nil
 }
 
 func parseInt32(key string, fallback int32) (int32, error) {

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -106,6 +106,44 @@ func TestLoad_Defaults(t *testing.T) {
 	if cfg.EmailFrom != "noreply@stratahq.co.za" {
 		t.Errorf("EmailFrom = %q, want default %q", cfg.EmailFrom, "noreply@stratahq.co.za")
 	}
+	if cfg.AuthLoginRateLimit != 5 {
+		t.Errorf("AuthLoginRateLimit = %d, want default %d", cfg.AuthLoginRateLimit, 5)
+	}
+	if cfg.AuthRefreshRateLimit != 30 {
+		t.Errorf("AuthRefreshRateLimit = %d, want default %d", cfg.AuthRefreshRateLimit, 30)
+	}
+}
+
+func TestLoad_AuthRateLimitOverrides(t *testing.T) {
+	required := map[string]string{
+		"DATABASE_URL":            "postgres://user:pass@localhost:5432/db",
+		"REDIS_URL":               "redis://localhost:6379",
+		"JWT_SECRET":              "test-secret-that-is-long-enough-32ch",
+		"RESEND_API_KEY":          "re_123",
+		"AI_BASE_URL":             "https://api.deepseek.com/v1",
+		"AI_API_KEY":              "sk-ai-123",
+		"AI_MODEL":                "deepseek-chat",
+		"APP_BASE_URL":            "http://localhost:3000",
+		"AUTH_LOGIN_RATE_LIMIT":   "120",
+		"AUTH_REFRESH_RATE_LIMIT": "240",
+	}
+
+	for k, v := range required {
+		os.Setenv(k, v)
+		defer os.Unsetenv(k)
+	}
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg.AuthLoginRateLimit != 120 {
+		t.Errorf("AuthLoginRateLimit = %d, want %d", cfg.AuthLoginRateLimit, 120)
+	}
+	if cfg.AuthRefreshRateLimit != 240 {
+		t.Errorf("AuthRefreshRateLimit = %d, want %d", cfg.AuthRefreshRateLimit, 240)
+	}
 }
 
 func TestLoad_MissingRequired(t *testing.T) {

--- a/backend/internal/server/router.go
+++ b/backend/internal/server/router.go
@@ -99,8 +99,8 @@ func NewRouter(cfg *config.Config, logger *slog.Logger, rdb *redis.Client, audit
 			// Auth endpoints with per-endpoint rate limiting
 			r.Route("/auth", func(r chi.Router) {
 				r.Use(middleware.AuditEvents(auditRecorder, logger))
-				r.With(middleware.PerEndpointRateLimit(rdb, "auth-login", 5, 1*time.Minute)).Post("/login", h.Auth.Login)
-				r.With(middleware.PerEndpointRateLimit(rdb, "auth-refresh", 30, 1*time.Minute)).Post("/refresh", h.Auth.Refresh)
+				r.With(middleware.PerEndpointRateLimit(rdb, "auth-login", cfg.AuthLoginRateLimit, 1*time.Minute)).Post("/login", h.Auth.Login)
+				r.With(middleware.PerEndpointRateLimit(rdb, "auth-refresh", cfg.AuthRefreshRateLimit, 1*time.Minute)).Post("/refresh", h.Auth.Refresh)
 				r.With(middleware.PerEndpointRateLimit(rdb, "auth-register", 5, 1*time.Minute)).Post("/register", h.Auth.Register)
 				r.With(middleware.PerEndpointRateLimit(rdb, "auth-logout", 20, 1*time.Minute)).Post("/logout", h.Auth.Logout)
 				r.With(middleware.PerEndpointRateLimit(rdb, "auth-forgot-password", 3, 1*time.Minute)).Post("/forgot-password", h.Auth.ForgotPassword)

--- a/docs/production-reliability-runbook.md
+++ b/docs/production-reliability-runbook.md
@@ -222,6 +222,18 @@ Optional secret:
 - `VERCEL_AUTOMATION_BYPASS_SECRET` - used only for protected Vercel frontend
   health checks
 
+The launch gate runs from a single GitHub Actions runner IP. If the deployed
+backend keeps the conservative defaults (`AUTH_LOGIN_RATE_LIMIT=5` and
+`AUTH_REFRESH_RATE_LIMIT=30` per minute per IP), the 10/25/50-user auth load
+matrix can hit auth throttles before measuring application capacity. For
+staging or production launch-gate windows, set these backend environment
+variables high enough for the matrix, then restore stricter values if desired:
+
+```bash
+AUTH_LOGIN_RATE_LIMIT=240
+AUTH_REFRESH_RATE_LIMIT=480
+```
+
 After the aggregated portfolio summary query is deployed, include a dedicated pass through `/agent` portfolio overview during staging verification to confirm summary counts and collection percentage remain correct under load.
 
 ## Monitoring


### PR DESCRIPTION
## Summary
- add AUTH_LOGIN_RATE_LIMIT and AUTH_REFRESH_RATE_LIMIT backend config with current defaults preserved
- wire auth login/refresh throttles from config instead of hardcoded values
- document Render launch-gate override values for the production reliability gate

## Validation
- go test ./internal/config
- go test ./internal/...