### PR TITLE
fix(#391): guard against empty levy periods array in financials dashboard

### DIFF
--- a/backend/internal/financials/service.go
+++ b/backend/internal/financials/service.go
@@ -161,7 +161,7 @@ func (s *Service) Dashboard(ctx context.Context, identity auth.Identity, schemeI
 		resp.AvailablePeriods = periods
 
 		selected := periodLabel
-		if selected == "" {
+		if selected == "" && len(periods) > 0 {
 			selected = periods[0]
 		}
 		resp.SelectedPeriod = selected


### PR DESCRIPTION
Adds length check before accessing periods[0] to prevent panic when a scheme has no levy periods.

Closes #391