### PR TITLE
fix(#183): force row-level security for all public tables

### DIFF
--- a/backend/db/migrations/00030_rls_force_and_policies.sql
+++ b/backend/db/migrations/00030_rls_force_and_policies.sql
@@ -1,0 +1,114 @@
+-- +goose Up
+
+-- Step 1: Add permissive policies on every table that has RLS enabled
+-- but no policies yet. This ensures data remains accessible after FORCE
+-- ROW LEVEL SECURITY is applied in step 2.
+-- +goose StatementBegin
+DO $$
+DECLARE
+    row_record RECORD;
+BEGIN
+    FOR row_record IN
+        SELECT t.schemaname, t.tablename
+        FROM pg_tables t
+        JOIN pg_class c ON c.relname = t.tablename AND c.relnamespace = (
+            SELECT oid FROM pg_namespace WHERE nspname = t.schemaname
+        )
+        WHERE t.schemaname = 'public'
+          AND t.tablename <> 'goose_db_version'
+          AND c.relrowsecurity = true
+          AND NOT EXISTS (
+              SELECT 1 FROM pg_policy p
+              WHERE p.polrelid = c.oid
+          )
+    LOOP
+        EXECUTE format(
+            'CREATE POLICY rls_default ON %I.%I FOR ALL USING (true) WITH CHECK (true)',
+            row_record.schemaname,
+            row_record.tablename
+        );
+    END LOOP;
+END $$;
+-- +goose StatementEnd
+
+-- Step 2: Force RLS on all public tables where it is enabled.
+-- This ensures even the table owner (the application's database role)
+-- is subject to RLS policies.
+-- +goose StatementBegin
+DO $$
+DECLARE
+    row_record RECORD;
+BEGIN
+    FOR row_record IN
+        SELECT t.schemaname, t.tablename
+        FROM pg_tables t
+        JOIN pg_class c ON c.relname = t.tablename AND c.relnamespace = (
+            SELECT oid FROM pg_namespace WHERE nspname = t.schemaname
+        )
+        WHERE t.schemaname = 'public'
+          AND t.tablename <> 'goose_db_version'
+          AND c.relrowsecurity = true
+    LOOP
+        EXECUTE format(
+            'ALTER TABLE %I.%I FORCE ROW LEVEL SECURITY',
+            row_record.schemaname,
+            row_record.tablename
+        );
+    END LOOP;
+END $$;
+-- +goose StatementEnd
+
+
+-- +goose Down
+
+-- Remove forced RLS and default policies
+-- +goose StatementBegin
+DO $$
+DECLARE
+    row_record RECORD;
+BEGIN
+    FOR row_record IN
+        SELECT t.schemaname, t.tablename
+        FROM pg_tables t
+        JOIN pg_class c ON c.relname = t.tablename AND c.relnamespace = (
+            SELECT oid FROM pg_namespace WHERE nspname = t.schemaname
+        )
+        WHERE t.schemaname = 'public'
+          AND t.tablename <> 'goose_db_version'
+          AND c.relrowsecurity = true
+          AND c.relforcerowsecurity = true
+    LOOP
+        EXECUTE format(
+            'ALTER TABLE %I.%I NO FORCE ROW LEVEL SECURITY',
+            row_record.schemaname,
+            row_record.tablename
+        );
+    END LOOP;
+END $$;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+DO $$
+DECLARE
+    row_record RECORD;
+BEGIN
+    FOR row_record IN
+        SELECT p.polname, t.schemaname, t.tablename
+        FROM pg_policy p
+        JOIN pg_class c ON c.oid = p.polrelid
+        JOIN pg_tables t ON t.tablename = c.relname
+            AND t.schemaname = (
+                SELECT nspname FROM pg_namespace WHERE oid = c.relnamespace
+            )
+        WHERE p.polname = 'rls_default'
+          AND t.schemaname = 'public'
+    LOOP
+        EXECUTE format(
+            'DROP POLICY IF EXISTS %I ON %I.%I',
+            row_record.polname,
+            row_record.schemaname,
+            row_record.tablename
+        );
+    END LOOP;
+END $$;
+-- +goose StatementEnd

--- a/backend/tests/migrations/rls_migration_test.go
+++ b/backend/tests/migrations/rls_migration_test.go
@@ -36,6 +36,38 @@ func TestSupabaseRLSHardeningMigrationExists(t *testing.T) {
 	}
 }
 
+func TestRLSForceAndPoliciesMigrationExists(t *testing.T) {
+	path := "../../db/migrations/00030_rls_force_and_policies.sql"
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read migration: %v", err)
+	}
+
+	sql := string(content)
+	required := []string{
+		"FORCE ROW LEVEL SECURITY",
+		"CREATE POLICY",
+		"rls_default",
+		"NO FORCE ROW LEVEL SECURITY",
+	}
+	wantMissing := []string{
+		"ENABLE ROW LEVEL SECURITY",
+	}
+
+	for _, token := range required {
+		if !strings.Contains(sql, token) {
+			t.Fatalf("missing expected SQL token: %q", token)
+		}
+	}
+
+	for _, token := range wantMissing {
+		if strings.Contains(sql, token) {
+			t.Fatalf("found unexpected SQL token: %q (should NOT have ENABLE, use FORCE)", token)
+		}
+	}
+}
+
 func TestWhatsAppMaintenanceInboxRLS(t *testing.T) {
 	path := "../../db/migrations/00027_whatsapp_maintenance_inbox.sql"
 


### PR DESCRIPTION
Adds migration 00030 that completes the RLS hardening started in migrations 00019 and 00023:

1. Creates permissive default policies (rls_default) on tables with RLS enabled but no policies, ensuring data remains accessible after FORCE is applied
2. Applies FORCE ROW LEVEL SECURITY so the application database role is subject to RLS instead of bypassing it as table owner

Also updates the CI test to verify FORCE ROW LEVEL SECURITY and CREATE POLICY presence.

This is a first step - policies should be tightened to org-level isolation in future work.

Closes #183