### PR TITLE
fix(#375): add CSRF protection to copilot API route

### DIFF
--- a/app/api/copilot/route.test.ts
+++ b/app/api/copilot/route.test.ts
@@ -4,6 +4,7 @@ vi.mock("next/headers", () => ({
   cookies: vi.fn(async () => ({
     get: vi.fn((name: string) => {
       if (name === "sh_access") return { value: "access-token" };
+      if (name === "sh_csrf") return { value: "csrf-token" };
       return undefined;
     }),
   })),
@@ -25,7 +26,7 @@ describe("copilot route", () => {
     const { POST } = await import("./route");
     const request = new Request("http://localhost/api/copilot", {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", "x-csrf-token": "csrf-token" },
       body: JSON.stringify({ message: "hello", history: [] }),
     });
 

--- a/app/api/copilot/route.ts
+++ b/app/api/copilot/route.ts
@@ -13,6 +13,15 @@ export async function POST(request: NextRequest) {
     return new Response('Missing access token.', { status: 401, headers: { 'Content-Type': 'text/plain' } })
   }
 
+  const csrfCookie = cookieStore.get('sh_csrf')?.value
+  const csrfHeader = request.headers.get('x-csrf-token')
+  if (!csrfCookie || !csrfHeader || csrfHeader !== csrfCookie) {
+    return new Response(JSON.stringify({ error: { code: 'FORBIDDEN', message: 'Invalid CSRF token' } }), {
+      status: 403,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
   const body = await request.json()
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), COPILOT_TIMEOUT_MS);

--- a/components/Copilot.tsx
+++ b/components/Copilot.tsx
@@ -3,6 +3,7 @@ import { useState, useRef, useEffect } from 'react'
 import { usePathname } from 'next/navigation'
 import { useAuth } from '@/lib/auth'
 import { isResidentRole } from '@/lib/session'
+import { readBrowserCSRFToken } from '@/lib/csrf'
 
 interface Message {
   role: 'user' | 'assistant'
@@ -54,10 +55,16 @@ export default function Copilot() {
     setStreamingContent('')
     setError(null)
 
+    const csrfToken = readBrowserCSRFToken()
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+    if (csrfToken) {
+      headers['x-csrf-token'] = csrfToken
+    }
+
     try {
       const response = await fetch('/api/copilot', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers,
         body: JSON.stringify({ message: text.trim(), history, scheme_id: schemeId }),
       })
 


### PR DESCRIPTION
Adds CSRF token validation to the copilot API route matching the pattern used by proxy and session-refresh routes.

Closes #375