### PR TITLE
fix(#396): abort auth session load on unmount

### DIFF
--- a/lib/auth.test.tsx
+++ b/lib/auth.test.tsx
@@ -89,10 +89,13 @@ describe("AuthProvider", () => {
       expect(screen.getByTestId("email")).toHaveTextContent("person@example.com");
     });
 
-    expect(fetchMock).toHaveBeenNthCalledWith(1, "/api/session");
-    expect(fetchMock).toHaveBeenNthCalledWith(2, "/api/session/refresh", {
-      method: "POST",
+    expect(fetchMock).toHaveBeenNthCalledWith(1, "/api/session", {
+      signal: expect.any(AbortSignal),
     });
+    expect(fetchMock).toHaveBeenNthCalledWith(2, "/api/session/refresh", expect.objectContaining({
+      method: "POST",
+      signal: expect.any(AbortSignal),
+    }));
   });
 
   it("retries temporary refresh unavailability before giving up", async () => {
@@ -150,12 +153,41 @@ describe("AuthProvider", () => {
       expect(screen.getByTestId("email")).toHaveTextContent("person@example.com");
     });
 
-    expect(fetchMock).toHaveBeenNthCalledWith(1, "/api/session");
-    expect(fetchMock).toHaveBeenNthCalledWith(2, "/api/session/refresh", {
-      method: "POST",
+    expect(fetchMock).toHaveBeenNthCalledWith(1, "/api/session", {
+      signal: expect.any(AbortSignal),
     });
-    expect(fetchMock).toHaveBeenNthCalledWith(3, "/api/session/refresh", {
+    expect(fetchMock).toHaveBeenNthCalledWith(2, "/api/session/refresh", expect.objectContaining({
       method: "POST",
+      signal: expect.any(AbortSignal),
+    }));
+    expect(fetchMock).toHaveBeenNthCalledWith(3, "/api/session/refresh", expect.objectContaining({
+      method: "POST",
+      signal: expect.any(AbortSignal),
+    }));
+  });
+
+  it("aborts pending session load when unmounted", async () => {
+    let capturedSignal: AbortSignal | undefined;
+    const fetchMock = vi.fn((_url: string, init?: RequestInit) => {
+      capturedSignal = init?.signal ?? undefined;
+      return new Promise<Response>(() => {});
     });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { unmount } = render(
+      <AuthProvider>
+        <AuthProbe />
+      </AuthProvider>,
+    );
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith("/api/session", {
+        signal: expect.any(AbortSignal),
+      });
+    });
+
+    unmount();
+
+    expect(capturedSignal?.aborted).toBe(true);
   });
 });

--- a/lib/auth.tsx
+++ b/lib/auth.tsx
@@ -29,6 +29,8 @@ export function AuthProvider({ children, initialUser }: AuthProviderProps) {
     }
 
     const MAX_REFRESH_RETRIES = 2;
+    const controller = new AbortController();
+    let active = true;
 
     async function tryRefreshSession(attempt = 0): Promise<SessionUser | null> {
       try {
@@ -36,6 +38,7 @@ export function AuthProvider({ children, initialUser }: AuthProviderProps) {
         const refreshResponse = await fetch("/api/session/refresh", {
           method: "POST",
           headers: csrfToken ? { "x-csrf-token": csrfToken } : undefined,
+          signal: controller.signal,
         });
         if (refreshResponse.status === 503 && attempt < MAX_REFRESH_RETRIES) {
           return tryRefreshSession(attempt + 1);
@@ -46,6 +49,9 @@ export function AuthProvider({ children, initialUser }: AuthProviderProps) {
 
         return (await refreshResponse.json()) as SessionUser | null;
       } catch {
+        if (controller.signal.aborted) {
+          return null;
+        }
         if (attempt < MAX_REFRESH_RETRIES) {
           return tryRefreshSession(attempt + 1);
         }
@@ -55,23 +61,30 @@ export function AuthProvider({ children, initialUser }: AuthProviderProps) {
 
     async function loadSession() {
       try {
-        const sessionResponse = await fetch("/api/session");
+        const sessionResponse = await fetch("/api/session", {
+          signal: controller.signal,
+        });
         const session = (await sessionResponse.json()) as SessionUser | null;
         if (session) {
-          setUser(session);
+          if (active) setUser(session);
           return;
         }
 
         const refreshed = await tryRefreshSession();
-        setUser(refreshed);
+        if (active) setUser(refreshed);
       } catch {
-        setUser(null);
+        if (active) setUser(null);
       } finally {
-        setLoading(false);
+        if (active) setLoading(false);
       }
     }
 
     void loadSession();
+
+    return () => {
+      active = false;
+      controller.abort();
+    };
   }, [initialUser]);
 
   function clearUser() {


### PR DESCRIPTION
Fixes #396

## Summary
- aborts in-flight `/api/session` and refresh requests when `AuthProvider` unmounts
- guards async session state updates with an active flag
- adds regression coverage for aborting a pending session load

## Tests
- Not run locally (per instruction to avoid validation unless explicitly requested); GitHub CI will run on this PR.