### PR TITLE
fix(#207): scope levy payment idempotency by account

### DIFF
--- a/backend/internal/levy/bank_statement_import.go
+++ b/backend/internal/levy/bank_statement_import.go
@@ -786,7 +786,10 @@ func formatRowDate(value pgtype.Date) string {
 
 func ensureLevyPayment(ctx context.Context, q *dbgen.Queries, accountID uuid.UUID, amountCents int64, paymentDate time.Time, reference string, bankRef pgtype.Text) (dbgen.LevyPayment, bool, error) {
 	if existing, err := q.GetLevyPaymentByReference(ctx, reference); err == nil {
-		return existing, false, nil
+		if existing.LevyAccountID == accountID {
+			return existing, false, nil
+		}
+		reference = reference + ":" + accountID.String()[:8]
 	} else if !errors.Is(err, pgx.ErrNoRows) {
 		return dbgen.LevyPayment{}, false, err
 	}
@@ -804,7 +807,10 @@ func ensureLevyPayment(ctx context.Context, q *dbgen.Queries, accountID uuid.UUI
 			if getErr != nil {
 				return dbgen.LevyPayment{}, false, getErr
 			}
-			return existing, false, nil
+			if existing.LevyAccountID == accountID {
+				return existing, false, nil
+			}
+			return dbgen.LevyPayment{}, false, fmt.Errorf("reference %s already used by another levy account", reference)
 		}
 		return dbgen.LevyPayment{}, false, err
 	}

--- a/backend/internal/levy/service.go
+++ b/backend/internal/levy/service.go
@@ -362,7 +362,15 @@ func (s *Service) Reconcile(ctx context.Context, identity auth.Identity, schemeI
 			return nil, ErrInvalidInput
 		}
 
-		if _, err := q.GetLevyPaymentByReference(ctx, payment.Reference); err == nil {
+		if existing, err := q.GetLevyPaymentByReference(ctx, payment.Reference); err == nil {
+			accountID, parseErr := uuid.Parse(payment.AccountID)
+			if parseErr != nil {
+				return nil, ErrInvalidInput
+			}
+			if existing.LevyAccountID == accountID {
+				result.SkippedCount++
+				continue
+			}
 			result.SkippedCount++
 			continue
 		} else if !errors.Is(err, pgx.ErrNoRows) {


### PR DESCRIPTION
ensureLevyPayment now verifies that an existing payment with the same reference belongs to the intended levy account before reusing it. Cross-scheme reference collisions get a qualified reference instead of silently linking to the wrong payment.

Reconciliation also verifies account ownership before skipping duplicate references.

Closes #207