### PR TITLE
fix(#366): surface OpenAPI reserve fund lookup errors

### DIFF
--- a/backend/internal/integrations/handler.go
+++ b/backend/internal/integrations/handler.go
@@ -1,6 +1,7 @@
 package integrations
 
 import (
+	"context"
 	_ "embed"
 	"errors"
 	"net/http"
@@ -10,6 +11,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 
 	dbgen "github.com/stratahq/backend/db/gen"
@@ -301,25 +303,40 @@ func (h *Handler) OpenFinancials(w http.ResponseWriter, r *http.Request) {
 		writeIntegrationsError(w, ErrInvalidInput)
 		return
 	}
-	periodLabel := r.URL.Query().Get("period")
-	var periodFilter pgtype.Text
-	if periodLabel != "" {
-		periodFilter = pgtype.Text{String: periodLabel, Valid: true}
-	}
-	lines, err := h.service.db.Q.ListOpenAPIBudgetLinesByScheme(r.Context(), dbgen.ListOpenAPIBudgetLinesBySchemeParams{
-		SchemeID:    sid,
-		PeriodLabel: periodFilter,
-	})
+	result, err := openAPIFinancials(r.Context(), h.service.db.Q, sid, r.URL.Query().Get("period"))
 	if err != nil {
 		writeIntegrationsError(w, err)
 		return
 	}
-	reserve, _ := h.service.db.Q.GetOpenAPIReserveFundByScheme(r.Context(), sid)
+	response.JSON(w, http.StatusOK, result)
+}
+
+type openAPIFinancialsQuerier interface {
+	ListOpenAPIBudgetLinesByScheme(ctx context.Context, arg dbgen.ListOpenAPIBudgetLinesBySchemeParams) ([]dbgen.BudgetLine, error)
+	GetOpenAPIReserveFundByScheme(ctx context.Context, schemeID uuid.UUID) (dbgen.ReserveFund, error)
+}
+
+func openAPIFinancials(ctx context.Context, q openAPIFinancialsQuerier, schemeID uuid.UUID, periodLabel string) (map[string]any, error) {
+	var periodFilter pgtype.Text
+	if periodLabel != "" {
+		periodFilter = pgtype.Text{String: periodLabel, Valid: true}
+	}
+	lines, err := q.ListOpenAPIBudgetLinesByScheme(ctx, dbgen.ListOpenAPIBudgetLinesBySchemeParams{
+		SchemeID:    schemeID,
+		PeriodLabel: periodFilter,
+	})
+	if err != nil {
+		return nil, err
+	}
+	reserve, err := q.GetOpenAPIReserveFundByScheme(ctx, schemeID)
+	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+		return nil, err
+	}
 	result := map[string]any{
 		"budget_lines": lines,
 	}
-	if reserve.SchemeID != uuid.Nil {
+	if err == nil && reserve.SchemeID != uuid.Nil {
 		result["reserve_fund"] = reserve
 	}
-	response.JSON(w, http.StatusOK, result)
+	return result, nil
 }

--- a/backend/internal/integrations/handler_test.go
+++ b/backend/internal/integrations/handler_test.go
@@ -1,0 +1,46 @@
+package integrations
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	dbgen "github.com/stratahq/backend/db/gen"
+)
+
+func TestOpenAPIFinancialsReturnsReserveFundErrors(t *testing.T) {
+	reserveErr := errors.New("reserve lookup failed")
+	_, err := openAPIFinancials(context.Background(), fakeOpenAPIFinancialsQuerier{
+		reserveErr: reserveErr,
+	}, uuid.New(), "")
+	if !errors.Is(err, reserveErr) {
+		t.Fatalf("expected reserve error, got %v", err)
+	}
+}
+
+func TestOpenAPIFinancialsSuppressesMissingReserveFund(t *testing.T) {
+	result, err := openAPIFinancials(context.Background(), fakeOpenAPIFinancialsQuerier{
+		reserveErr: pgx.ErrNoRows,
+	}, uuid.New(), "")
+	if err != nil {
+		t.Fatalf("missing reserve fund should not fail: %v", err)
+	}
+	if _, ok := result["reserve_fund"]; ok {
+		t.Fatalf("missing reserve fund should be omitted, got %+v", result)
+	}
+}
+
+type fakeOpenAPIFinancialsQuerier struct {
+	reserveErr error
+}
+
+func (f fakeOpenAPIFinancialsQuerier) ListOpenAPIBudgetLinesByScheme(context.Context, dbgen.ListOpenAPIBudgetLinesBySchemeParams) ([]dbgen.BudgetLine, error) {
+	return []dbgen.BudgetLine{}, nil
+}
+
+func (f fakeOpenAPIFinancialsQuerier) GetOpenAPIReserveFundByScheme(context.Context, uuid.UUID) (dbgen.ReserveFund, error) {
+	return dbgen.ReserveFund{}, f.reserveErr
+}


### PR DESCRIPTION
## Summary
- route OpenAPI financials assembly through a small query seam
- suppress only pgx.ErrNoRows for missing reserve fund data
- return non-empty reserve lookup errors instead of silent partial 200 responses

Fixes #366

## Tests
- Not run locally per instruction; relying on GitHub CI.