### PR TITLE
fix(#335): make onboarding setup idempotent by checking existing schemes

### DIFF
--- a/backend/internal/auth/handler.go
+++ b/backend/internal/auth/handler.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"errors"
 	"net/http"
 	"strings"
 
@@ -114,6 +115,10 @@ func (h *Handler) Setup(w http.ResponseWriter, r *http.Request) {
 	}
 	res, err := h.service.Setup(r.Context(), identity.OrgID, req.OrgName, req.ContactEmail, req.SchemeName, req.SchemeAddress, req.UnitCount)
 	if err != nil {
+		if errors.Is(err, ErrSetupAlreadyComplete) {
+			response.Error(w, http.StatusConflict, response.CodeConflict, "onboarding setup has already been completed")
+			return
+		}
 		response.Error(w, http.StatusInternalServerError, response.CodeInternalError, "onboarding failed")
 		return
 	}

--- a/backend/internal/auth/service.go
+++ b/backend/internal/auth/service.go
@@ -26,7 +26,8 @@ var (
 	ErrInvalidCredentials = errors.New("invalid credentials")
 	ErrInvalidToken       = errors.New("invalid or expired token")
 	ErrWrongPassword      = errors.New("current password is incorrect")
-	ErrWeakPassword       = errors.New("password does not meet requirements")
+	ErrWeakPassword         = errors.New("password does not meet requirements")
+	ErrSetupAlreadyComplete = errors.New("setup already complete")
 )
 
 const passwordResetTTL = time.Hour
@@ -440,6 +441,14 @@ func (s *Service) Setup(ctx context.Context, orgID, orgName, contactEmail, schem
 	oid, err := uuid.Parse(orgID)
 	if err != nil {
 		return nil, fmt.Errorf("invalid org id: %w", err)
+	}
+
+	existingSchemes, err := s.db.Q.ListSchemesByOrg(ctx, oid)
+	if err != nil {
+		return nil, err
+	}
+	if len(existingSchemes) > 0 {
+		return nil, ErrSetupAlreadyComplete
 	}
 
 	var resp SetupResponse


### PR DESCRIPTION
Check if the org already has schemes before allowing the setup endpoint to create another. Returns 409 Conflict if setup has already been completed, preventing duplicate schemes and overwritten org settings from replayed or retried requests.

Closes #335