### PR TITLE
fix(#395): clear toast dismissal timers on unmount

### DIFF
--- a/lib/toast.test.tsx
+++ b/lib/toast.test.tsx
@@ -1,0 +1,37 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { ToastProvider, useToast } from './toast'
+
+function ToastTrigger() {
+  const { addToast } = useToast()
+  return (
+    <button type="button" onClick={() => addToast('Saved', 'success')}>
+      Add toast
+    </button>
+  )
+}
+
+describe('ToastProvider', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it('clears pending dismissal timers on unmount', () => {
+    vi.useFakeTimers()
+    const clearTimeoutSpy = vi.spyOn(globalThis, 'clearTimeout')
+    const { unmount } = render(
+      <ToastProvider>
+        <ToastTrigger />
+      </ToastProvider>,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add toast' }))
+    expect(screen.getByText('Saved')).toBeInTheDocument()
+
+    unmount()
+
+    expect(clearTimeoutSpy).toHaveBeenCalledTimes(1)
+  })
+})

--- a/lib/toast.tsx
+++ b/lib/toast.tsx
@@ -1,5 +1,5 @@
 'use client'
-import { createContext, useContext, useState, useCallback, type ReactNode } from 'react'
+import { createContext, useContext, useState, useCallback, useEffect, useRef, type ReactNode } from 'react'
 
 interface Toast {
   id: number
@@ -15,11 +15,23 @@ const ToastContext = createContext<ToastContextValue>({ addToast: () => {} })
 
 export function ToastProvider({ children }: { children: ReactNode }) {
   const [toasts, setToasts] = useState<Toast[]>([])
+  const dismissalTimers = useRef<Set<ReturnType<typeof setTimeout>>>(new Set())
 
   const addToast = useCallback((message: string, type: Toast['type'] = 'success') => {
     const id = Date.now()
     setToasts(prev => [...prev, { id, message, type }])
-    setTimeout(() => setToasts(prev => prev.filter(t => t.id !== id)), 3000)
+    const timer = setTimeout(() => {
+      dismissalTimers.current.delete(timer)
+      setToasts(prev => prev.filter(t => t.id !== id))
+    }, 3000)
+    dismissalTimers.current.add(timer)
+  }, [])
+
+  useEffect(() => () => {
+    for (const timer of dismissalTimers.current) {
+      clearTimeout(timer)
+    }
+    dismissalTimers.current.clear()
   }, [])
 
   return (


### PR DESCRIPTION
Fixes #395

## Summary
- tracks toast dismissal timers in a ref-backed set
- clears pending timers when `ToastProvider` unmounts
- adds fake-timer coverage for unmount cleanup

## Tests
- Not run locally (per instruction to avoid validation unless explicitly requested); GitHub CI will run on this PR.