### PR TITLE
fix(#368): return portfolio compliance errors

### DIFF
--- a/backend/internal/compliance/service.go
+++ b/backend/internal/compliance/service.go
@@ -48,11 +48,15 @@ type DashboardResponse struct {
 }
 
 type Service struct {
-	db *database.Pool
+	db                   *database.Pool
+	listSchemesByOrgFn   func(context.Context, uuid.UUID) ([]dbgen.Scheme, error)
+	dashboardForSchemeFn func(context.Context, uuid.UUID) (*DashboardResponse, error)
 }
 
 func NewService(db *database.Pool) *Service {
-	return &Service{db: db}
+	svc := &Service{db: db}
+	svc.dashboardForSchemeFn = svc.dashboardForScheme
+	return svc
 }
 
 func (s *Service) Dashboard(ctx context.Context, identity auth.Identity, schemeID string) (*DashboardResponse, error) {
@@ -344,11 +348,11 @@ func (s *Service) Assess(ctx context.Context, identity auth.Identity, schemeID s
 	}
 
 	_, _ = s.db.Q.CreateComplianceAssessment(ctx, dbgen.CreateComplianceAssessmentParams{
-		SchemeID:         scheme.ID,
-		Score:            int32(dashboard.Score),
-		TotalItems:       int32(dashboard.Total),
-		CompliantCount:   int32(dashboard.CompliantCount),
-		AtRiskCount:      int32(dashboard.AtRiskCount),
+		SchemeID:          scheme.ID,
+		Score:             int32(dashboard.Score),
+		TotalItems:        int32(dashboard.Total),
+		CompliantCount:    int32(dashboard.CompliantCount),
+		AtRiskCount:       int32(dashboard.AtRiskCount),
 		NonCompliantCount: int32(dashboard.NonCompliantCount),
 	})
 
@@ -386,7 +390,11 @@ func (s *Service) PortfolioDashboard(ctx context.Context, identity auth.Identity
 		return nil, ErrInvalidInput
 	}
 
-	rows, err := s.db.Q.ListSchemesByOrg(ctx, orgID)
+	listSchemesByOrg := s.listSchemesByOrgFn
+	if listSchemesByOrg == nil {
+		listSchemesByOrg = s.db.Q.ListSchemesByOrg
+	}
+	rows, err := listSchemesByOrg(ctx, orgID)
 	if err != nil {
 		return nil, err
 	}
@@ -397,9 +405,13 @@ func (s *Service) PortfolioDashboard(ctx context.Context, identity auth.Identity
 	var totalScore int
 
 	for _, row := range rows {
-		dashboard, dashErr := s.dashboardForScheme(ctx, row.ID)
+		dashboardForScheme := s.dashboardForSchemeFn
+		if dashboardForScheme == nil {
+			dashboardForScheme = s.dashboardForScheme
+		}
+		dashboard, dashErr := dashboardForScheme(ctx, row.ID)
 		if dashErr != nil {
-			continue
+			return nil, dashErr
 		}
 
 		info := PortfolioSchemeInfo{

--- a/backend/internal/compliance/service_test.go
+++ b/backend/internal/compliance/service_test.go
@@ -1,0 +1,52 @@
+package compliance
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+
+	dbgen "github.com/stratahq/backend/db/gen"
+	"github.com/stratahq/backend/internal/auth"
+)
+
+func TestPortfolioDashboardReturnsErrorWhenSchemeDashboardFails(t *testing.T) {
+	t.Helper()
+
+	failingSchemeID := uuid.New()
+	successSchemeID := uuid.New()
+	dashboardErr := errors.New("scheme dashboard failed")
+
+	svc := &Service{
+		listSchemesByOrgFn: func(_ context.Context, _ uuid.UUID) ([]dbgen.Scheme, error) {
+			return []dbgen.Scheme{
+				{
+					ID:   successSchemeID,
+					Name: "Good Scheme",
+				},
+				{
+					ID:   failingSchemeID,
+					Name: "Broken Scheme",
+				},
+			}, nil
+		},
+		dashboardForSchemeFn: func(_ context.Context, schemeID uuid.UUID) (*DashboardResponse, error) {
+			if schemeID == failingSchemeID {
+				return nil, dashboardErr
+			}
+			return &DashboardResponse{Score: 100}, nil
+		},
+	}
+
+	identity := auth.Identity{
+		UserID: uuid.NewString(),
+		OrgID:  uuid.NewString(),
+		Role:   string(auth.RoleAdmin),
+	}
+
+	_, err := svc.PortfolioDashboard(context.Background(), identity)
+	if !errors.Is(err, dashboardErr) {
+		t.Fatalf("expected portfolio dashboard to fail with scheme dashboard error, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- fail portfolio dashboard assembly when any scheme-specific compliance dashboard load fails
- replace silent continue with early error return so portfolio totals are not silently inaccurate
- add unit test for fail-fast behavior on per-scheme dashboard error

Fixes #368

## Tests
- Not run locally per instruction; relying on GitHub CI.