### PR TITLE
fix(#227): stop overwriting org-wide role on scheme membership updates

### DIFF
--- a/backend/internal/scheme/service.go
+++ b/backend/internal/scheme/service.go
@@ -590,16 +590,6 @@ func (s *Service) UpdateMember(ctx context.Context, identity auth.Identity, sche
 			return txErr
 		}
 
-		if _, txErr := q.UpdateOrgMembershipRole(ctx, dbgen.UpdateOrgMembershipRoleParams{
-			UserID: memberUserID,
-			OrgID:  scheme.OrgID,
-			Role:   input.Role,
-		}); txErr != nil {
-			if errors.Is(txErr, pgx.ErrNoRows) {
-				return ErrNotFound
-			}
-			return txErr
-		}
 		return nil
 	})
 	if err != nil {


### PR DESCRIPTION
Removes UpdateOrgMembershipRole from UpdateMember so changing a user's role in one scheme no longer overwrites their org-wide role. The org role should be managed independently, not derived from a single scheme membership update.

Closes #227