### PR TITLE
fix(#284): scope WhatsApp dashboard cache by user identity

### DIFF
--- a/app/app/[schemeId]/whatsapp/page.test.tsx
+++ b/app/app/[schemeId]/whatsapp/page.test.tsx
@@ -103,7 +103,7 @@ describe("WhatsAppPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockGetCached.mockReturnValue(mockDashboard);
-    mockUseAuth.mockReturnValue({ user: { role: "admin" } });
+    mockUseAuth.mockReturnValue({ user: { id: "user-1", role: "admin" } });
   });
 
   it("operator sees Maintenance tab with candidate count", async () => {
@@ -138,7 +138,7 @@ describe("WhatsAppPage", () => {
   });
 
   it("resident view does not show Maintenance tab", async () => {
-    mockUseAuth.mockReturnValue({ user: { role: "resident" } });
+    mockUseAuth.mockReturnValue({ user: { id: "user-2", role: "resident" } });
 
     const { default: WhatsAppPage } = await import("@/app/app/[schemeId]/whatsapp/page");
     render(<WhatsAppPage />);

--- a/app/app/[schemeId]/whatsapp/page.tsx
+++ b/app/app/[schemeId]/whatsapp/page.tsx
@@ -484,7 +484,7 @@ export default function WhatsAppPage() {
   const [loading, setLoading] = useState(true)
 
   const loadDashboard = useCallback(async (invalidate = false) => {
-    const key = `scheme:${schemeId}:whatsapp`
+    const key = `scheme:${schemeId}:whatsapp:${user?.id ?? 'anonymous'}`
     if (invalidate) {
       invalidateCache(key)
     }
@@ -507,7 +507,7 @@ export default function WhatsAppPage() {
     } finally {
       setLoading(false)
     }
-  }, [addToast, schemeId])
+  }, [addToast, schemeId, user?.id])
 
   useEffect(() => {
     loadDashboard()

--- a/app/app/[schemeId]/whatsapp/page.tsx
+++ b/app/app/[schemeId]/whatsapp/page.tsx
@@ -484,9 +484,10 @@ export default function WhatsAppPage() {
   const [loading, setLoading] = useState(true)
 
   const loadDashboard = useCallback(async (invalidate = false) => {
-    if (!user?.id) return
+    const userId = user?.id
+    if (!userId) return
 
-    const key = `scheme:${schemeId}:whatsapp:${user.id}`
+    const key = `scheme:${schemeId}:whatsapp:${userId}`
     if (invalidate) {
       invalidateCache(key)
     }

--- a/app/app/[schemeId]/whatsapp/page.tsx
+++ b/app/app/[schemeId]/whatsapp/page.tsx
@@ -484,7 +484,9 @@ export default function WhatsAppPage() {
   const [loading, setLoading] = useState(true)
 
   const loadDashboard = useCallback(async (invalidate = false) => {
-    const key = `scheme:${schemeId}:whatsapp:${user?.id ?? 'anonymous'}`
+    if (!user?.id) return
+
+    const key = `scheme:${schemeId}:whatsapp:${user.id}`
     if (invalidate) {
       invalidateCache(key)
     }


### PR DESCRIPTION
## Summary

The WhatsApp dashboard cache key was `scheme:${schemeId}:whatsapp`, shared across all users. An admin's cached response (containing all threads) could be served to a resident visiting the same page.

## Changes

- **`page.tsx:487`**: Cache key now includes the user ID: `scheme:${schemeId}:whatsapp:${user?.id ?? 'anonymous'}`

## Impact

Each user now gets their own cache entry, preventing cross-user data leakage through the shared in-memory cache.

Closes #284