### PR TITLE
fix(#383): handle WhatsApp threads with no messages

### DIFF
--- a/app/app/[schemeId]/whatsapp/page.test.tsx
+++ b/app/app/[schemeId]/whatsapp/page.test.tsx
@@ -146,4 +146,27 @@ describe("WhatsAppPage", () => {
     expect(screen.queryByText("Maintenance")).not.toBeInTheDocument();
     expect(screen.getByText("Connect via WhatsApp")).toBeInTheDocument();
   });
+
+  it("renders an operator thread with no messages without crashing", async () => {
+    const baseThread = mockDashboard.threads[0];
+    if (!baseThread) throw new Error("missing base thread");
+
+    mockGetCached.mockReturnValue({
+      ...mockDashboard,
+      threads: [
+        {
+          ...baseThread,
+          id: "thread-empty",
+          messages: [],
+          unread: 0,
+        },
+      ],
+      unread_count: 0,
+    });
+
+    const { default: WhatsAppPage } = await import("@/app/app/[schemeId]/whatsapp/page");
+    render(<WhatsAppPage />);
+
+    expect(screen.getByText("No messages yet")).toBeInTheDocument();
+  });
 });

--- a/app/app/[schemeId]/whatsapp/page.tsx
+++ b/app/app/[schemeId]/whatsapp/page.tsx
@@ -184,7 +184,7 @@ function ResidentView({ thread, phoneNumber }: { thread?: WhatsAppThread | null;
 
 function ThreadCard({ thread }: { thread: WhatsAppThread }) {
   const [expanded, setExpanded] = useState(false)
-  const lastMsg = thread.messages[thread.messages.length - 1]
+  const lastMsg = thread.messages.length > 0 ? thread.messages[thread.messages.length - 1] : null
 
   return (
     <div className={`border-b border-border last:border-b-0 ${!thread.connected ? 'opacity-50' : ''}`}>


### PR DESCRIPTION
Fixes #383

## Summary
- makes the thread-card last-message lookup explicit for empty message arrays
- renders `No messages yet` for connected threads with no messages
- adds page coverage for an operator thread with an empty message list

## Tests
- Not run locally (per instruction to avoid validation unless explicitly requested); GitHub CI will run on this PR.