### PR TITLE
fix(#332): clear resolved_at on reassignment and require resolved status in dashboard

### DIFF
--- a/backend/db/gen/maintenance.sql.go
+++ b/backend/db/gen/maintenance.sql.go
@@ -18,7 +18,8 @@ UPDATE maintenance_requests
 SET contractor_id    = NULL,
     contractor_name  = $2,
     contractor_phone = $3,
-    status           = 'in_progress'
+    status           = 'in_progress',
+    resolved_at      = NULL
 WHERE id = $1
 RETURNING id, scheme_id, unit_id, title, description, category, status, contractor_name, contractor_phone, sla_hours, submitted_by_unit, created_at, updated_at, resolved_at, contractor_id
 `
@@ -57,7 +58,8 @@ UPDATE maintenance_requests
 SET contractor_id    = $1,
     contractor_name  = $2,
     contractor_phone = $3,
-    status           = 'in_progress'
+    status           = 'in_progress',
+    resolved_at      = NULL
 WHERE id = $4
 RETURNING id, scheme_id, unit_id, title, description, category, status, contractor_name, contractor_phone, sla_hours, submitted_by_unit, created_at, updated_at, resolved_at, contractor_id
 `

--- a/backend/db/queries/maintenance.sql
+++ b/backend/db/queries/maintenance.sql
@@ -39,7 +39,8 @@ UPDATE maintenance_requests
 SET contractor_id    = NULL,
     contractor_name  = $2,
     contractor_phone = $3,
-    status           = 'in_progress'
+    status           = 'in_progress',
+    resolved_at      = NULL
 WHERE id = $1
 RETURNING *;
 
@@ -66,6 +67,7 @@ UPDATE maintenance_requests
 SET contractor_id    = sqlc.arg(contractor_id),
     contractor_name  = sqlc.arg(contractor_name),
     contractor_phone = sqlc.arg(contractor_phone),
-    status           = 'in_progress'
+    status           = 'in_progress',
+    resolved_at      = NULL
 WHERE id = sqlc.arg(id)
 RETURNING *;

--- a/backend/internal/maintenance/service.go
+++ b/backend/internal/maintenance/service.go
@@ -126,7 +126,7 @@ func (s *Service) Dashboard(ctx context.Context, identity auth.Identity, schemeI
 		if item.Status == string(dbgen.MaintenanceStatusPendingApproval) {
 			response.PendingApprovalCount++
 		}
-		if item.ResolvedAt != nil && item.ResolvedAt.After(monthStart) {
+		if item.Status == string(dbgen.MaintenanceStatusResolved) && item.ResolvedAt != nil && item.ResolvedAt.After(monthStart) {
 			response.ResolvedThisMonth++
 		}
 	}


### PR DESCRIPTION
Two fixes for maintenance request resolution tracking:

1. Clear resolved_at when reassigning a maintenance request back to in_progress (both AssignMaintenanceContractor and AssignMaintenanceContractorProfile).

2. Dashboard ResolvedThisMonth now requires status=resolved in addition to the timestamp check.

Closes #332