### PR TITLE
fix(#346,#347): prevent bank statement auto-matching overpay

### DIFF
--- a/backend/internal/levy/bank_statement_import.go
+++ b/backend/internal/levy/bank_statement_import.go
@@ -225,6 +225,13 @@ func matchBankStatementRow(row ParsedBankStatementRow, accounts []candidateLevyA
 	}
 
 	if len(candidates) == 1 {
+		if row.AmountCents > candidates[0].OutstandingCents {
+			return matchedBankStatementRow{
+				Status:     dbgen.BankStatementRowStatusAmbiguous,
+				Confidence: 50,
+				Reason:     fmt.Sprintf("unit %s matched but amount %d exceeds outstanding %d", candidates[0].UnitIdentifier, row.AmountCents, candidates[0].OutstandingCents),
+			}
+		}
 		return matchedBankStatementRow{
 			Status:               dbgen.BankStatementRowStatusMatched,
 			MatchedLevyAccountID: &candidates[0].LevyAccountID,
@@ -722,6 +729,17 @@ func (s *Service) ProcessBankStatementImport(ctx context.Context, importID strin
 						PaidDate:  dateValue(parsed.TransactionDate),
 					}); updErr != nil {
 						return updErr
+					}
+					for ai := range accounts {
+						if accounts[ai].LevyAccountID == acct.ID {
+							accounts[ai].PaidCents = newPaid
+							remaining := acct.AmountCents - newPaid
+							if remaining < 0 {
+								remaining = 0
+							}
+							accounts[ai].OutstandingCents = remaining
+							break
+						}
 					}
 				}
 				if _, updErr := q.UpdateBankStatementRowApplied(ctx, dbgen.UpdateBankStatementRowAppliedParams{

--- a/backend/internal/levy/bank_statement_import_test.go
+++ b/backend/internal/levy/bank_statement_import_test.go
@@ -163,3 +163,39 @@ func TestMatchAmbiguousResolvedByAmountWhenSingleExactMatch(t *testing.T) {
 		t.Fatal("expected amount-disambiguated match")
 	}
 }
+
+func TestMatchMarksOverpayAsAmbiguous(t *testing.T) {
+	account := candidateLevyAccount{
+		LevyAccountID:    uuid.New(),
+		UnitIdentifier:   "5C",
+		OwnerName:        "Over Payer",
+		OutstandingCents: 100000,
+	}
+	row := ParsedBankStatementRow{
+		AmountCents: 1000000,
+		Reference:   "EFT 5C",
+		Description: "Overpaid levy",
+	}
+	got := matchBankStatementRow(row, []candidateLevyAccount{account})
+	if got.Status != "ambiguous" {
+		t.Fatalf("status = %q, want ambiguous", got.Status)
+	}
+}
+
+func TestMatchAllowsPartialPaymentOnSingleCandidate(t *testing.T) {
+	account := candidateLevyAccount{
+		LevyAccountID:    uuid.New(),
+		UnitIdentifier:   "3B",
+		OwnerName:        "Partial Payer",
+		OutstandingCents: 200000,
+	}
+	row := ParsedBankStatementRow{
+		AmountCents: 50000,
+		Reference:   "EFT 3B",
+		Description: "Partial levy payment",
+	}
+	got := matchBankStatementRow(row, []candidateLevyAccount{account})
+	if got.Status != "matched" {
+		t.Fatalf("status = %q, want matched", got.Status)
+	}
+}


### PR DESCRIPTION
Two fixes for bank statement import matching:

1. Single-candidate unit matches now check amount <= outstanding before auto-matching. Overpaying amounts are marked ambiguous for manual review (#347).

2. In-memory outstanding balance is updated after each successful auto-apply, preventing the same account from being matched by multiple rows after it's already been paid (#346).

Closes #346
Closes #347