### PR TITLE
fix(#362): report WhatsApp broadcast delivery outcomes

### DIFF
--- a/app/app/[schemeId]/whatsapp/page.tsx
+++ b/app/app/[schemeId]/whatsapp/page.tsx
@@ -239,6 +239,8 @@ function ThreadCard({ thread }: { thread: WhatsAppThread }) {
 
 function BroadcastCard({ broadcast }: { broadcast: WhatsAppBroadcast }) {
   const [expanded, setExpanded] = useState(false)
+  const deliveredCount = broadcast.delivered_recipient_count ?? broadcast.recipient_count
+  const failedCount = broadcast.failed_recipient_count ?? 0
 
   return (
     <div className="border-b border-border last:border-b-0">
@@ -255,9 +257,14 @@ function BroadcastCard({ broadcast }: { broadcast: WhatsAppBroadcast }) {
           </div>
           <p className="text-[13px] text-ink truncate">{broadcast.message.split('\n')[0]}</p>
           <p className="text-[11px] text-muted mt-0.5">
-            Sent to {broadcast.recipient_count} residents
+            Sent to {failedCount ? `${deliveredCount} of ` : ''}{broadcast.recipient_count} residents
             {broadcast.sent_by_name ? ` by ${broadcast.sent_by_name}` : ''}
           </p>
+          {failedCount > 0 && (
+            <p className="text-[11px] text-amber mt-0.5">
+              Delivery failed for {failedCount} resident{failedCount === 1 ? '' : 's'}
+            </p>
+          )}
         </div>
         <span className={`text-muted text-[12px] flex-shrink-0 mt-1 transition-transform ${expanded ? 'rotate-180' : ''}`}>
           ▼
@@ -299,11 +306,18 @@ function OperatorView({
         message: broadcastText.trim(),
         type: broadcastType,
       })
+      const deliveredCount = created.delivered_recipient_count ?? created.recipient_count
+      const failedCount = created.failed_recipient_count ?? 0
       setBroadcastOpen(false)
       setBroadcastText('')
       setBroadcastType('general')
       await onReload()
-      addToast(`WhatsApp broadcast sent to ${created.recipient_count} connected residents.`, 'success')
+      if (failedCount > 0) {
+        addToast(`WhatsApp broadcast sent to ${deliveredCount} of ${created.recipient_count} connected residents.`, 'success')
+        addToast(`Delivery to ${failedCount} resident${failedCount === 1 ? '' : 's'} failed.`, 'info')
+      } else {
+        addToast(`WhatsApp broadcast sent to ${created.recipient_count} connected residents.`, 'success')
+      }
     } catch (error) {
       addToast(
         error instanceof Error ? error.message : 'Failed to send WhatsApp broadcast',

--- a/backend/internal/whatsapp/service.go
+++ b/backend/internal/whatsapp/service.go
@@ -58,6 +58,10 @@ type BroadcastInfo struct {
 	Message        string    `json:"message"`
 	Type           string    `json:"type"`
 	RecipientCount int       `json:"recipient_count"`
+	// DeliveredRecipientCount is the number of connected threads that were sent successfully.
+	DeliveredRecipientCount int `json:"delivered_recipient_count"`
+	// FailedRecipientCount is the number of connected threads that did not deliver successfully.
+	FailedRecipientCount int `json:"failed_recipient_count"`
 }
 
 //nolint:govet // Keep response DTO fields grouped by meaning rather than field packing.
@@ -288,6 +292,7 @@ func (s *Service) CreateBroadcast(ctx context.Context, identity auth.Identity, s
 
 	now := created.SentAt
 	sendErrors := 0
+	deliveredRecipientCount := 0
 	for _, row := range threadRows {
 		if !row.Connected {
 			continue
@@ -315,7 +320,11 @@ func (s *Service) CreateBroadcast(ctx context.Context, identity auth.Identity, s
 			if err := s.sender.SendWhatsAppMessage(row.PhoneNumber.String, message); err != nil {
 				s.logger.Error("failed to send WhatsApp broadcast", "phone", row.PhoneNumber.String, "error", err)
 				sendErrors++
+			} else {
+				deliveredRecipientCount++
 			}
+		} else {
+			sendErrors++
 		}
 	}
 
@@ -349,6 +358,8 @@ func (s *Service) CreateBroadcast(ctx context.Context, identity auth.Identity, s
 		Type:           string(created.Type),
 		SentAt:         created.SentAt,
 		RecipientCount: int(created.RecipientCount),
+		DeliveredRecipientCount: deliveredRecipientCount,
+		FailedRecipientCount:    sendErrors,
 	}, nil
 }
 

--- a/backend/tests/integration/whatsapp_test.go
+++ b/backend/tests/integration/whatsapp_test.go
@@ -5,6 +5,7 @@ package integration
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -20,10 +21,28 @@ import (
 	"github.com/stratahq/backend/internal/whatsapp"
 )
 
-func newWhatsAppHandler(t *testing.T) *whatsapp.Handler {
+type scriptedWhatsAppSender struct {
+	failOnNth int
+	failErr   error
+	calls     int
+}
+
+func (s *scriptedWhatsAppSender) SendWhatsAppMessage(to, body string) error {
+	s.calls++
+	if s.failOnNth > 0 && s.calls == s.failOnNth {
+		return s.failErr
+	}
+	return nil
+}
+
+func newWhatsAppHandlerWithSender(t *testing.T, sender whatsapp.MessageSender) *whatsapp.Handler {
 	t.Helper()
-	service := whatsapp.NewService(testPool, whatsapp.NewNoOpSender(), slog.Default())
+	service := whatsapp.NewService(testPool, sender, slog.Default())
 	return whatsapp.NewHandler(service)
+}
+
+func newWhatsAppHandler(t *testing.T) *whatsapp.Handler {
+	return newWhatsAppHandlerWithSender(t, whatsapp.NewNoOpSender())
 }
 
 func TestWhatsAppDashboardAndBroadcast(t *testing.T) {
@@ -129,6 +148,9 @@ func TestWhatsAppDashboardAndBroadcast(t *testing.T) {
 	if created.Type != "agm" || created.RecipientCount != 1 {
 		t.Fatalf("unexpected whatsapp broadcast: %+v", created)
 	}
+	if created.DeliveredRecipientCount != 1 || created.FailedRecipientCount != 0 {
+		t.Fatalf("unexpected whatsapp broadcast: %+v", created)
+	}
 
 	req = httptest.NewRequest(http.MethodGet, "/whatsapp/"+schemeID, nil)
 	req = withRouteParams(req, map[string]string{"schemeId": schemeID})
@@ -151,9 +173,79 @@ func TestWhatsAppDashboardAndBroadcast(t *testing.T) {
 	req = withRouteParams(req, map[string]string{"schemeId": schemeID})
 	req = req.WithContext(auth.ContextWithIdentity(req.Context(), residentUserID, orgID, string(auth.RoleResident)))
 	w = httptest.NewRecorder()
-	h.CreateBroadcast(w, req)
+		h.CreateBroadcast(w, req)
 	if w.Code != http.StatusForbidden {
 		t.Fatalf("resident create broadcast should be forbidden: status=%d body=%s", w.Code, w.Body)
+	}
+}
+
+func TestWhatsAppBroadcastReportsFailedRecipients(t *testing.T) {
+	h := newWhatsAppHandlerWithSender(t, &scriptedWhatsAppSender{
+		failOnNth: 1,
+		failErr:   errors.New("whatsapp provider unavailable"),
+	})
+
+	accessToken, orgID := setupAgent(t)
+	schemeID := setupScheme(t, accessToken)
+
+	unitResidentID := createUnitRecord(t, schemeID, "7A")
+	unitOtherID := createUnitRecord(t, schemeID, "9B")
+	trusteeEmail := uniqueEmail(t)
+	trusteeUserID := createMemberRecord(t, orgID, schemeID, trusteeEmail, "Trustee User", string(auth.RoleTrustee), nil)
+
+	schemeUUID := mustParseUUID(schemeID)
+	residentUnitUUID := mustParseUUID(unitResidentID)
+	otherUnitUUID := mustParseUUID(unitOtherID)
+	now := time.Now().UTC()
+
+	if _, err := testQ.CreateWhatsAppThread(t.Context(), dbgen.CreateWhatsAppThreadParams{
+		SchemeID:       schemeUUID,
+		UnitID:         residentUnitUUID,
+		ResidentUserID: pgtype.UUID{},
+		PhoneNumber:    pgtype.Text{String: "+27715550404", Valid: true},
+		Connected:      true,
+		ConsentedAt:    pgtype.Timestamptz{Time: now.Add(-24 * time.Hour), Valid: true},
+		UnreadCount:    0,
+		LastActiveAt:   now,
+	}); err != nil {
+		t.Fatalf("create connected thread 1: %v", err)
+	}
+
+	if _, err := testQ.CreateWhatsAppThread(t.Context(), dbgen.CreateWhatsAppThreadParams{
+		SchemeID:       schemeUUID,
+		UnitID:         otherUnitUUID,
+		ResidentUserID: pgtype.UUID{},
+		PhoneNumber:    pgtype.Text{String: "+27715550405", Valid: true},
+		Connected:      true,
+		ConsentedAt:    pgtype.Timestamptz{Time: now.Add(-24 * time.Hour), Valid: true},
+		UnreadCount:    0,
+		LastActiveAt:   now.Add(-time.Hour),
+	}); err != nil {
+		t.Fatalf("create connected thread 2: %v", err)
+	}
+
+	reqBody, _ := json.Marshal(map[string]any{
+		"message": "AGM reminder with provider failure",
+		"type":    "agm",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/whatsapp/"+schemeID+"/broadcasts", bytes.NewReader(reqBody))
+	req = withRouteParams(req, map[string]string{"schemeId": schemeID})
+	req = req.WithContext(auth.ContextWithIdentity(req.Context(), trusteeUserID, orgID, string(auth.RoleTrustee)))
+	w := httptest.NewRecorder()
+	h.CreateBroadcast(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("trustee create whatsapp broadcast with failed sends: status=%d body=%s", w.Code, w.Body)
+	}
+
+	created := decodeSuccess[whatsapp.BroadcastInfo](t, w)
+	if created.RecipientCount != 2 {
+		t.Fatalf("expected recipient count 2, got %d: %+v", created.RecipientCount, created)
+	}
+	if created.DeliveredRecipientCount != 1 {
+		t.Fatalf("expected 1 delivered recipient, got %d: %+v", created.DeliveredRecipientCount, created)
+	}
+	if created.FailedRecipientCount != 1 {
+		t.Fatalf("expected 1 failed recipient, got %d: %+v", created.FailedRecipientCount, created)
 	}
 }
 

--- a/lib/mock/whatsapp.ts
+++ b/lib/mock/whatsapp.ts
@@ -27,6 +27,8 @@ export interface WhatsAppBroadcast {
   sent_at: string        // ISO timestamp
   sent_by: string
   recipient_count: number
+  delivered_recipient_count?: number
+  failed_recipient_count?: number
   message: string
   type: 'levy' | 'agm' | 'maintenance' | 'general'
 }

--- a/lib/whatsapp.ts
+++ b/lib/whatsapp.ts
@@ -53,6 +53,8 @@ export interface WhatsAppBroadcast {
   type: WhatsAppBroadcastType;
   sent_at: string;
   recipient_count: number;
+  delivered_recipient_count?: number;
+  failed_recipient_count?: number;
 }
 
 export interface WhatsAppDashboard {


### PR DESCRIPTION
## Summary\n- report successful and failed outbound WhatsApp broadcast delivery counts in the create response\n- keep existing  to preserve current API contract while exposing partial failure details\n- surface delivery warnings in the WhatsApp operator UI\n- add integration coverage for mixed broadcast delivery outcomes using a scripted sender\n\nFixes #362\n\n## Tests\n- Not run locally per instruction; GitHub CI will validate.