### PR TITLE
fix(#367): reject blank compliance item fields

### DIFF
--- a/backend/internal/compliance/service.go
+++ b/backend/internal/compliance/service.go
@@ -3,6 +3,7 @@ package compliance
 import (
 	"context"
 	"errors"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -205,7 +206,13 @@ func (s *Service) CreateItem(ctx context.Context, identity auth.Identity, scheme
 	if auth.IsResidentRole(role) {
 		return nil, ErrForbidden
 	}
-	if !validCategory(input.Category) || input.Title == "" {
+
+	input.Category = strings.TrimSpace(input.Category)
+	input.Title = strings.TrimSpace(input.Title)
+	input.Requirement = strings.TrimSpace(input.Requirement)
+	input.Detail = strings.TrimSpace(input.Detail)
+	input.Action = strings.TrimSpace(input.Action)
+	if !validCategory(input.Category) || input.Title == "" || input.Requirement == "" || input.Detail == "" || input.Action == "" {
 		return nil, ErrInvalidInput
 	}
 
@@ -344,11 +351,11 @@ func (s *Service) Assess(ctx context.Context, identity auth.Identity, schemeID s
 	}
 
 	_, _ = s.db.Q.CreateComplianceAssessment(ctx, dbgen.CreateComplianceAssessmentParams{
-		SchemeID:         scheme.ID,
-		Score:            int32(dashboard.Score),
-		TotalItems:       int32(dashboard.Total),
-		CompliantCount:   int32(dashboard.CompliantCount),
-		AtRiskCount:      int32(dashboard.AtRiskCount),
+		SchemeID:          scheme.ID,
+		Score:             int32(dashboard.Score),
+		TotalItems:        int32(dashboard.Total),
+		CompliantCount:    int32(dashboard.CompliantCount),
+		AtRiskCount:       int32(dashboard.AtRiskCount),
 		NonCompliantCount: int32(dashboard.NonCompliantCount),
 	})
 

--- a/backend/tests/integration/compliance_test.go
+++ b/backend/tests/integration/compliance_test.go
@@ -5,6 +5,7 @@ package integration
 import (
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -101,6 +102,82 @@ func TestComplianceDashboard(t *testing.T) {
 	if w.Code != http.StatusForbidden {
 		t.Fatalf("resident compliance dashboard should be forbidden: status=%d body=%s", w.Code, w.Body)
 	}
+}
+
+func TestComplianceCreateItemRejectsWhitespaceRequiredTextFields(t *testing.T) {
+	h := newComplianceHandler(t)
+	accessToken, orgID := setupAgent(t)
+	schemeID := setupScheme(t, accessToken)
+	trusteeUserID := createMemberRecord(t, orgID, schemeID, uniqueEmail(t), "Trustee User", string(auth.RoleTrustee), nil)
+
+	basePayload := map[string]string{
+		"category":    string(dbgen.ComplianceCategoryFinancial),
+		"title":       "Reserve fund review",
+		"requirement": "Confirm annual reserve fund planning",
+		"detail":      "Review the latest approved maintenance plan",
+		"action":      "Upload trustee approval evidence",
+	}
+
+	for _, field := range []string{"title", "requirement", "detail", "action"} {
+		t.Run(field, func(t *testing.T) {
+			payload := make(map[string]string, len(basePayload))
+			for key, value := range basePayload {
+				payload[key] = value
+			}
+			payload[field] = "   "
+
+			req := complianceCreateItemRequest(t, schemeID, payload)
+			req = req.WithContext(auth.ContextWithIdentity(req.Context(), trusteeUserID, orgID, string(auth.RoleTrustee)))
+			w := httptest.NewRecorder()
+			h.CreateItem(w, req)
+			if w.Code != http.StatusBadRequest {
+				t.Fatalf("create compliance item with blank %s should be rejected: status=%d body=%s", field, w.Code, w.Body)
+			}
+		})
+	}
+}
+
+func TestComplianceCreateItemStoresTrimmedRequiredTextFields(t *testing.T) {
+	h := newComplianceHandler(t)
+	accessToken, orgID := setupAgent(t)
+	schemeID := setupScheme(t, accessToken)
+	trusteeUserID := createMemberRecord(t, orgID, schemeID, uniqueEmail(t), "Trustee User", string(auth.RoleTrustee), nil)
+
+	req := complianceCreateItemRequest(t, schemeID, map[string]string{
+		"category":    " " + string(dbgen.ComplianceCategoryFinancial) + " ",
+		"title":       "  Reserve fund review  ",
+		"requirement": "  Confirm annual reserve fund planning  ",
+		"detail":      "  Review the latest approved maintenance plan  ",
+		"action":      "  Upload trustee approval evidence  ",
+	})
+	req = req.WithContext(auth.ContextWithIdentity(req.Context(), trusteeUserID, orgID, string(auth.RoleTrustee)))
+	w := httptest.NewRecorder()
+	h.CreateItem(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("create compliance item with padded fields: status=%d body=%s", w.Code, w.Body)
+	}
+
+	item := decodeSuccess[compliance.ItemInfo](t, w)
+	if item.Category != string(dbgen.ComplianceCategoryFinancial) ||
+		item.Title != "Reserve fund review" ||
+		item.Requirement != "Confirm annual reserve fund planning" ||
+		item.Detail != "Review the latest approved maintenance plan" ||
+		item.Action != "Upload trustee approval evidence" {
+		t.Fatalf("expected trimmed compliance item fields, got %+v", item)
+	}
+}
+
+func complianceCreateItemRequest(t *testing.T, schemeID string, payload map[string]string) *http.Request {
+	t.Helper()
+
+	body := `{"category":"` + payload["category"] +
+		`","title":"` + payload["title"] +
+		`","requirement":"` + payload["requirement"] +
+		`","detail":"` + payload["detail"] +
+		`","action":"` + payload["action"] + `"}`
+	req := httptest.NewRequest(http.MethodPost, "/compliance/"+schemeID+"/items", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	return withRouteParams(req, map[string]string{"schemeId": schemeID})
 }
 
 func timePointer(value time.Time) *time.Time {


### PR DESCRIPTION
## Summary
- trim compliance item create fields before validation
- reject blank title, requirement, detail, or action values after trimming
- cover blank-field rejection and trimmed persistence in integration tests

Fixes #367

## Tests
- Not run locally per instruction; relying on GitHub CI.