### PR TITLE
fix(#262): scope WhatsApp dashboard counts by user role

### DIFF
--- a/backend/internal/whatsapp/service.go
+++ b/backend/internal/whatsapp/service.go
@@ -174,20 +174,25 @@ func (s *Service) Dashboard(ctx context.Context, identity auth.Identity, schemeI
 		}
 
 		thread := mapThread(row, messages, mediaRows)
-		response.TotalResidents++
-		if row.Connected {
-			response.ConnectedCount++
-		}
-		response.UnreadCount += int(row.UnreadCount)
 
 		if auth.IsResidentRole(access.role) {
 			if sameUnit(row.UnitID, access.memberUnitID) {
 				copy := thread
 				response.ResidentThread = &copy
+				response.TotalResidents = 1
+				if copy.Connected {
+					response.ConnectedCount = 1
+				}
+				response.UnreadCount = copy.Unread
 			}
 			continue
 		}
 
+		response.TotalResidents++
+		if row.Connected {
+			response.ConnectedCount++
+		}
+		response.UnreadCount += int(row.UnreadCount)
 		response.Threads = append(response.Threads, thread)
 	}
 
@@ -206,15 +211,18 @@ func (s *Service) Dashboard(ctx context.Context, identity auth.Identity, schemeI
 		return nil, err
 	}
 	for _, row := range broadcastRows {
-		response.Broadcasts = append(response.Broadcasts, BroadcastInfo{
-			SentByName:     textPointer(row.SentByName),
-			ID:             row.ID.String(),
-			SchemeID:       row.SchemeID.String(),
-			Message:        row.Message,
-			Type:           string(row.Type),
-			SentAt:         row.SentAt,
-			RecipientCount: int(row.RecipientCount),
-		})
+		broadcast := BroadcastInfo{
+			SentByName: textPointer(row.SentByName),
+			ID:         row.ID.String(),
+			SchemeID:   row.SchemeID.String(),
+			Message:    row.Message,
+			Type:       string(row.Type),
+			SentAt:     row.SentAt,
+		}
+		if !auth.IsResidentRole(access.role) {
+			broadcast.RecipientCount = int(row.RecipientCount)
+		}
+		response.Broadcasts = append(response.Broadcasts, broadcast)
 	}
 
 	return response, nil


### PR DESCRIPTION
## Summary

The WhatsApp dashboard endpoint accumulated scheme-wide counts (`total_residents`, `connected_count`, `unread_count`) **before** the role check, so residents received aggregate statistics about other residents in their scheme.

## Changes

- **Moved counting logic inside role branches**: Residents now only see counts for their own thread (`total_residents: 1`, own `connected` status, own `unread` count)
- **Hidden broadcast `recipient_count` from residents**: Residents can still see broadcast messages but no longer see how many recipients received each broadcast

## Before

A resident calling `GET /whatsapp/{schemeId}` would see:
- `total_residents: 15` (all residents in the scheme)
- `connected_count: 12` (all connected residents)
- `unread_count: 47` (all unread messages across all residents)
- `broadcasts[].recipient_count: 15` (how many people got each broadcast)

## After

A resident now sees:
- `total_residents: 1` (just themselves)
- `connected_count: 1` or `0` (their own status)
- `unread_count: N` (only their own unread messages)
- `broadcasts[].recipient_count: 0` (hidden for residents)

Admins and trustees see the same scheme-wide counts as before.

Closes #262