### PR TITLE
fix(#176): use GETDEL for atomic password reset token consumption

### DIFF
--- a/backend/internal/auth/service.go
+++ b/backend/internal/auth/service.go
@@ -526,7 +526,7 @@ func (s *Service) IssuePasswordResetURL(ctx context.Context, email, appBaseURL s
 
 func (s *Service) ResetPassword(ctx context.Context, token, password string) error {
 	key := "pwreset:" + HashRefreshToken(token)
-	userIDStr, err := s.cache.Get(ctx, key).Result()
+	userIDStr, err := s.cache.GetDel(ctx, key).Result()
 	if err != nil {
 		return ErrInvalidToken
 	}
@@ -554,7 +554,6 @@ func (s *Service) ResetPassword(ctx context.Context, token, password string) err
 		return err
 	}
 
-	s.cache.Del(ctx, key)
 	return nil
 }
 


### PR DESCRIPTION
Replaces the two-step GET+DEL pattern with GETDEL which atomically gets and deletes the reset token in one Redis operation. This prevents token reuse when DEL fails after a successful DB password update.

Closes #176