### PR TITLE
fix(#364): dedupe integration client scheme ids

### DIFF
--- a/backend/internal/integrations/service.go
+++ b/backend/internal/integrations/service.go
@@ -178,11 +178,16 @@ func validScopes(scopes []string) bool {
 
 func parseUUIDs(values []string) ([]uuid.UUID, error) {
 	ids := make([]uuid.UUID, 0, len(values))
+	seen := make(map[uuid.UUID]struct{}, len(values))
 	for _, value := range values {
 		id, err := uuid.Parse(value)
 		if err != nil {
 			return nil, err
 		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
 		ids = append(ids, id)
 	}
 	return ids, nil

--- a/backend/tests/integration/integrations_test.go
+++ b/backend/tests/integration/integrations_test.go
@@ -73,6 +73,30 @@ func TestOpenAPI_LevyAccountsRejectsInvalidStatusFilter(t *testing.T) {
 	}
 }
 
+func TestIntegrations_AdminCreatesAPIClientWithDuplicateSchemeIDs(t *testing.T) {
+	h := newIntegrationsHandler(t)
+	accessToken, _ := setupAgent(t)
+	schemeID := setupScheme(t, accessToken)
+
+	body, _ := json.Marshal(map[string]any{
+		"name":       "Duplicate Scheme Reader",
+		"scheme_ids": []string{schemeID, schemeID},
+		"scopes":     []string{"read:schemes"},
+	})
+	req := httptest.NewRequest(http.MethodPost, "/integrations/api-clients", bytes.NewReader(body))
+	req = withAuthContext(req, accessToken, testJWTSigningKey)
+	w := httptest.NewRecorder()
+	h.CreateAPIClient(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("create client with duplicate scheme ids: status=%d body=%s", w.Code, w.Body)
+	}
+
+	created := decodeSuccess[integrations.APIClientCreateResponse](t, w)
+	if len(created.SchemeIDs) != 1 || created.SchemeIDs[0] != schemeID {
+		t.Fatalf("expected duplicate scheme ids to be stored once, got %+v", created.SchemeIDs)
+	}
+}
+
 func TestIntegrations_AdminCreatesAndRevokesAPIClient(t *testing.T) {
 	h := newIntegrationsHandler(t)
 	accessToken, orgID := setupAgent(t)


### PR DESCRIPTION
## Summary
- de-duplicate parsed scheme IDs during integration API client creation
- validate and link only the unique scheme set
- cover duplicate scheme IDs creating a single scoped client

Fixes #364

## Tests
- Not run locally per instruction; relying on GitHub CI.