### PR TITLE
fix(#253): gate product access on active billing entitlement

### DIFF
--- a/backend/internal/billing/service.go
+++ b/backend/internal/billing/service.go
@@ -119,7 +119,7 @@ func (s *Service) GetSubscription(ctx context.Context, identity auth.Identity) (
 func (s *Service) HasActiveEntitlement(ctx context.Context, identity auth.Identity) (bool, error) {
 	orgID, err := uuid.Parse(identity.OrgID)
 	if err != nil {
-		return false, nil
+		return false, err
 	}
 
 	subscription, err := s.db.Q.GetOrgSubscription(ctx, orgID)

--- a/backend/internal/billing/service.go
+++ b/backend/internal/billing/service.go
@@ -116,6 +116,23 @@ func (s *Service) GetSubscription(ctx context.Context, identity auth.Identity) (
 	return &response, nil
 }
 
+func (s *Service) HasActiveEntitlement(ctx context.Context, identity auth.Identity) (bool, error) {
+	orgID, err := uuid.Parse(identity.OrgID)
+	if err != nil {
+		return false, nil
+	}
+
+	subscription, err := s.db.Q.GetOrgSubscription(ctx, orgID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	return entitlementActive(subscription.Status), nil
+}
+
 func (s *Service) CreateCheckoutSession(ctx context.Context, identity auth.Identity) (*CheckoutResponse, error) {
 	org, err := s.requireAdminOrg(ctx, identity)
 	if err != nil {

--- a/backend/internal/middleware/entitlement.go
+++ b/backend/internal/middleware/entitlement.go
@@ -1,0 +1,63 @@
+package middleware
+
+import (
+	"net/http"
+	"strings"
+	"errors"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/stratahq/backend/internal/billing"
+	"github.com/stratahq/backend/internal/auth"
+	"github.com/stratahq/backend/internal/platform/response"
+)
+
+func Entitlement(svc *billing.Service) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			path := r.URL.Path
+
+			if isExemptFromEntitlement(path) {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			identity, ok := auth.IdentityFromRequest(r)
+			if !ok {
+				response.Error(w, http.StatusUnauthorized, response.CodeUnauthorized, "missing auth context")
+				return
+			}
+
+			subscription, err := svc.GetSubscription(r.Context(), identity)
+			if err != nil {
+				if errors.Is(err, pgx.ErrNoRows) || errors.Is(err, billing.ErrForbidden) {
+					response.Error(w, http.StatusForbidden, response.CodeForbidden, "subscription required")
+					return
+				}
+				response.Error(w, http.StatusInternalServerError, response.CodeInternalError, "failed to check subscription")
+				return
+			}
+
+			if !subscription.EntitlementActive {
+				response.Error(w, http.StatusForbidden, response.CodeForbidden, "active subscription required")
+				return
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+func isExemptFromEntitlement(path string) bool {
+	exemptPrefixes := []string{
+		"/api/v1/auth/",
+		"/api/v1/billing/",
+		"/api/v1/onboarding",
+	}
+	for _, prefix := range exemptPrefixes {
+		if strings.HasPrefix(path, prefix) {
+			return true
+		}
+	}
+	return false
+}

--- a/backend/internal/middleware/entitlement.go
+++ b/backend/internal/middleware/entitlement.go
@@ -1,18 +1,16 @@
 package middleware
 
 import (
+	"log/slog"
 	"net/http"
 	"strings"
-	"errors"
 
-	"github.com/jackc/pgx/v5"
-
-	"github.com/stratahq/backend/internal/billing"
 	"github.com/stratahq/backend/internal/auth"
+	"github.com/stratahq/backend/internal/billing"
 	"github.com/stratahq/backend/internal/platform/response"
 )
 
-func Entitlement(svc *billing.Service) func(http.Handler) http.Handler {
+func Entitlement(svc *billing.Service, logger *slog.Logger) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			path := r.URL.Path
@@ -28,17 +26,14 @@ func Entitlement(svc *billing.Service) func(http.Handler) http.Handler {
 				return
 			}
 
-			subscription, err := svc.GetSubscription(r.Context(), identity)
+			active, err := svc.HasActiveEntitlement(r.Context(), identity)
 			if err != nil {
-				if errors.Is(err, pgx.ErrNoRows) || errors.Is(err, billing.ErrForbidden) {
-					response.Error(w, http.StatusForbidden, response.CodeForbidden, "subscription required")
-					return
-				}
+				logger.Error("entitlement check failed", "error", err)
 				response.Error(w, http.StatusInternalServerError, response.CodeInternalError, "failed to check subscription")
 				return
 			}
 
-			if !subscription.EntitlementActive {
+			if !active {
 				response.Error(w, http.StatusForbidden, response.CodeForbidden, "active subscription required")
 				return
 			}

--- a/backend/internal/server/router.go
+++ b/backend/internal/server/router.go
@@ -141,7 +141,7 @@ func NewRouter(cfg *config.Config, logger *slog.Logger, rdb *redis.Client, audit
 			r.Use(middleware.Auth(cfg.JWTSecret, cfg.JWTIssuer, cfg.JWTAudience))
 			r.Use(middleware.AuditEvents(auditRecorder, logger))
 			if h.BillingService != nil {
-				r.Use(middleware.Entitlement(h.BillingService))
+				r.Use(middleware.Entitlement(h.BillingService, logger))
 			}
 			r.Get("/auth/me", h.Auth.Me)
 			r.Patch("/auth/profile", h.Auth.UpdateProfile)

--- a/backend/internal/server/router.go
+++ b/backend/internal/server/router.go
@@ -47,6 +47,7 @@ type Handlers struct {
 	WhatsApp        *whatsapp.Handler
 	WhatsAppWebhook *whatsapp.WebhookHandler
 	Billing         *billing.Handler
+	BillingService  *billing.Service
 	Contractors     *contractors.Handler
 	Invitation      *invitation.Handler
 	EarlyAccess     *earlyaccess.Handler
@@ -139,6 +140,9 @@ func NewRouter(cfg *config.Config, logger *slog.Logger, rdb *redis.Client, audit
 		r.Group(func(r chi.Router) {
 			r.Use(middleware.Auth(cfg.JWTSecret, cfg.JWTIssuer, cfg.JWTAudience))
 			r.Use(middleware.AuditEvents(auditRecorder, logger))
+			if h.BillingService != nil {
+				r.Use(middleware.Entitlement(h.BillingService))
+			}
 			r.Get("/auth/me", h.Auth.Me)
 			r.Patch("/auth/profile", h.Auth.UpdateProfile)
 			r.Patch("/auth/org", h.Auth.UpdateOrg)

--- a/backend/internal/server/router_rate_limit_test.go
+++ b/backend/internal/server/router_rate_limit_test.go
@@ -38,8 +38,9 @@ func testHandlers() Handlers {
 	billingService := billing.NewService(nil, nil, "")
 	billingHandler := billing.NewHandler(billingService)
 	return Handlers{
-		Integrations: integrations.NewHandler(integrations.NewService(nil)),
-		Billing:      billingHandler,
+		Integrations:   integrations.NewHandler(integrations.NewService(nil)),
+		Billing:        billingHandler,
+		BillingService: billingService,
 		WhatsAppWebhook: whatsapp.NewWebhookHandler(nil, nil, nil, nil, slog.Default(), "twilio-token"),
 	}
 }


### PR DESCRIPTION
Adds entitlement middleware that checks the org's subscription status before allowing access to protected product routes.

- Auth routes (/auth/me, /auth/profile, /auth/org, /auth/change-password) are exempt so users can manage their account
- Billing routes (/billing/) are exempt so users can start/manage subscriptions  
- Onboarding routes are exempt for new org setup
- All other protected routes (/schemes, /financials, /levies, etc.) require active or trialing subscription
- Middleware is nil-safe: skips entitlement check if BillingService is not configured

Closes #253