### PR TITLE
fix(#386): handle bank import raw data marshal errors

### DIFF
--- a/backend/internal/levy/bank_statement_import.go
+++ b/backend/internal/levy/bank_statement_import.go
@@ -203,6 +203,14 @@ func fingerprintBankStatementRow(bankName string, row ParsedBankStatementRow) st
 	return fmt.Sprintf("%x", h.Sum(nil))
 }
 
+func marshalBankStatementRawData(rawData map[string]string) ([]byte, error) {
+	rawDataJSON, err := json.Marshal(rawData)
+	if err != nil {
+		return nil, fmt.Errorf("marshal bank statement raw data: %w", err)
+	}
+	return rawDataJSON, nil
+}
+
 func matchBankStatementRow(row ParsedBankStatementRow, accounts []candidateLevyAccount) matchedBankStatementRow {
 	normalRef := row.NormalizedRef
 	if normalRef == "" {
@@ -674,7 +682,10 @@ func (s *Service) ProcessBankStatementImport(ctx context.Context, importID strin
 	var matchedCount, ambiguousCount, unmatchedCount int32
 
 	for _, parsed := range parsedRows {
-		rawDataJSON, _ := json.Marshal(parsed.RawData)
+		rawDataJSON, marshalErr := marshalBankStatementRawData(parsed.RawData)
+		if marshalErr != nil {
+			return fmt.Errorf("%w: %v", jobs.ErrNonRetryable, marshalErr)
+		}
 		match := matchBankStatementRow(parsed, accounts)
 
 		var matchedAccountID pgtype.UUID

--- a/backend/internal/levy/bank_statement_import_test.go
+++ b/backend/internal/levy/bank_statement_import_test.go
@@ -1,6 +1,7 @@
 package levy
 
 import (
+	"encoding/json"
 	"os"
 	"testing"
 	"time"
@@ -94,6 +95,25 @@ func TestFingerprintIsDeterministic(t *testing.T) {
 	fp2 := fingerprintBankStatementRow("fnb", row1)
 	if fp1 != fp2 {
 		t.Fatalf("fingerprint mismatch: %s vs %s", fp1, fp2)
+	}
+}
+
+func TestMarshalBankStatementRawDataPreservesSourceFields(t *testing.T) {
+	rawDataJSON, err := marshalBankStatementRawData(map[string]string{
+		"Date":        "2026-04-01",
+		"Description": "EFT Unit 1A",
+		"Amount":      "2450.00",
+	})
+	if err != nil {
+		t.Fatalf("marshal raw data: %v", err)
+	}
+
+	var decoded map[string]string
+	if err := json.Unmarshal(rawDataJSON, &decoded); err != nil {
+		t.Fatalf("unmarshal raw data: %v", err)
+	}
+	if decoded["Description"] != "EFT Unit 1A" {
+		t.Fatalf("description = %q, want source value", decoded["Description"])
 	}
 }
 


### PR DESCRIPTION
Fixes #386

## Summary
- handles `json.Marshal` failures for bank statement raw row data explicitly
- fails the import job as non-retryable instead of inserting nil raw data
- adds unit coverage for raw data JSON preservation

## Tests
- Not run locally (per instruction to avoid validation unless explicitly requested); GitHub CI will run on this PR.