### PR TITLE
fix(#397): avoid invalidating members cache before invite validation

### DIFF
--- a/app/app/[schemeId]/members/page.test.tsx
+++ b/app/app/[schemeId]/members/page.test.tsx
@@ -34,6 +34,18 @@ vi.mock("@/hooks/useAuthenticatedQuery", () => ({
   useAuthenticatedQuery: mockUseAuthenticatedQuery,
 }));
 
+function mockLoadedMembersPage() {
+  mockUseAuthenticatedQuery.mockImplementation((config: { queryKey: readonly string[] }) => {
+    const isUnitsQuery = config.queryKey[config.queryKey.length - 1] === "units";
+    return {
+      data: [],
+      isLoading: false,
+      refetch: vi.fn(),
+      ...(isUnitsQuery ? {} : { error: undefined }),
+    };
+  });
+}
+
 describe("MembersPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -86,17 +98,7 @@ describe("MembersPage", () => {
   });
 
   it("does not invalidate member cache when invite validation fails", async () => {
-    mockUseAuthenticatedQuery
-      .mockReturnValueOnce({
-        data: [],
-        isLoading: false,
-        refetch: vi.fn(),
-      })
-      .mockReturnValueOnce({
-        data: [],
-        isLoading: false,
-        refetch: vi.fn(),
-      });
+    mockLoadedMembersPage();
 
     const { default: MembersPage } = await import("@/app/app/[schemeId]/members/page");
     render(<MembersPage />);
@@ -113,17 +115,7 @@ describe("MembersPage", () => {
 
   it("invalidates member cache after a valid invite is accepted", async () => {
     mockApiFetch.mockResolvedValueOnce({ ok: true });
-    mockUseAuthenticatedQuery
-      .mockReturnValueOnce({
-        data: [],
-        isLoading: false,
-        refetch: vi.fn(),
-      })
-      .mockReturnValueOnce({
-        data: [],
-        isLoading: false,
-        refetch: vi.fn(),
-      });
+    mockLoadedMembersPage();
 
     const { default: MembersPage } = await import("@/app/app/[schemeId]/members/page");
     render(<MembersPage />);
@@ -131,7 +123,9 @@ describe("MembersPage", () => {
     fireEvent.click(screen.getByRole("button", { name: /\+ Invite member/i }));
     fireEvent.change(screen.getByPlaceholderText("e.g. Nkosi, A."), { target: { value: "Trustee User" } });
     fireEvent.change(screen.getByPlaceholderText("e.g. nkosi@email.co.za"), { target: { value: "trustee@example.com" } });
-    fireEvent.change(screen.getAllByRole("combobox")[0], { target: { value: "trustee" } });
+    const roleSelect = screen.getAllByRole("combobox").at(0);
+    if (!roleSelect) throw new Error("missing role select");
+    fireEvent.change(roleSelect, { target: { value: "trustee" } });
     fireEvent.click(screen.getByRole("button", { name: "Send invite" }));
 
     await waitFor(() => {

--- a/app/app/[schemeId]/members/page.test.tsx
+++ b/app/app/[schemeId]/members/page.test.tsx
@@ -1,10 +1,29 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 
 const mockUseAuthenticatedQuery = vi.hoisted(() => vi.fn());
+const mockApiFetch = vi.hoisted(() => vi.fn());
+const mockInvalidateCache = vi.hoisted(() => vi.fn());
+const mockAddToast = vi.hoisted(() => vi.fn());
 
 vi.mock("@/lib/auth", () => ({
   useAuth: vi.fn(() => ({ user: { role: "admin" } })),
+}));
+
+vi.mock("@/lib/api", () => ({
+  apiFetch: mockApiFetch,
+}));
+
+vi.mock("@/lib/api-contract", () => ({
+  readApiError: vi.fn(),
+}));
+
+vi.mock("@/lib/data-cache", () => ({
+  invalidateCache: mockInvalidateCache,
+}));
+
+vi.mock("@/lib/toast", () => ({
+  useToast: vi.fn(() => ({ addToast: mockAddToast })),
 }));
 
 vi.mock("next/navigation", () => ({
@@ -64,5 +83,61 @@ describe("MembersPage", () => {
     render(<MembersPage />);
 
     expect(screen.getByText("Could not load members")).toBeInTheDocument();
+  });
+
+  it("does not invalidate member cache when invite validation fails", async () => {
+    mockUseAuthenticatedQuery
+      .mockReturnValueOnce({
+        data: [],
+        isLoading: false,
+        refetch: vi.fn(),
+      })
+      .mockReturnValueOnce({
+        data: [],
+        isLoading: false,
+        refetch: vi.fn(),
+      });
+
+    const { default: MembersPage } = await import("@/app/app/[schemeId]/members/page");
+    render(<MembersPage />);
+
+    fireEvent.click(screen.getByRole("button", { name: /\+ Invite member/i }));
+    fireEvent.change(screen.getByPlaceholderText("e.g. Nkosi, A."), { target: { value: "Resident User" } });
+    fireEvent.change(screen.getByPlaceholderText("e.g. nkosi@email.co.za"), { target: { value: "resident@example.com" } });
+    fireEvent.click(screen.getByRole("button", { name: "Send invite" }));
+
+    expect(mockAddToast).toHaveBeenCalledWith("Residents require a unit assignment", "error");
+    expect(mockInvalidateCache).not.toHaveBeenCalled();
+    expect(mockApiFetch).not.toHaveBeenCalled();
+  });
+
+  it("invalidates member cache after a valid invite is accepted", async () => {
+    mockApiFetch.mockResolvedValueOnce({ ok: true });
+    mockUseAuthenticatedQuery
+      .mockReturnValueOnce({
+        data: [],
+        isLoading: false,
+        refetch: vi.fn(),
+      })
+      .mockReturnValueOnce({
+        data: [],
+        isLoading: false,
+        refetch: vi.fn(),
+      });
+
+    const { default: MembersPage } = await import("@/app/app/[schemeId]/members/page");
+    render(<MembersPage />);
+
+    fireEvent.click(screen.getByRole("button", { name: /\+ Invite member/i }));
+    fireEvent.change(screen.getByPlaceholderText("e.g. Nkosi, A."), { target: { value: "Trustee User" } });
+    fireEvent.change(screen.getByPlaceholderText("e.g. nkosi@email.co.za"), { target: { value: "trustee@example.com" } });
+    fireEvent.change(screen.getAllByRole("combobox")[0], { target: { value: "trustee" } });
+    fireEvent.click(screen.getByRole("button", { name: "Send invite" }));
+
+    await waitFor(() => {
+      expect(mockApiFetch).toHaveBeenCalledWith("/api/v1/invitations", expect.any(Object));
+    });
+    expect(mockInvalidateCache).toHaveBeenCalledWith("scheme:scheme-1:members");
+    expect(mockAddToast).toHaveBeenCalledWith("Invite sent to trustee@example.com", "success");
   });
 });

--- a/app/app/[schemeId]/members/page.tsx
+++ b/app/app/[schemeId]/members/page.tsx
@@ -126,7 +126,6 @@ export default function MembersPage() {
   }
 
   async function handleInvite() {
-    invalidateCache(`scheme:${schemeId}:members`)
     if (!inviteForm.full_name.trim() || !inviteForm.email.trim()) return
     if (inviteForm.role === 'resident' && !inviteForm.unit_id) {
       addToast('Residents require a unit assignment', 'error')
@@ -150,6 +149,7 @@ export default function MembersPage() {
         throw new Error(await readApiError(response, 'Failed to send invitation'))
       }
 
+      invalidateCache(`scheme:${schemeId}:members`)
       setShowInviteModal(false)
       setInviteForm(EMPTY_INVITE_FORM)
       addToast(`Invite sent to ${inviteForm.email.trim()}`, 'success')


### PR DESCRIPTION
Fixes #397

## Summary
- keeps members cache intact when invite form validation fails
- invalidates the members cache only after the invitation API accepts a valid request
- adds component coverage for invalid resident invites and valid trustee invites

## Tests
- Not run locally (per instruction to avoid validation unless explicitly requested); GitHub CI will run on this PR.