### PR TITLE
fix(#305): add secrets detection CI and sanitize .env.example

### DIFF
--- a/.github/workflows/secrets-detection.yml
+++ b/.github/workflows/secrets-detection.yml
@@ -1,0 +1,65 @@
+name: Secrets Detection
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  detect-secrets:
+    name: Detect committed secrets
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Scan for common secret patterns
+        run: |
+          set -e
+          FOUND=0
+
+          # Patterns that suggest real secrets (not placeholders)
+          PATTERNS=(
+            'sk_live_[A-Za-z0-9]'
+            'sk_test_51[A-Za-z0-9]'
+            'whsec_[a-f0-9]{20,}'
+            're_[A-Za-z0-9_-]{20,}'
+            'AC[a-f0-9]{32}'
+            '[a-f0-9]{32}'
+          )
+
+          # Files to exclude from scanning
+          EXCLUDE='(\.gitignore|\.env\.example|node_modules|go\.sum|package-lock\.json|\.png|\.jpg|\.svg|\.woff|\.woff2|\.ttf|\.eot)'
+
+          echo "Scanning for committed secrets..."
+
+          for pattern in "${PATTERNS[@]}"; do
+            MATCHES=$(git grep -n -E "$pattern" -- ':(exclude)*' 2>/dev/null | grep -v -E "$EXCLUDE" || true)
+            if [ -n "$MATCHES" ]; then
+              echo ""
+              echo "=== Potential secret detected (pattern: $pattern) ==="
+              echo "$MATCHES"
+              FOUND=1
+            fi
+          done
+
+          if [ "$FOUND" -eq 1 ]; then
+            echo ""
+            echo "ERROR: Potential secrets found in committed files."
+            echo "Use placeholder values in tracked files. Real secrets belong in .env (gitignored)."
+            exit 1
+          fi
+
+          echo "No committed secrets detected."
+
+      - name: Check .env files are not tracked
+        run: |
+          TRACKED=$(git ls-files -- '*.env' '*.env.local' '*.env.*.local' 'backend/.env' 'backend/.env.local' || true)
+          if [ -n "$TRACKED" ]; then
+            echo "ERROR: The following .env files are tracked by git:"
+            echo "$TRACKED"
+            echo "Add them to .gitignore and remove from tracking."
+            exit 1
+          fi
+          echo "No .env files are tracked by git."

--- a/.github/workflows/secrets-detection.yml
+++ b/.github/workflows/secrets-detection.yml
@@ -22,20 +22,25 @@ jobs:
           # Patterns that suggest real secrets (not placeholders)
           PATTERNS=(
             'sk_live_[A-Za-z0-9]'
-            'sk_test_51[A-Za-z0-9]'
+            'sk_test_[A-Za-z0-9]{10,}'
             'whsec_[a-f0-9]{20,}'
             're_[A-Za-z0-9_-]{20,}'
-            'AC[a-f0-9]{32}'
-            '[a-f0-9]{32}'
+            'AC[a-f0-9A-F]{32}'
+            'AKIA[A-Z0-9]{16}'
+            'ghp_[A-Za-z0-9]{36}'
+            'gho_[A-Za-z0-9]{36}'
+            'github_pat_[A-Za-z0-9]{22}_[A-Za-z0-9]{59}'
+            'AIza[A-Za-z0-9_-]{35}'
+            '-----BEGIN.*PRIVATE KEY-----'
           )
 
           # Files to exclude from scanning
-          EXCLUDE='(\.gitignore|\.env\.example|node_modules|go\.sum|package-lock\.json|\.png|\.jpg|\.svg|\.woff|\.woff2|\.ttf|\.eot)'
+          EXCLUDE='(\.gitignore|\.env\.example|node_modules|go\.sum|package-lock\.json|yarn\.lock|pnpm-lock\.yaml|\.png$|\.jpg$|\.svg$|\.woff$|\.woff2$|\.ttf$|\.eot$|\.map$)'
 
           echo "Scanning for committed secrets..."
 
           for pattern in "${PATTERNS[@]}"; do
-            MATCHES=$(git grep -n -E "$pattern" -- ':(exclude)*' 2>/dev/null | grep -v -E "$EXCLUDE" || true)
+            MATCHES=$(git grep -n -E "$pattern" 2>/dev/null | grep -v -E "$EXCLUDE" || true)
             if [ -n "$MATCHES" ]; then
               echo ""
               echo "=== Potential secret detected (pattern: $pattern) ==="

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -38,6 +38,9 @@ AI_MODEL=deepseek-chat
 # CORS (comma-separated origins)
 ALLOWED_ORIGINS=http://localhost:3000
 
+# Email
+EMAIL_FROM=no-reply@example.com
+
 # URLs
 APP_BASE_URL=http://localhost:3000           # frontend URL (used for password reset, billing callbacks)
 BACKEND_BASE_URL=http://localhost:8080       # backend URL (used for early-access email action links)


### PR DESCRIPTION
## Summary

- Add GitHub Actions workflow that scans for committed secrets using pattern matching (Stripe keys, Twilio SIDs, API tokens, etc.)
- Verify no `.env` files are tracked by git
- Add missing `EMAIL_FROM` variable to `backend/.env.example`

## Changes

- **New file:** `.github/workflows/secrets-detection.yml` — runs on every push/PR, scans for common secret patterns and ensures no `.env` files are tracked
- **Updated:** `backend/.env.example` — added missing `EMAIL_FROM` variable

## Context

The `backend/.env` file contains live provider secrets on disk. While it is properly `.gitignore`d and was never committed, there was no automated guard to prevent accidental exposure. This PR adds a CI check that will catch any real secrets that accidentally make it into tracked files.

Closes #305