### PR TITLE
fix(#281): require read:levies scope for levy-period endpoint

### DIFF
--- a/backend/internal/integrations/handler.go
+++ b/backend/internal/integrations/handler.go
@@ -200,7 +200,7 @@ func (h *Handler) OpenListUnits(w http.ResponseWriter, r *http.Request) {
 
 func (h *Handler) OpenListLevyPeriods(w http.ResponseWriter, r *http.Request) {
 	identity, ok := integrationIdentity(w, r)
-	if !ok || !requireScope(w, r, identity, "read:schemes") {
+	if !ok || !requireScope(w, r, identity, "read:levies") {
 		return
 	}
 	schemeID := chi.URLParam(r, "schemeId")

--- a/backend/internal/integrations/openapi.json
+++ b/backend/internal/integrations/openapi.json
@@ -29,6 +29,11 @@
     "/schemes": {
       "get": {
         "summary": "List granted schemes",
+        "security": [
+          {
+            "IntegrationBearer": ["read:schemes"]
+          }
+        ],
         "responses": {
           "200": {
             "$ref": "#/components/responses/ListResponse"
@@ -42,6 +47,11 @@
     "/schemes/{schemeId}": {
       "get": {
         "summary": "Get one granted scheme",
+        "security": [
+          {
+            "IntegrationBearer": ["read:schemes"]
+          }
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/SchemeID"
@@ -60,6 +70,11 @@
     "/schemes/{schemeId}/units": {
       "get": {
         "summary": "List units",
+        "security": [
+          {
+            "IntegrationBearer": ["read:schemes"]
+          }
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/SchemeID"
@@ -75,6 +90,11 @@
     "/schemes/{schemeId}/levy-periods": {
       "get": {
         "summary": "List levy periods",
+        "security": [
+          {
+            "IntegrationBearer": ["read:levies"]
+          }
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/SchemeID"
@@ -90,6 +110,11 @@
     "/schemes/{schemeId}/levy-accounts": {
       "get": {
         "summary": "List levy accounts",
+        "security": [
+          {
+            "IntegrationBearer": ["read:levies"]
+          }
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/SchemeID"
@@ -134,6 +159,11 @@
     "/schemes/{schemeId}/levy-payments": {
       "get": {
         "summary": "List levy payments",
+        "security": [
+          {
+            "IntegrationBearer": ["read:levies"]
+          }
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/SchemeID"
@@ -171,6 +201,11 @@
     "/schemes/{schemeId}/financials": {
       "get": {
         "summary": "Get scheme financials",
+        "security": [
+          {
+            "IntegrationBearer": ["read:financials"]
+          }
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/SchemeID"


### PR DESCRIPTION
## Summary

The OpenAPI `/schemes/{schemeId}/levy-periods` endpoint previously required only `read:schemes` scope, which allowed clients with scheme-level access to retrieve financial data (`amount_cents`, `due_date`) that should require `read:levies` scope.

## Changes

- **`handler.go:203`**: Changed scope check from `read:schemes` to `read:levies`, matching the existing requirements on `OpenListLevyAccounts` and `OpenListLevyPayments`
- **`openapi.json`**: Added per-endpoint `security` annotations documenting the required scope for every endpoint (`read:schemes`, `read:levies`, `read:financials`)

## Before

A client with only `read:schemes` scope could call `GET /schemes/{schemeId}/levy-periods` and receive levy amounts and due dates.

## After

The endpoint returns 403 Forbidden unless the client has `read:levies` scope, consistent with the other levy endpoints.

Closes #281