### PR TITLE
fix(#390): cancel unused proxy retry body

### DIFF
--- a/app/api/proxy/[...path]/route.test.ts
+++ b/app/api/proxy/[...path]/route.test.ts
@@ -203,6 +203,43 @@ describe("proxyRequest", () => {
     ]);
   });
 
+  it("cancels the unused retry body branch when no retry is needed", async () => {
+    const cancelRetryBody = vi.fn(async () => undefined);
+    const request = {
+      method: "POST",
+      url: "http://localhost/api/proxy/api/v1/invitations",
+      headers: new Headers({
+        "x-csrf-token": "expected-token",
+      }),
+      body: {
+        tee: () => [
+          new ReadableStream({
+            start(controller) {
+              controller.enqueue(new TextEncoder().encode(JSON.stringify({ full_name: "Test User" })));
+              controller.close();
+            },
+          }),
+          { cancel: cancelRetryBody },
+        ],
+      },
+    };
+
+    vi.stubGlobal("fetch", vi.fn(async () => {
+      return new Response(JSON.stringify({ data: { ok: true } }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }));
+
+    const { POST } = await import("./route");
+    const params = Promise.resolve({ path: ["api", "v1", "invitations"] });
+
+    const response = await POST(request as unknown as import("next/server").NextRequest, { params });
+
+    expect(response.status).toBe(200);
+    expect(cancelRetryBody).toHaveBeenCalledTimes(1);
+  });
+
   it("returns 503 without clearing auth when refresh is temporarily unavailable", async () => {
     vi.stubGlobal("fetch", vi.fn(async () => new Response(null, { status: 401 })));
     refreshAuthSession.mockResolvedValue({ kind: "unavailable" });

--- a/app/api/proxy/[...path]/route.ts
+++ b/app/api/proxy/[...path]/route.ts
@@ -115,6 +115,15 @@ function shouldRetry(method: string, status: number): boolean {
   return method === "GET" && (status === 502 || status === 503 || status === 504);
 }
 
+async function cancelUnusedRetryBody(body?: ReadableStream<Uint8Array>) {
+  if (!body) return;
+  try {
+    await body.cancel();
+  } catch {
+    // The branch may already be closed or errored by the runtime. Cleanup is best-effort.
+  }
+}
+
 function forbiddenResponse(message: string) {
   return new Response(
     JSON.stringify({
@@ -156,7 +165,7 @@ async function proxyRequest(request: NextRequest, pathSegments: string[]) {
   }
 
   let requestBody: BodyInit | undefined;
-  let requestBodyRetry: BodyInit | undefined;
+  let requestBodyRetry: ReadableStream<Uint8Array> | undefined;
   if (request.method !== "GET" && request.method !== "HEAD" && request.body) {
     const [firstBody, secondBody] = request.body.tee();
     requestBody = firstBody;
@@ -193,6 +202,7 @@ async function proxyRequest(request: NextRequest, pathSegments: string[]) {
     });
   } catch (error) {
     clearTimeout(timeout);
+    await cancelUnusedRetryBody(requestBodyRetry);
     if (error instanceof DOMException && error.name === "AbortError") {
       return upstreamUnavailableResponse();
     }
@@ -238,15 +248,18 @@ async function proxyRequest(request: NextRequest, pathSegments: string[]) {
         throw error;
       }
     }
+    await cancelUnusedRetryBody(requestBodyRetry);
     return proxyResponse(withTiming(firstResponse), requestId);
   }
 
   const refreshed = await refreshAuthSession();
   if (refreshed.kind === "invalid") {
+    await cancelUnusedRetryBody(requestBodyRetry);
     await clearAuthCookies();
     return unauthorizedResponse();
   }
   if (refreshed.kind === "unavailable") {
+    await cancelUnusedRetryBody(requestBodyRetry);
     return upstreamUnavailableResponse();
   }
 


### PR DESCRIPTION
Fixes #390

## Summary
- cancels the spare retry stream branch when the proxy exits without consuming it
- keeps auth-refresh retry behavior intact for mutating requests
- adds regression coverage for non-retry success cleanup

## Tests
- Not run locally (per instruction to avoid validation unless explicitly requested); GitHub CI will run on this PR.