### PR TITLE
fix(#372): invalidate current financials after budget save

### DIFF
--- a/app/app/[schemeId]/financials/page.test.tsx
+++ b/app/app/[schemeId]/financials/page.test.tsx
@@ -1,13 +1,24 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockUseAuth = vi.hoisted(() => vi.fn());
 const mockUseAuthenticatedQuery = vi.hoisted(() => vi.fn());
+const mockInvalidateCache = vi.hoisted(() => vi.fn());
+const mockInvalidateQueries = vi.hoisted(() => vi.fn());
+const mockUpsertBudgetLine = vi.hoisted(() => vi.fn());
+const mockAddToast = vi.hoisted(() => vi.fn());
 
 vi.mock("@/lib/auth", () => ({ useAuth: mockUseAuth }));
 vi.mock("next/navigation", () => ({ useParams: vi.fn(() => ({ schemeId: "scheme-1" })) }));
 vi.mock("@/hooks/useAuthenticatedQuery", () => ({ useAuthenticatedQuery: mockUseAuthenticatedQuery }));
-vi.mock("@/lib/toast", () => ({ useToast: vi.fn(() => ({ addToast: vi.fn() })) }));
+vi.mock("@/lib/toast", () => ({ useToast: vi.fn(() => ({ addToast: mockAddToast })) }));
+vi.mock("@/lib/data-cache", () => ({ invalidateCache: mockInvalidateCache }));
+vi.mock("@/lib/query-client", () => ({ queryClient: { invalidateQueries: mockInvalidateQueries } }));
+vi.mock("@/lib/financials-api", () => ({
+  getFinancialDashboard: vi.fn(),
+  updateReserveFund: vi.fn(),
+  upsertBudgetLine: mockUpsertBudgetLine,
+}));
 
 const dashboard = {
   reserve_fund: { scheme_id: "scheme-1", balance_cents: 1000000, target_cents: 2500000, last_updated: new Date().toISOString() },
@@ -39,6 +50,7 @@ const dashboard = {
 describe("FinancialsPage predictive levy analytics", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockUseAuth.mockReturnValue({ user: { role: "admin" } });
     mockUseAuthenticatedQuery.mockReturnValue({ data: dashboard, isLoading: false });
   });
 
@@ -60,5 +72,42 @@ describe("FinancialsPage predictive levy analytics", () => {
     render(<FinancialsPage />);
 
     expect(screen.queryByText("Predictive levy outlook")).not.toBeInTheDocument();
+  });
+
+  it("invalidates the visible current financials query after saving a budget line", async () => {
+    mockUseAuth.mockReturnValue({ user: { role: "admin" } });
+    mockUpsertBudgetLine.mockResolvedValueOnce(undefined);
+    const { default: FinancialsPage } = await import("@/app/app/[schemeId]/financials/page");
+
+    render(<FinancialsPage />);
+
+    fireEvent.click(screen.getByRole("button", { name: "+ Budget line" }));
+    const textboxes = screen.getAllByRole("textbox");
+    const categoryInput = textboxes.at(0);
+    const periodInput = textboxes.at(1);
+    if (!categoryInput || !periodInput) throw new Error("missing budget text inputs");
+    fireEvent.change(categoryInput, { target: { value: "Maintenance" } });
+    fireEvent.change(periodInput, { target: { value: "2027" } });
+    const amountInputs = screen.getAllByRole("spinbutton");
+    const budgetAmountInput = amountInputs.at(0);
+    const actualAmountInput = amountInputs.at(1);
+    if (!budgetAmountInput || !actualAmountInput) throw new Error("missing budget amount inputs");
+    fireEvent.change(budgetAmountInput, { target: { value: "1000" } });
+    fireEvent.change(actualAmountInput, { target: { value: "250" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(mockUpsertBudgetLine).toHaveBeenCalledWith("scheme-1", {
+        category: "Maintenance",
+        period_label: "2027",
+        budgeted_cents: 100000,
+        actual_cents: 25000,
+      });
+    });
+    expect(mockInvalidateCache).toHaveBeenCalledWith("scheme:scheme-1:financials");
+    expect(mockInvalidateQueries).toHaveBeenCalledWith({
+      queryKey: ["scheme", "scheme-1", "financials"],
+    });
+    expect(mockAddToast).toHaveBeenCalledWith("Budget line saved", "success");
   });
 });

--- a/app/app/[schemeId]/financials/page.tsx
+++ b/app/app/[schemeId]/financials/page.tsx
@@ -112,8 +112,7 @@ export default function FinancialsPage() {
 
   async function refreshDashboard(nextPeriod?: string) {
     invalidateCache(`scheme:${schemeId}:financials`)
-    const newPeriod = nextPeriod || selectedPeriod || 'current'
-    await queryClient.invalidateQueries({ queryKey: schemeKeys.financials(schemeId, newPeriod) })
+    await queryClient.invalidateQueries({ queryKey: schemeKeys.financialsBase(schemeId) })
     if (!nextPeriod && dashboard?.selected_period) {
       setSelectedPeriod(dashboard.selected_period)
     }


### PR DESCRIPTION
Fixes #372

## Summary
- invalidates the scheme financials query prefix after budget/reserve mutations
- ensures the visible `current` financials query refetches after saving a new-period budget line
- adds component coverage for the budget-save invalidation path

## Tests
- Not run locally (per instruction to avoid validation unless explicitly requested); GitHub CI will run on this PR.