### PR TITLE
fix(#231): prevent checkout_completed from downgrading active entitlements

### DIFF
--- a/backend/internal/billing/service.go
+++ b/backend/internal/billing/service.go
@@ -236,6 +236,9 @@ func (s *Service) HandleWebhook(ctx context.Context, payload []byte, signature s
 	}
 
 	status := pickString(event.Status, pickString(existing.Status, "inactive"))
+	if event.Status == "checkout_completed" && entitlementActive(existing.Status) {
+		status = existing.Status
+	}
 	planCode := pickString(event.PlanCode, pickString(existing.PlanCode, defaultPlanCode))
 
 	_, err = s.db.Q.UpsertOrgSubscription(ctx, dbgen.UpsertOrgSubscriptionParams{


### PR DESCRIPTION
When a checkout.session.completed webhook arrives after customer.subscription.updated has already set status to active, the checkout_completed status no longer overwrites the active status.

Closes #231