### PR TITLE
fix(#329): disable metrics endpoint when METRICS_TOKEN is unset in non-dev environments

### DIFF
--- a/backend/internal/server/router.go
+++ b/backend/internal/server/router.go
@@ -83,7 +83,7 @@ func NewRouter(cfg *config.Config, logger *slog.Logger, rdb *redis.Client, audit
 			})
 			r.Handle("/metrics", promhttp.Handler())
 		})
-	} else {
+	} else if cfg.Env == "development" {
 		r.Handle("/metrics", promhttp.Handler())
 	}
 


### PR DESCRIPTION
Only expose /metrics publicly in development mode. In production/staging, the endpoint is disabled entirely unless METRICS_TOKEN is configured to require bearer token authentication. This prevents accidental exposure of operational metrics when the token is misconfigured.

Closes #329