### PR TITLE
fix(#365): validate levy account status filters

### DIFF
--- a/backend/internal/integrations/openapi.json
+++ b/backend/internal/integrations/openapi.json
@@ -137,7 +137,8 @@
             "name": "status",
             "in": "query",
             "schema": {
-              "type": "string"
+              "type": "string",
+              "enum": ["paid", "partial", "overdue", "pending"]
             }
           },
           {

--- a/backend/internal/integrations/service.go
+++ b/backend/internal/integrations/service.go
@@ -3,6 +3,7 @@ package integrations
 import (
 	"context"
 	"errors"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -424,6 +425,10 @@ func (s *Service) ListOpenAPILevyAccounts(ctx context.Context, schemeID string, 
 	}
 	var status pgtype.Text
 	if filters.Status != "" {
+		filters.Status = strings.TrimSpace(filters.Status)
+		if !validOpenAPILevyAccountStatus(filters.Status) {
+			return nil, 0, ErrInvalidInput
+		}
 		status = pgtype.Text{String: filters.Status, Valid: true}
 	}
 	var updatedSince pgtype.Timestamptz
@@ -472,6 +477,15 @@ func (s *Service) ListOpenAPILevyAccounts(ctx context.Context, schemeID string, 
 		})
 	}
 	return result, int(total), nil
+}
+
+func validOpenAPILevyAccountStatus(status string) bool {
+	switch status {
+	case "paid", "partial", "overdue", "pending":
+		return true
+	default:
+		return false
+	}
 }
 
 func (s *Service) ListOpenAPILevyPayments(ctx context.Context, schemeID string, filters OpenAPILevyPaymentFilters) ([]OpenAPILevyPaymentInfo, int, error) {

--- a/backend/tests/integration/integrations_test.go
+++ b/backend/tests/integration/integrations_test.go
@@ -45,6 +45,34 @@ func TestOpenAPI_ReadsSchemeLevyAndFinancialDataWithAPIKey(t *testing.T) {
 	}
 }
 
+func TestOpenAPI_LevyAccountsRejectsInvalidStatusFilter(t *testing.T) {
+	h := newIntegrationsHandler(t)
+	accessToken, _ := setupAgent(t)
+	schemeID := setupScheme(t, accessToken)
+
+	body, _ := json.Marshal(map[string]any{
+		"name":       "Levy Status Reader",
+		"scheme_ids": []string{schemeID},
+		"scopes":     []string{"read:levies"},
+	})
+	req := httptest.NewRequest(http.MethodPost, "/integrations/api-clients", bytes.NewReader(body))
+	req = withAuthContext(req, accessToken, testJWTSigningKey)
+	w := httptest.NewRecorder()
+	h.CreateAPIClient(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("create client: status=%d body=%s", w.Code, w.Body)
+	}
+	created := decodeSuccess[integrations.APIClientCreateResponse](t, w)
+
+	req = httptest.NewRequest(http.MethodGet, "/schemes/"+schemeID+"/levy-accounts?status=paidd", nil)
+	req.Header.Set("Authorization", "Bearer "+created.APIKey)
+	w = httptest.NewRecorder()
+	h.OpenRoutes().ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("invalid levy account status filter should be rejected: status=%d body=%s", w.Code, w.Body)
+	}
+}
+
 func TestIntegrations_AdminCreatesAndRevokesAPIClient(t *testing.T) {
 	h := newIntegrationsHandler(t)
 	accessToken, orgID := setupAgent(t)


### PR DESCRIPTION
## Summary
- validate OpenAPI levy account status filters before querying
- reject unsupported status values with 400 instead of returning empty 200 responses
- document supported levy account statuses as an OpenAPI enum

Fixes #365

## Tests
- Not run locally per instruction; relying on GitHub CI.