### PR TITLE
fix(#220): populate session payload in invitation acceptance response

### DIFF
--- a/backend/internal/invitation/service.go
+++ b/backend/internal/invitation/service.go
@@ -72,6 +72,7 @@ type queryStore interface {
 	CreateRefreshToken(ctx context.Context, arg dbgen.CreateRefreshTokenParams) (dbgen.RefreshToken, error)
 	GetScheme(ctx context.Context, id uuid.UUID) (dbgen.Scheme, error)
 	GetUnit(ctx context.Context, id uuid.UUID) (dbgen.Unit, error)
+	GetOrg(ctx context.Context, id uuid.UUID) (dbgen.Org, error)
 }
 
 type txStore interface {
@@ -417,6 +418,15 @@ func (s *Service) Accept(ctx context.Context, token, password string) (*auth.Aut
 		return nil, err
 	}
 
+	org, orgErr := s.q.GetOrg(ctx, inv.OrgID)
+	if orgErr != nil {
+		return nil, orgErr
+	}
+	scheme, schemeErr := s.q.GetScheme(ctx, inv.SchemeID)
+	if schemeErr != nil {
+		return nil, schemeErr
+	}
+
 	return &auth.AuthResponse{
 		AccessToken:  accessToken,
 		RefreshToken: refreshToken,
@@ -425,6 +435,23 @@ func (s *Service) Accept(ctx context.Context, token, password string) (*auth.Aut
 			ID:       user.ID.String(),
 			Email:    user.Email,
 			FullName: user.FullName,
+		},
+		Session: auth.MeResponse{
+			ID:       user.ID.String(),
+			Email:    user.Email,
+			FullName: user.FullName,
+			Role:     inv.Role,
+			Org: auth.OrgInfo{
+				ID:   org.ID.String(),
+				Name: org.Name,
+			},
+			SchemeMemberships: []auth.SchemeMembership{
+				{
+					SchemeID:   scheme.ID.String(),
+					SchemeName: scheme.Name,
+					Role:       inv.Role,
+				},
+			},
 		},
 	}, nil
 }

--- a/backend/internal/invitation/service_test.go
+++ b/backend/internal/invitation/service_test.go
@@ -179,6 +179,10 @@ func (f *fakeInvitationStore) UpsertSchemeMembership(context.Context, dbgen.Upse
 	return dbgen.SchemeMembership{}, nil
 }
 
+func (f *fakeInvitationStore) GetOrg(ctx context.Context, id uuid.UUID) (dbgen.Org, error) {
+	return dbgen.Org{ID: id, Name: "Test Org"}, nil
+}
+
 func newTestService(store *fakeInvitationStore) *Service {
 	return &Service{
 		q:             store,


### PR DESCRIPTION
Builds the Session (MeResponse) field in the invitation acceptance response from the created user, org, and scheme membership data. This ensures the frontend receives a valid session cookie after invite acceptance, matching login/register behavior.

Closes #220