### PR TITLE
fix(#381): use time.Now().UTC() for business date calculations

### DIFF
--- a/backend/internal/agm/service.go
+++ b/backend/internal/agm/service.go
@@ -117,7 +117,7 @@ func (s *Service) Dashboard(ctx context.Context, identity auth.Identity, schemeI
 	})
 
 	response := &DashboardResponse{Role: access.role}
-	now := startOfDay(time.Now())
+	now := startOfDay(time.Now().UTC())
 
 	for _, meeting := range meetings {
 		meetingDate := meeting.MeetingDate.Time

--- a/backend/internal/ai/service.go
+++ b/backend/internal/ai/service.go
@@ -231,7 +231,7 @@ func (s *Service) buildSchemePrompt(ctx context.Context, identity auth.Identity,
 		"financials":        mapFinancials(budgetLines, reserveErr == nil, reserveFund),
 		"levy":              levySummary,
 		"agm":               agmSummary,
-		"today":             time.Now().Format("2006-01-02"),
+		"today":             time.Now().UTC().Format("2006-01-02"),
 		"available_actions": []string{"scheme_qna", "levy_reconciliation"},
 		"action_guidance":   levyActionGuidance(),
 	}
@@ -299,7 +299,7 @@ func (s *Service) buildAgmSummary(ctx context.Context, meetings []dbgen.AgmMeeti
 
 	var latest map[string]any
 	var upcoming map[string]any
-	now := startOfDay(time.Now())
+	now := startOfDay(time.Now().UTC())
 	for _, meeting := range meetings {
 		resolutions, err := s.db.Q.ListAgmResolutionsByMeeting(ctx, meeting.ID)
 		if err != nil {
@@ -343,7 +343,7 @@ Rules:
 - Current scope is %s.
 
 LIVE DATA:
-%s`, time.Now().Format("2 January 2006"), scope, contextJSON)
+%s`, time.Now().UTC().Format("2 January 2006"), scope, contextJSON)
 }
 
 func levyActionGuidance() map[string]string {
@@ -537,7 +537,7 @@ func levyStatusFor(paidCents, amountCents int64, dueDate pgtype.Date) string {
 		return "paid"
 	case paidCents > 0:
 		return "partial"
-	case dueDate.Valid && dueDate.Time.Before(startOfDay(time.Now())):
+	case dueDate.Valid && dueDate.Time.Before(startOfDay(time.Now().UTC())):
 		return "overdue"
 	default:
 		return "pending"

--- a/backend/internal/compliance/service.go
+++ b/backend/internal/compliance/service.go
@@ -223,7 +223,7 @@ func (s *Service) CreateItem(ctx context.Context, identity auth.Identity, scheme
 		Detail:      input.Detail,
 		Action:      input.Action,
 		DueDate:     dueDate,
-		AssessedAt:  time.Now(),
+		AssessedAt:  time.Now().UTC(),
 	})
 	if err != nil {
 		return nil, err

--- a/backend/internal/financials/service.go
+++ b/backend/internal/financials/service.go
@@ -421,7 +421,7 @@ func levyStatusFor(paidCents, amountCents int64, dueDate pgtype.Date) string {
 		return "paid"
 	case paidCents > 0:
 		return "partial"
-	case dueDate.Valid && dueDate.Time.Before(startOfDay(time.Now())):
+	case dueDate.Valid && dueDate.Time.Before(startOfDay(time.Now().UTC())):
 		return "overdue"
 	default:
 		return "pending"

--- a/backend/internal/levy/service.go
+++ b/backend/internal/levy/service.go
@@ -627,7 +627,7 @@ func statusFor(paidCents, amountCents int64, dueDate pgtype.Date) string {
 		return "paid"
 	case paidCents > 0:
 		return "partial"
-	case dueDate.Valid && dueDate.Time.Before(startOfDay(time.Now())):
+	case dueDate.Valid && dueDate.Time.Before(startOfDay(time.Now().UTC())):
 		return "overdue"
 	default:
 		return "pending"
@@ -842,7 +842,7 @@ func (s *Service) buildAttentionQueueFromData(ctx context.Context, data []struct
 		}
 	}
 
-	now := time.Now()
+	now := time.Now().UTC()
 	items := make([]AttentionItem, 0, len(data))
 	for _, rd := range data {
 		outstanding := rd.amount - rd.paid

--- a/backend/internal/maintenance/service.go
+++ b/backend/internal/maintenance/service.go
@@ -107,7 +107,7 @@ func (s *Service) Dashboard(ctx context.Context, identity auth.Identity, schemeI
 		Role:     access.role,
 	}
 
-	now := time.Now()
+	now := time.Now().UTC()
 	monthStart := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, now.Location())
 
 	for _, row := range rows {
@@ -458,7 +458,7 @@ func (s *Service) enrichRequest(ctx context.Context, request dbgen.MaintenanceRe
 		}
 	}
 
-	now := time.Now()
+	now := time.Now().UTC()
 	return &RequestInfo{
 		ContractorID:    uuidTextPointer(request.ContractorID),
 		ContractorName:  textPointer(request.ContractorName),

--- a/backend/internal/scheme/service.go
+++ b/backend/internal/scheme/service.go
@@ -138,7 +138,7 @@ func (s *Service) List(ctx context.Context, identity auth.Identity) ([]SchemeSum
 			return nil, err
 		}
 
-		now := time.Now()
+		now := time.Now().UTC()
 		summaries := make([]SchemeSummary, 0, len(rows))
 		for _, row := range rows {
 			var nextAgmDate *string
@@ -821,7 +821,7 @@ func pointerToUnit(unit UnitInfo) *UnitInfo {
 }
 
 func nextAgm(meetings []dbgen.AgmMeeting) (*string, *int) {
-	now := time.Now()
+	now := time.Now().UTC()
 	var next *time.Time
 	for _, meeting := range meetings {
 		if !meeting.MeetingDate.Valid {


### PR DESCRIPTION
Replaces time.Now() with time.Now().UTC() in service files where dates affect business logic: overdue checks, monthly stat boundaries, date formatting, assessment timestamps, and attention queue scoring.

Metrics and logging timestamps are left unchanged as they don't affect business correctness.

Closes #381