### PR TITLE
fix: allow next inline scripts in CSP

### DIFF
--- a/lib/middleware.test.ts
+++ b/lib/middleware.test.ts
@@ -181,7 +181,7 @@ describe("proxy", () => {
 
     expect(response.status).toBe(200);
     expect(response.headers.get("content-security-policy")).toBe(
-      "default-src 'self'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'",
+      "default-src 'self'; script-src 'self' 'unsafe-inline'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'",
     );
   });
 });

--- a/proxy.ts
+++ b/proxy.ts
@@ -128,7 +128,7 @@ export function proxy(request: NextRequest) {
   );
   response.headers.set(
     "Content-Security-Policy",
-    "default-src 'self'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'",
+    "default-src 'self'; script-src 'self' 'unsafe-inline'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'",
   );
 
   if (process.env.NODE_ENV === "production") {


### PR DESCRIPTION
## Summary
- allow Next.js inline runtime scripts through the frontend CSP
- update middleware CSP coverage to match the new header

## Verification
- Local test command could not run in the clean worktree because vitest dependencies were not installed there; CI will verify.

## Context
The login page was blocked by `default-src self` fallback for inline scripts, causing browser CSP errors and runtime connection failures.