### PR TITLE
fix(#331): allow audit event retrieval for deleted schemes

### DIFF
--- a/backend/db/gen/resource_audit_events.sql.go
+++ b/backend/db/gen/resource_audit_events.sql.go
@@ -25,6 +25,25 @@ func (q *Queries) CountResourceAuditEventsByScheme(ctx context.Context, schemeID
 	return count, err
 }
 
+const countResourceAuditEventsBySchemeAndOrg = `-- name: CountResourceAuditEventsBySchemeAndOrg :one
+SELECT COUNT(*)
+FROM resource_audit_events
+WHERE scheme_id = $1
+  AND org_id = $2
+`
+
+type CountResourceAuditEventsBySchemeAndOrgParams struct {
+	SchemeID uuid.UUID `json:"scheme_id"`
+	OrgID    uuid.UUID `json:"org_id"`
+}
+
+func (q *Queries) CountResourceAuditEventsBySchemeAndOrg(ctx context.Context, arg CountResourceAuditEventsBySchemeAndOrgParams) (int64, error) {
+	row := q.db.QueryRow(ctx, countResourceAuditEventsBySchemeAndOrg, arg.SchemeID, arg.OrgID)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
 const createResourceAuditEvent = `-- name: CreateResourceAuditEvent :one
 INSERT INTO resource_audit_events (
     scheme_id,
@@ -150,6 +169,54 @@ type ListResourceAuditEventsBySchemeAndActionParams struct {
 
 func (q *Queries) ListResourceAuditEventsBySchemeAndAction(ctx context.Context, arg ListResourceAuditEventsBySchemeAndActionParams) ([]ResourceAuditEvent, error) {
 	rows, err := q.db.Query(ctx, listResourceAuditEventsBySchemeAndAction, arg.SchemeID, arg.Action, arg.Limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ResourceAuditEvent{}
+	for rows.Next() {
+		var i ResourceAuditEvent
+		if err := rows.Scan(
+			&i.ID,
+			&i.SchemeID,
+			&i.OrgID,
+			&i.ActorUserID,
+			&i.ActorRole,
+			&i.ResourceType,
+			&i.ResourceID,
+			&i.Action,
+			&i.BeforeState,
+			&i.AfterState,
+			&i.Metadata,
+			&i.OccurredAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listResourceAuditEventsBySchemeAndOrg = `-- name: ListResourceAuditEventsBySchemeAndOrg :many
+SELECT id, scheme_id, org_id, actor_user_id, actor_role, resource_type, resource_id, action, before_state, after_state, metadata, occurred_at
+FROM resource_audit_events
+WHERE scheme_id = $1
+  AND org_id = $2
+ORDER BY occurred_at DESC, id DESC
+LIMIT $3
+`
+
+type ListResourceAuditEventsBySchemeAndOrgParams struct {
+	SchemeID uuid.UUID `json:"scheme_id"`
+	OrgID    uuid.UUID `json:"org_id"`
+	Limit    int32     `json:"limit"`
+}
+
+func (q *Queries) ListResourceAuditEventsBySchemeAndOrg(ctx context.Context, arg ListResourceAuditEventsBySchemeAndOrgParams) ([]ResourceAuditEvent, error) {
+	rows, err := q.db.Query(ctx, listResourceAuditEventsBySchemeAndOrg, arg.SchemeID, arg.OrgID, arg.Limit)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/db/queries/resource_audit_events.sql
+++ b/backend/db/queries/resource_audit_events.sql
@@ -30,6 +30,20 @@ WHERE scheme_id = $1
 ORDER BY occurred_at DESC, id DESC
 LIMIT $3;
 
+-- name: ListResourceAuditEventsBySchemeAndOrg :many
+SELECT *
+FROM resource_audit_events
+WHERE scheme_id = $1
+  AND org_id = $2
+ORDER BY occurred_at DESC, id DESC
+LIMIT $3;
+
+-- name: CountResourceAuditEventsBySchemeAndOrg :one
+SELECT COUNT(*)
+FROM resource_audit_events
+WHERE scheme_id = $1
+  AND org_id = $2;
+
 -- name: CountResourceAuditEventsByScheme :one
 SELECT COUNT(*)
 FROM resource_audit_events

--- a/backend/internal/audit/service.go
+++ b/backend/internal/audit/service.go
@@ -138,8 +138,10 @@ type ResourceRecorder interface {
 type ResourceAuditQueries interface {
 	CreateResourceAuditEvent(ctx context.Context, arg dbgen.CreateResourceAuditEventParams) (dbgen.ResourceAuditEvent, error)
 	ListResourceAuditEventsByScheme(ctx context.Context, arg dbgen.ListResourceAuditEventsBySchemeParams) ([]dbgen.ResourceAuditEvent, error)
+	ListResourceAuditEventsBySchemeAndOrg(ctx context.Context, arg dbgen.ListResourceAuditEventsBySchemeAndOrgParams) ([]dbgen.ResourceAuditEvent, error)
 	ListResourceAuditEventsBySchemeAndAction(ctx context.Context, arg dbgen.ListResourceAuditEventsBySchemeAndActionParams) ([]dbgen.ResourceAuditEvent, error)
 	CountResourceAuditEventsByScheme(ctx context.Context, schemeID uuid.UUID) (int64, error)
+	CountResourceAuditEventsBySchemeAndOrg(ctx context.Context, arg dbgen.CountResourceAuditEventsBySchemeAndOrgParams) (int64, error)
 	GetScheme(ctx context.Context, id uuid.UUID) (dbgen.Scheme, error)
 	GetSchemeMembership(ctx context.Context, arg dbgen.GetSchemeMembershipParams) (dbgen.SchemeMembership, error)
 }
@@ -244,7 +246,7 @@ func (s *ResourceService) ListSchemeEvents(ctx context.Context, identity auth.Id
 	scheme, err := s.q.GetScheme(ctx, parsedSchemeID)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrNotFound
+			return s.listEventsForDeletedScheme(ctx, identity, parsedSchemeID, limit)
 		}
 		return nil, err
 	}
@@ -283,6 +285,39 @@ func (s *ResourceService) ListSchemeEvents(ctx context.Context, identity auth.Id
 		return nil, err
 	}
 	total, err := s.q.CountResourceAuditEventsByScheme(ctx, parsedSchemeID)
+	if err != nil {
+		return nil, err
+	}
+	events := make([]ResourceEventInfo, 0, len(rows))
+	for _, row := range rows {
+		events = append(events, mapResourceAuditEvent(row))
+	}
+	return &ListResourceEventsResponse{Events: events, Total: total, Limit: limit}, nil
+}
+
+func (s *ResourceService) listEventsForDeletedScheme(ctx context.Context, identity auth.Identity, parsedSchemeID uuid.UUID, limit int32) (*ListResourceEventsResponse, error) {
+	if !auth.IsAdminRole(identity.Role) {
+		return nil, ErrForbidden
+	}
+	orgID, parseErr := uuid.Parse(identity.OrgID)
+	if parseErr != nil {
+		return nil, ErrForbidden
+	}
+	if limit <= 0 || limit > 200 {
+		limit = 50
+	}
+	rows, err := s.q.ListResourceAuditEventsBySchemeAndOrg(ctx, dbgen.ListResourceAuditEventsBySchemeAndOrgParams{
+		SchemeID: parsedSchemeID,
+		OrgID:    orgID,
+		Limit:    limit,
+	})
+	if err != nil {
+		return nil, err
+	}
+	total, err := s.q.CountResourceAuditEventsBySchemeAndOrg(ctx, dbgen.CountResourceAuditEventsBySchemeAndOrgParams{
+		SchemeID: parsedSchemeID,
+		OrgID:    orgID,
+	})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fixes #331