### PR TITLE
fix: use pgbouncer-compatible pgx query mode

### DIFF
--- a/backend/internal/platform/database/database.go
+++ b/backend/internal/platform/database/database.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	dbgen "github.com/stratahq/backend/db/gen"
@@ -20,17 +21,10 @@ type Pool struct {
 // New creates and validates a pgx connection pool with production-ready
 // defaults, then returns a Pool that includes the sqlc query layer.
 func New(ctx context.Context, databaseURL string) (*Pool, error) {
-	cfg, err := pgxpool.ParseConfig(databaseURL)
+	cfg, err := newPoolConfig(databaseURL)
 	if err != nil {
-		return nil, fmt.Errorf("parse database url: %w", err)
+		return nil, err
 	}
-
-	// Sensible defaults — override via DATABASE_URL query params if needed.
-	cfg.MaxConns = 10
-	cfg.MinConns = 2
-	cfg.MaxConnLifetime = time.Hour
-	cfg.MaxConnIdleTime = 30 * time.Minute
-	cfg.HealthCheckPeriod = time.Minute
 
 	pool, err := pgxpool.NewWithConfig(ctx, cfg)
 	if err != nil {
@@ -46,6 +40,23 @@ func New(ctx context.Context, databaseURL string) (*Pool, error) {
 		Pool: pool,
 		Q:    dbgen.New(pool),
 	}, nil
+}
+
+func newPoolConfig(databaseURL string) (*pgxpool.Config, error) {
+	cfg, err := pgxpool.ParseConfig(databaseURL)
+	if err != nil {
+		return nil, fmt.Errorf("parse database url: %w", err)
+	}
+
+	// Sensible defaults — override via DATABASE_URL query params if needed.
+	cfg.ConnConfig.DefaultQueryExecMode = pgx.QueryExecModeExec
+	cfg.MaxConns = 10
+	cfg.MinConns = 2
+	cfg.MaxConnLifetime = time.Hour
+	cfg.MaxConnIdleTime = 30 * time.Minute
+	cfg.HealthCheckPeriod = time.Minute
+
+	return cfg, nil
 }
 
 // Ping implements health.Checker so *Pool can be passed directly to the

--- a/backend/internal/platform/database/database_test.go
+++ b/backend/internal/platform/database/database_test.go
@@ -1,0 +1,18 @@
+package database
+
+import (
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+)
+
+func TestNewPoolConfigUsesPgBouncerCompatibleExecMode(t *testing.T) {
+	cfg, err := newPoolConfig("postgres://user:pass@localhost:5432/db")
+	if err != nil {
+		t.Fatalf("newPoolConfig returned error: %v", err)
+	}
+
+	if got := cfg.ConnConfig.DefaultQueryExecMode; got != pgx.QueryExecModeExec {
+		t.Fatalf("DefaultQueryExecMode = %v, want %v", got, pgx.QueryExecModeExec)
+	}
+}


### PR DESCRIPTION
## Summary
- configure pgx to use non-cached exec mode for database queries
- keep existing pool defaults behind a testable pool config seam
- add regression coverage for the PgBouncer-compatible query mode

## Verification
- go test ./internal/platform/database

## Production note
The launch gate currently fails under concurrent auth because identical credentials return mostly 401/500 under 10 VUs while single login succeeds. Supabase pooler on port 6543 is compatible with non-cached pgx query execution; this avoids prepared-statement cache behavior behind the pooler.