### PR TITLE
fix(#370 #371): treat empty levy periods as fully collected

### DIFF
--- a/backend/internal/ai/service.go
+++ b/backend/internal/ai/service.go
@@ -365,7 +365,7 @@ func countOpenMaintenance(requests []dbgen.MaintenanceRequest) int {
 
 func collectionPctFromRows(accounts []dbgen.ListLevyAccountsByPeriodRow) int {
 	if len(accounts) == 0 {
-		return 0
+		return 100
 	}
 	var totalDue int64
 	var totalPaid int64
@@ -374,7 +374,7 @@ func collectionPctFromRows(accounts []dbgen.ListLevyAccountsByPeriodRow) int {
 		totalPaid += minInt64(account.PaidCents, account.AmountCents)
 	}
 	if totalDue == 0 {
-		return 0
+		return 100
 	}
 	return int(math.Round(float64(totalPaid) * 100 / float64(totalDue)))
 }

--- a/backend/internal/ai/service_test.go
+++ b/backend/internal/ai/service_test.go
@@ -81,6 +81,19 @@ func TestTopOverdueAccountsRedactsOwnerName(t *testing.T) {
 	}
 }
 
+func TestCollectionPctFromRowsTreatsEmptyAndZeroDueAsFullyCollected(t *testing.T) {
+	if got := collectionPctFromRows(nil); got != 100 {
+		t.Fatalf("empty collection pct = %d, want 100", got)
+	}
+
+	got := collectionPctFromRows([]dbgen.ListLevyAccountsByPeriodRow{
+		{AmountCents: 0, PaidCents: 0},
+	})
+	if got != 100 {
+		t.Fatalf("zero-due collection pct = %d, want 100", got)
+	}
+}
+
 func TestMapMaintenanceRedactsContractorName(t *testing.T) {
 	items := mapMaintenance([]dbgen.MaintenanceRequest{
 		{

--- a/backend/internal/financials/service.go
+++ b/backend/internal/financials/service.go
@@ -328,6 +328,8 @@ func (s *Service) buildLevySummary(ctx context.Context, schemeID uuid.UUID) (*Le
 	}
 	if summary.TotalBilledCents > 0 {
 		summary.CollectionRatePct = int(math.Round(float64(summary.TotalCollectedCents) * 100 / float64(summary.TotalBilledCents)))
+	} else {
+		summary.CollectionRatePct = 100
 	}
 	return summary, nil
 }

--- a/backend/tests/integration/financials_test.go
+++ b/backend/tests/integration/financials_test.go
@@ -139,6 +139,39 @@ func TestFinancials_DashboardAndUpdates(t *testing.T) {
 	}
 }
 
+func TestFinancials_EmptyLevyPeriodReportsFullyCollected(t *testing.T) {
+	h := newFinancialsHandler(t)
+	accessToken, _ := setupAgent(t)
+	schemeID := setupScheme(t, accessToken)
+	schemeUUID := mustParseFinancialUUID(t, schemeID)
+
+	if _, err := testQ.CreateLevyPeriod(t.Context(), dbgen.CreateLevyPeriodParams{
+		SchemeID:    schemeUUID,
+		Label:       "Empty Period",
+		AmountCents: 245000,
+		DueDate:     pgtype.Date{Time: time.Now().AddDate(0, 0, 14), Valid: true},
+	}); err != nil {
+		t.Fatalf("create empty levy period: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/financials/"+schemeID, nil)
+	req = withRouteParams(req, map[string]string{"schemeId": schemeID})
+	req = withAuthContext(req, accessToken, testJWTSigningKey)
+	w := httptest.NewRecorder()
+	h.Dashboard(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("dashboard: status=%d body=%s", w.Code, w.Body)
+	}
+
+	dashboard := decodeSuccess[financials.DashboardResponse](t, w)
+	if dashboard.LevySummary == nil {
+		t.Fatalf("expected levy summary for empty current period")
+	}
+	if dashboard.LevySummary.TotalBilledCents != 0 || dashboard.LevySummary.CollectionRatePct != 100 {
+		t.Fatalf("levy summary = %+v, want zero billed and 100%% collected", dashboard.LevySummary)
+	}
+}
+
 func mustParseFinancialUUID(t *testing.T, value string) uuid.UUID {
 	t.Helper()
 	id, err := uuid.Parse(value)


### PR DESCRIPTION
Fixes #370
Fixes #371

## Summary
- aligns Copilot and financial dashboard collection-rate semantics with scheme summary behavior
- reports empty or zero-total levy periods as 100% collected instead of 0%
- adds unit and integration coverage for empty/zero-due levy-period collection rates

## Tests
- Not run locally (per instruction to avoid validation unless explicitly requested); GitHub CI will run on this PR.