### PR TITLE
fix(#350): validate section_value_bps upper bound and scheme total

### DIFF
--- a/backend/db/gen/scheme.sql.go
+++ b/backend/db/gen/scheme.sql.go
@@ -419,6 +419,19 @@ func (q *Queries) ListUnitsByScheme(ctx context.Context, schemeID uuid.UUID) ([]
 	return items, nil
 }
 
+const sumSectionValuesByScheme = `-- name: SumSectionValuesByScheme :one
+SELECT COALESCE(SUM(section_value_bps), 0)::INTEGER AS total_bps
+FROM units
+WHERE scheme_id = $1
+`
+
+func (q *Queries) SumSectionValuesByScheme(ctx context.Context, schemeID uuid.UUID) (int32, error) {
+	row := q.db.QueryRow(ctx, sumSectionValuesByScheme, schemeID)
+	var total_bps int32
+	err := row.Scan(&total_bps)
+	return total_bps, err
+}
+
 const updateScheme = `-- name: UpdateScheme :one
 UPDATE schemes
 SET name = $2, address = $3, unit_count = $4

--- a/backend/db/migrations/00031_section_value_bps_upper.sql
+++ b/backend/db/migrations/00031_section_value_bps_upper.sql
@@ -1,0 +1,7 @@
+-- +goose Up
+
+ALTER TABLE units ADD CONSTRAINT units_section_value_bps_upper CHECK (section_value_bps <= 10000);
+
+-- +goose Down
+
+ALTER TABLE units DROP CONSTRAINT IF EXISTS units_section_value_bps_upper;

--- a/backend/db/queries/scheme.sql
+++ b/backend/db/queries/scheme.sql
@@ -148,3 +148,8 @@ ORDER BY u.full_name;
 -- name: DeleteSchemeMembership :exec
 DELETE FROM scheme_memberships
 WHERE user_id = $1 AND scheme_id = $2;
+
+-- name: SumSectionValuesByScheme :one
+SELECT COALESCE(SUM(section_value_bps), 0)::INTEGER AS total_bps
+FROM units
+WHERE scheme_id = $1;

--- a/backend/internal/scheme/handler.go
+++ b/backend/internal/scheme/handler.go
@@ -170,7 +170,7 @@ func (h *Handler) CreateUnit(w http.ResponseWriter, r *http.Request) {
 
 	input, valid := normalizeUnitRequest(req)
 	if !valid {
-		response.Error(w, http.StatusBadRequest, response.CodeBadRequest, "identifier, owner_name, floor, and section_value_bps are required")
+		response.Error(w, http.StatusBadRequest, response.CodeBadRequest, "identifier, owner_name, floor, and section_value_bps (1-10000) are required")
 		return
 	}
 
@@ -198,7 +198,7 @@ func (h *Handler) UpdateUnit(w http.ResponseWriter, r *http.Request) {
 
 	input, valid := normalizeUnitRequest(req)
 	if !valid {
-		response.Error(w, http.StatusBadRequest, response.CodeBadRequest, "identifier, owner_name, floor, and section_value_bps are required")
+		response.Error(w, http.StatusBadRequest, response.CodeBadRequest, "identifier, owner_name, floor, and section_value_bps (1-10000) are required")
 		return
 	}
 
@@ -274,7 +274,7 @@ func normalizeSchemeRequest(req schemeRequest) (CreateSchemeInput, bool) {
 func normalizeUnitRequest(req unitRequest) (CreateUnitInput, bool) {
 	identifier := strings.TrimSpace(req.Identifier)
 	ownerName := strings.TrimSpace(req.OwnerName)
-	if identifier == "" || ownerName == "" || req.SectionValueBps <= 0 {
+	if identifier == "" || ownerName == "" || req.SectionValueBps <= 0 || req.SectionValueBps > 10000 {
 		return CreateUnitInput{}, false
 	}
 	return CreateUnitInput{

--- a/backend/internal/scheme/service.go
+++ b/backend/internal/scheme/service.go
@@ -416,6 +416,14 @@ func (s *Service) CreateUnit(ctx context.Context, identity auth.Identity, scheme
 		return nil, ErrForbidden
 	}
 
+	existingTotal, err := s.db.Q.SumSectionValuesByScheme(ctx, scheme.ID)
+	if err != nil {
+		return nil, err
+	}
+	if int32(existingTotal)+input.SectionValueBps > 10000 {
+		return nil, errors.New("section value total would exceed 10000 basis points")
+	}
+
 	unit, err := s.db.Q.CreateUnit(ctx, dbgen.CreateUnitParams{
 		SchemeID:        scheme.ID,
 		Identifier:      input.Identifier,
@@ -469,6 +477,17 @@ func (s *Service) UpdateUnit(ctx context.Context, identity auth.Identity, scheme
 	}
 	if current.SchemeID != scheme.ID {
 		return nil, ErrForbidden
+	}
+
+	if input.SectionValueBps != current.SectionValueBps {
+		existingTotal, sumErr := s.db.Q.SumSectionValuesByScheme(ctx, scheme.ID)
+		if sumErr != nil {
+			return nil, sumErr
+		}
+		adjustedTotal := int32(existingTotal) - current.SectionValueBps + input.SectionValueBps
+		if adjustedTotal > 10000 {
+			return nil, errors.New("section value total would exceed 10000 basis points")
+		}
 	}
 
 	beforeInfo := mapUnit(current)


### PR DESCRIPTION
Add CHECK constraint (section_value_bps <= 10000) in migration 00031. Validate individual unit values (1-10000) in normalizeUnitRequest. Sum existing section values per scheme and reject create/update that would exceed 10000 bps total, preventing impossible participation quotas.

Closes #350