### PR TITLE
fix(#328): stop overwriting org-wide role when editing scheme membership

### DIFF
--- a/backend/internal/auth/service.go
+++ b/backend/internal/auth/service.go
@@ -330,11 +330,11 @@ func (s *Service) Me(ctx context.Context, userID, orgID string) (*MeResponse, er
 		}
 	} else {
 		resp.WizardComplete = true
-		memberships, err := s.db.Q.ListSchemeMembershipsByUser(ctx, uid)
+		schemeMemberships, err := s.db.Q.ListSchemeMembershipsByUser(ctx, uid)
 		if err != nil {
 			return nil, err
 		}
-		for _, m := range memberships {
+		for _, m := range schemeMemberships {
 			sm := SchemeMembership{
 				SchemeID:   m.SchemeID.String(),
 				SchemeName: m.SchemeName,
@@ -350,6 +350,7 @@ func (s *Service) Me(ctx context.Context, userID, orgID string) (*MeResponse, er
 			}
 			resp.SchemeMemberships = append(resp.SchemeMemberships, sm)
 		}
+		resp.Role = strongestSchemeRole(schemeMemberships, membership.Role)
 	}
 
 	if resp.SchemeMemberships == nil {
@@ -617,6 +618,23 @@ func textValue(value *string) pgtype.Text {
 		return pgtype.Text{}
 	}
 	return pgtype.Text{String: *value, Valid: true}
+}
+
+func strongestSchemeRole(memberships []dbgen.ListSchemeMembershipsByUserRow, fallback string) string {
+	if len(memberships) == 0 {
+		return fallback
+	}
+	hasRole := make(map[string]bool, len(memberships))
+	for _, m := range memberships {
+		hasRole[m.Role] = true
+	}
+	if hasRole[string(RoleOwner)] {
+		return string(RoleOwner)
+	}
+	if hasRole[string(RoleTrustee)] {
+		return string(RoleTrustee)
+	}
+	return string(RoleResident)
 }
 
 func isUniqueEmailViolation(err error) bool {


### PR DESCRIPTION
Two related changes to ensure scheme membership edits don't overwrite the user's org-wide role:

1. f68086f already removed UpdateOrgMembershipRole call from UpdateMember so changing a user's role in one scheme no longer overwrites their org membership role.

2. (this PR) For non-admin users, the session role in Me is now derived from the strongest per-scheme membership (owner > trustee > resident) instead of blindly reading the org membership role. Falls back to the org membership role when the user has no scheme memberships.

Scenario fixed: A user trustee in Scheme A and resident in Scheme B would previously see their session role incorrectly reported as "resident" based on stale org membership data. Now the strongest role across all schemes is used.

**Verification:** go build ./... passes, go test ./internal/... -count=1 passes.