### PR TITLE
fix(#398): format levy date-only values without timezone shifts

### DIFF
--- a/app/app/[schemeId]/levy/page.tsx
+++ b/app/app/[schemeId]/levy/page.tsx
@@ -9,6 +9,7 @@ import BankStatementImportModal from '@/components/BankStatementImportModal'
 import RetryState from '@/components/RetryState'
 import { useAuth } from '@/lib/auth'
 import { invalidateCache } from '@/lib/data-cache'
+import { formatDateOnly, formatShortDate } from '@/lib/date-format'
 import { createLevyPeriod, getLevyDashboard, reconcileLevyPayments } from '@/lib/levy-api'
 import type { LevyAccountInfo, LevyDashboard, ReconcilePaymentInput } from '@/lib/levy'
 import { useToast } from '@/lib/toast'
@@ -19,13 +20,6 @@ import { useAuthenticatedQuery } from '@/hooks/useAuthenticatedQuery'
 
 function formatRand(cents: number): string {
   return `R ${(cents / 100).toLocaleString('en-ZA', { minimumFractionDigits: 0 })}`
-}
-
-function formatShortDate(value: string): string {
-  return new Date(value).toLocaleDateString('en-ZA', {
-    day: 'numeric',
-    month: 'short',
-  })
 }
 
 const STATUS_STYLES: Record<string, string> = {
@@ -202,7 +196,7 @@ export default function LevyPaymentsPage() {
                 <div key={payment.id} className={`flex items-center justify-between px-5 py-3 text-[13px] min-w-[400px] ${index < myPayments.length - 1 ? 'border-b border-border' : ''}`}>
                   <div>
                     <span className="font-medium text-ink">{formatRand(payment.amount_cents)}</span>
-                    <span className="text-muted ml-3">{new Date(payment.payment_date).toLocaleDateString('en-ZA', { day: 'numeric', month: 'short', year: 'numeric' })}</span>
+                    <span className="text-muted ml-3">{formatDateOnly(payment.payment_date, { day: 'numeric', month: 'short', year: 'numeric' })}</span>
                   </div>
                   <span className="text-[11px] text-muted font-mono flex-shrink-0">{payment.reference}</span>
                 </div>

--- a/lib/date-format.test.ts
+++ b/lib/date-format.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+
+import { formatDateOnly, formatShortDate } from './date-format'
+
+describe('date-only formatting', () => {
+  it('formats date-only strings without shifting in timezones behind UTC', () => {
+    expect(formatShortDate('2026-04-15')).toBe('15 Apr')
+    expect(formatDateOnly('2026-04-15', {
+      day: 'numeric',
+      month: 'short',
+      year: 'numeric',
+      timeZone: 'America/Los_Angeles',
+    })).toBe('15 Apr 2026')
+  })
+})

--- a/lib/date-format.ts
+++ b/lib/date-format.ts
@@ -1,0 +1,19 @@
+const DATE_ONLY_PATTERN = /^(\d{4})-(\d{2})-(\d{2})$/
+
+export function formatDateOnly(value: string, options: Intl.DateTimeFormatOptions): string {
+  const match = DATE_ONLY_PATTERN.exec(value)
+  if (!match) {
+    return new Date(value).toLocaleDateString('en-ZA', options)
+  }
+
+  const [, year, month, day] = match
+  const date = new Date(Date.UTC(Number(year), Number(month) - 1, Number(day)))
+  return date.toLocaleDateString('en-ZA', { ...options, timeZone: 'UTC' })
+}
+
+export function formatShortDate(value: string): string {
+  return formatDateOnly(value, {
+    day: 'numeric',
+    month: 'short',
+  })
+}


### PR DESCRIPTION
Fixes #398

## Summary
- adds a shared date-only formatter that renders `YYYY-MM-DD` values in UTC calendar space
- updates the levy page due-date and payment-date displays to avoid `new Date("YYYY-MM-DD")` timezone shifts
- adds Vitest coverage for timezones behind UTC

## Tests
- Not run locally (per instruction to avoid validation unless explicitly requested); GitHub CI will run on this PR.