### PR TITLE
fix: use simple protocol for pooled postgres

### DIFF
--- a/backend/internal/platform/database/database.go
+++ b/backend/internal/platform/database/database.go
@@ -49,7 +49,7 @@ func newPoolConfig(databaseURL string) (*pgxpool.Config, error) {
 	}
 
 	// Sensible defaults — override via DATABASE_URL query params if needed.
-	cfg.ConnConfig.DefaultQueryExecMode = pgx.QueryExecModeExec
+	cfg.ConnConfig.DefaultQueryExecMode = pgx.QueryExecModeSimpleProtocol
 	cfg.MaxConns = 10
 	cfg.MinConns = 2
 	cfg.MaxConnLifetime = time.Hour

--- a/backend/internal/platform/database/database_test.go
+++ b/backend/internal/platform/database/database_test.go
@@ -6,13 +6,13 @@ import (
 	"github.com/jackc/pgx/v5"
 )
 
-func TestNewPoolConfigUsesPgBouncerCompatibleExecMode(t *testing.T) {
+func TestNewPoolConfigUsesPgBouncerCompatibleSimpleProtocol(t *testing.T) {
 	cfg, err := newPoolConfig("postgres://user:pass@localhost:5432/db")
 	if err != nil {
 		t.Fatalf("newPoolConfig returned error: %v", err)
 	}
 
-	if got := cfg.ConnConfig.DefaultQueryExecMode; got != pgx.QueryExecModeExec {
-		t.Fatalf("DefaultQueryExecMode = %v, want %v", got, pgx.QueryExecModeExec)
+	if got := cfg.ConnConfig.DefaultQueryExecMode; got != pgx.QueryExecModeSimpleProtocol {
+		t.Fatalf("DefaultQueryExecMode = %v, want %v", got, pgx.QueryExecModeSimpleProtocol)
 	}
 }


### PR DESCRIPTION
## Summary
- switch pgx pooled database queries from exec mode to simple protocol for the Supabase pooler
- keep the regression test covering the pooler-compatible query mode

## Verification
- go test ./internal/platform/database

## Production note
The previous exec-mode hardening merged in #149 caused Render login/register user lookups to fail in production. Simple protocol is the pgx-documented fallback for pooler/proxy compatibility when extended protocol behavior is not supported.