### PR TITLE
fix(#373): cool down repeated legal review flags

### DIFF
--- a/backend/internal/levy/attention.go
+++ b/backend/internal/levy/attention.go
@@ -35,9 +35,12 @@ type AttentionItem struct {
 	RecommendedAction string   `json:"recommended_action"`
 }
 
+const legalReviewCooldownDays = 7
+
 func scoreAttentionItem(item attentionAccount, _ time.Time) AttentionItem {
 	score := 0
 	drivers := make([]string, 0, 4)
+	recentLegalReview := item.LastActionType == "legal_review_flagged" && item.LastActionDaysAgo <= legalReviewCooldownDays
 
 	switch {
 	case item.DaysOverdue >= 90:
@@ -72,8 +75,15 @@ func scoreAttentionItem(item attentionAccount, _ time.Time) AttentionItem {
 		drivers = append(drivers, "recent reminder already sent")
 	}
 
+	if recentLegalReview {
+		score -= 25
+		drivers = append(drivers, "recent legal review already flagged")
+	}
+
 	recommended := "reminder_sent"
 	if item.LastActionType == "reminder_sent" && item.LastActionDaysAgo <= 2 {
+		recommended = "follow_up_logged"
+	} else if recentLegalReview {
 		recommended = "follow_up_logged"
 	} else if item.HasActivePromise {
 		score -= 20

--- a/backend/internal/levy/attention_test.go
+++ b/backend/internal/levy/attention_test.go
@@ -95,6 +95,31 @@ func TestScoreAttentionItemSuppressesUrgencyWhenFreshFollowUpExists(t *testing.T
 	}
 }
 
+func TestScoreAttentionItemSuppressesRepeatedLegalReviewRecommendation(t *testing.T) {
+	now := time.Date(2026, 4, 16, 0, 0, 0, 0, time.UTC)
+	item := attentionAccount{
+		LevyAccountID:     "acc-1",
+		SchemeID:          "scheme-1",
+		SchemeName:        "Rosewood Estate",
+		UnitID:            "unit-1",
+		UnitIdentifier:    "12C",
+		OwnerName:         "Owner Example",
+		OutstandingCents:  930000,
+		DaysOverdue:       97,
+		LastActionType:    "legal_review_flagged",
+		LastActionDaysAgo: 1,
+	}
+
+	scored := scoreAttentionItem(item, now)
+
+	if scored.RecommendedAction != "follow_up_logged" {
+		t.Fatalf("recommended_action = %q, want follow_up_logged after recent legal review", scored.RecommendedAction)
+	}
+	if scored.RiskScore >= 65 {
+		t.Fatalf("risk score = %d, want reduced score below 65 after recent legal review", scored.RiskScore)
+	}
+}
+
 func TestBuildReminderDraftMarksMissingChannels(t *testing.T) {
 	item := attentionAccount{
 		LevyAccountID:    "acc-1",


### PR DESCRIPTION
Fixes #373

## Summary
- adds a legal-review cooldown for accounts recently flagged for legal review
- recommends `follow_up_logged` instead of repeatedly recommending another `legal_review_flagged` event
- adds scorer regression coverage for 90+ day arrears with a fresh legal-review flag

## Tests
- Not run locally (per instruction to avoid validation unless explicitly requested); GitHub CI will run on this PR.