### PR TITLE
fix(#374): suppress attention queue reminders for active promises to pay

### DIFF
--- a/backend/internal/levy/attention.go
+++ b/backend/internal/levy/attention.go
@@ -8,6 +8,7 @@ import (
 
 type attentionAccount struct {
 	PromiseDateOverdue bool
+	HasActivePromise   bool
 	DaysOverdue        int
 	LastActionDaysAgo  int
 	OutstandingCents   int64
@@ -74,6 +75,10 @@ func scoreAttentionItem(item attentionAccount, _ time.Time) AttentionItem {
 	recommended := "reminder_sent"
 	if item.LastActionType == "reminder_sent" && item.LastActionDaysAgo <= 2 {
 		recommended = "follow_up_logged"
+	} else if item.HasActivePromise {
+		score -= 20
+		drivers = append(drivers, "active promise to pay")
+		recommended = "active_promise"
 	} else if item.PromiseDateOverdue || item.DaysOverdue >= 90 {
 		score += 20
 		drivers = append(drivers, "broken promise or legal threshold")

--- a/backend/internal/levy/attention_test.go
+++ b/backend/internal/levy/attention_test.go
@@ -148,6 +148,32 @@ func TestBuildReminderDraftGeneratesDeterministicBodies(t *testing.T) {
 	}
 }
 
+func TestScoreAttentionItemSuppressesReminderForActivePromise(t *testing.T) {
+	now := time.Date(2026, 4, 16, 0, 0, 0, 0, time.UTC)
+	item := attentionAccount{
+		LevyAccountID:     "acc-1",
+		SchemeID:          "scheme-1",
+		SchemeName:        "Rosewood Estate",
+		UnitID:            "unit-1",
+		UnitIdentifier:    "5C",
+		OwnerName:         "Rose Example",
+		OutstandingCents:  930000,
+		DaysOverdue:       97,
+		LastActionType:    "promise_to_pay",
+		LastActionDaysAgo: 2,
+		HasActivePromise:  true,
+	}
+
+	scored := scoreAttentionItem(item, now)
+
+	if scored.RecommendedAction != "active_promise" {
+		t.Fatalf("recommended action = %q, want active_promise", scored.RecommendedAction)
+	}
+	if scored.RiskScore >= 70 {
+		t.Fatalf("risk score = %d, want reduced score below 70 for active promise", scored.RiskScore)
+	}
+}
+
 func TestScoreAttentionItemReducesUrgencyAfterFreshReminder(t *testing.T) {
 	now := time.Date(2026, 4, 16, 0, 0, 0, 0, time.UTC)
 	item := attentionAccount{

--- a/backend/internal/levy/service.go
+++ b/backend/internal/levy/service.go
@@ -858,12 +858,14 @@ func (s *Service) buildAttentionQueueFromData(ctx context.Context, data []struct
 		var lastActionType string
 		var lastActionDaysAgo int
 		var promiseDateOverdue bool
+		var hasActivePromise bool
 
 		if lastEv, ok := lastActionByAccount[rd.id.String()]; ok {
 			lastActionType = lastEv.EventType
 			lastActionDaysAgo = int(now.Sub(lastEv.CreatedAt).Hours() / 24)
 			if lastActionType == "promise_to_pay" && lastEv.PromiseDate.Valid {
 				promiseDateOverdue = lastEv.PromiseDate.Time.Before(now)
+				hasActivePromise = !promiseDateOverdue
 			}
 		}
 
@@ -879,6 +881,7 @@ func (s *Service) buildAttentionQueueFromData(ctx context.Context, data []struct
 			LastActionType:     lastActionType,
 			LastActionDaysAgo:  lastActionDaysAgo,
 			PromiseDateOverdue: promiseDateOverdue,
+			HasActivePromise:   hasActivePromise,
 		}
 
 		item := scoreAttentionItem(account, now)

--- a/components/AttentionQueue.tsx
+++ b/components/AttentionQueue.tsx
@@ -99,6 +99,8 @@ function actionLabel(
       return "Legal review";
     case "promise_to_pay":
       return "Promise to pay";
+    case "active_promise":
+      return "Awaiting promise";
     case "follow_up_logged":
       return "Follow-up";
     default:

--- a/lib/attention.ts
+++ b/lib/attention.ts
@@ -9,7 +9,7 @@ export interface AttentionItem {
   days_overdue: number;
   risk_score: number;
   score_drivers: string[];
-  recommended_action: "reminder_sent" | "follow_up_logged" | "promise_to_pay" | "legal_review_flagged";
+  recommended_action: "reminder_sent" | "follow_up_logged" | "promise_to_pay" | "legal_review_flagged" | "active_promise";
 }
 
 export interface ReminderChannelDraft {


### PR DESCRIPTION
## Problem
The collections attention queue only treates a promise_to_pay event as meaningful after the promise date is overdue. While a promise is still active, the scorer falls back to reminder_sent, so operators are prompted to chase a resident before the agreed promise date.

## Fix
When an operator logs a promise_to_pay with a future date, the attention queue now:
- Shows an `active_promise` recommended action ("Awaiting promise" in the UI)
- Reduces the risk score by 20 points
- Adds an "active promise to pay" score driver

This stops operators being prompted to send reminders while an active promise is in place.

## Changes
- `backend/internal/levy/attention.go` — Added `HasActivePromise` field, new scoring branch before overdue check
- `backend/internal/levy/service.go` — Computes `hasActivePromise` in `buildAttentionQueueFromData`
- `backend/internal/levy/attention_test.go` — Added `TestScoreAttentionItemSuppressesReminderForActivePromise`
- `lib/attention.ts` — Added `active_promise` to `recommended_action` union type
- `components/AttentionQueue.tsx` — Added "Awaiting promise" label for `active_promise`