### PR TITLE
fix(#169,#338): verify levy account belongs to requested scheme

### DIFF
--- a/backend/db/gen/levy.sql.go
+++ b/backend/db/gen/levy.sql.go
@@ -240,6 +240,26 @@ func (q *Queries) GetLevyPeriod(ctx context.Context, id uuid.UUID) (LevyPeriod, 
 	return i, err
 }
 
+const levyAccountBelongsToScheme = `-- name: LevyAccountBelongsToScheme :one
+SELECT EXISTS(
+    SELECT 1 FROM levy_accounts la
+    JOIN levy_periods lp ON lp.id = la.period_id
+    WHERE la.id = $1 AND lp.scheme_id = $2
+) AS belongs
+`
+
+type LevyAccountBelongsToSchemeParams struct {
+	ID       uuid.UUID `json:"id"`
+	SchemeID uuid.UUID `json:"scheme_id"`
+}
+
+func (q *Queries) LevyAccountBelongsToScheme(ctx context.Context, arg LevyAccountBelongsToSchemeParams) (bool, error) {
+	row := q.db.QueryRow(ctx, levyAccountBelongsToScheme, arg.ID, arg.SchemeID)
+	var belongs bool
+	err := row.Scan(&belongs)
+	return belongs, err
+}
+
 const listLevyAccountsByPeriod = `-- name: ListLevyAccountsByPeriod :many
 SELECT la.id, la.unit_id, la.period_id, la.amount_cents, la.paid_cents, la.status, la.due_date, la.paid_date, la.created_at, la.updated_at, u.identifier AS unit_identifier, u.owner_name
 FROM levy_accounts la

--- a/backend/db/queries/levy.sql
+++ b/backend/db/queries/levy.sql
@@ -29,6 +29,13 @@ SELECT * FROM levy_accounts
 WHERE id = $1
 LIMIT 1;
 
+-- name: LevyAccountBelongsToScheme :one
+SELECT EXISTS(
+    SELECT 1 FROM levy_accounts la
+    JOIN levy_periods lp ON lp.id = la.period_id
+    WHERE la.id = $1 AND lp.scheme_id = $2
+) AS belongs;
+
 -- name: GetLevyAccountByUnitAndPeriod :one
 SELECT * FROM levy_accounts
 WHERE unit_id = $1 AND period_id = $2

--- a/backend/internal/levy/service.go
+++ b/backend/internal/levy/service.go
@@ -494,6 +494,28 @@ func (s *Service) resolveSchemeAccess(ctx context.Context, identity auth.Identit
 	return scheme, membership.Role, unitID, nil
 }
 
+func (s *Service) requireAccountForScheme(ctx context.Context, schemeID, accountID string) error {
+	accountUUID, err := uuid.Parse(accountID)
+	if err != nil {
+		return ErrInvalidInput
+	}
+	schemeUUID, err := uuid.Parse(schemeID)
+	if err != nil {
+		return ErrInvalidInput
+	}
+	belongs, err := s.db.Q.LevyAccountBelongsToScheme(ctx, dbgen.LevyAccountBelongsToSchemeParams{
+		ID:       accountUUID,
+		SchemeID: schemeUUID,
+	})
+	if err != nil {
+		return err
+	}
+	if !belongs {
+		return ErrNotFound
+	}
+	return nil
+}
+
 func (s *Service) buildTrend(ctx context.Context, periods []dbgen.LevyPeriod) ([]CollectionTrendPoint, error) {
 	if len(periods) == 0 {
 		return []CollectionTrendPoint{}, nil
@@ -867,6 +889,10 @@ func (s *Service) CollectionEvents(ctx context.Context, identity auth.Identity, 
 		return nil, ErrForbidden
 	}
 
+	if err := s.requireAccountForScheme(ctx, schemeID, accountID); err != nil {
+		return nil, err
+	}
+
 	events, err := s.db.Q.ListCollectionEventsByAccountIDs(ctx, []uuid.UUID{uuid.MustParse(accountID)})
 	if err != nil {
 		return nil, err
@@ -907,6 +933,10 @@ func (s *Service) RecordCollectionEvent(ctx context.Context, identity auth.Ident
 	}
 	if role == string(auth.RoleResident) {
 		return nil, ErrForbidden
+	}
+
+	if err := s.requireAccountForScheme(ctx, schemeID, accountID); err != nil {
+		return nil, err
 	}
 
 	accountUUID := uuid.MustParse(accountID)
@@ -1051,6 +1081,16 @@ func (s *Service) loadReminderContext(ctx context.Context, identity auth.Identit
 }
 
 func (s *Service) ReminderDraft(ctx context.Context, identity auth.Identity, schemeID, accountID string) (*ReminderDraftResponse, error) {
+	if _, role, _, err := s.resolveSchemeAccess(ctx, identity, schemeID); err != nil {
+		return nil, err
+	} else if role == string(auth.RoleResident) {
+		return nil, ErrForbidden
+	}
+
+	if err := s.requireAccountForScheme(ctx, schemeID, accountID); err != nil {
+		return nil, err
+	}
+
 	account, err := s.loadReminderContext(ctx, identity, schemeID, accountID)
 	if err != nil {
 		return nil, err
@@ -1062,6 +1102,16 @@ func (s *Service) ReminderDraft(ctx context.Context, identity auth.Identity, sch
 func (s *Service) SendReminder(ctx context.Context, identity auth.Identity, schemeID, accountID string, input SendReminderInput) (*CollectionEvent, error) {
 	if !input.Email.Enabled && !input.WhatsApp.Enabled {
 		return nil, ErrInvalidInput
+	}
+
+	if _, role, _, err := s.resolveSchemeAccess(ctx, identity, schemeID); err != nil {
+		return nil, err
+	} else if role == string(auth.RoleResident) {
+		return nil, ErrForbidden
+	}
+
+	if err := s.requireAccountForScheme(ctx, schemeID, accountID); err != nil {
+		return nil, err
 	}
 
 	account, err := s.loadReminderContext(ctx, identity, schemeID, accountID)

--- a/backend/internal/levy/service.go
+++ b/backend/internal/levy/service.go
@@ -935,7 +935,7 @@ func (s *Service) RecordCollectionEvent(ctx context.Context, identity auth.Ident
 		return nil, ErrForbidden
 	}
 
-	if err := s.requireAccountForScheme(ctx, schemeID, accountID); err != nil {
+	if err = s.requireAccountForScheme(ctx, schemeID, accountID); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Adds requireAccountForScheme helper that joins levy_accounts through levy_periods to verify the account belongs to the authorized scheme.

Applied to:
- CollectionEvents: verifies account belongs to scheme before listing events
- RecordCollectionEvent: verifies account belongs to scheme before creating events
- ReminderDraft: adds missing resolveSchemeAccess call + account verification
- SendReminder: adds scheme access check + account verification

Also adds LevyAccountBelongsToScheme SQL query.

Closes #169
Closes #338