### PR TITLE
fix(#351 #358): trim auth onboarding fields and refresh session after auth writes

### DIFF
--- a/backend/internal/auth/handler.go
+++ b/backend/internal/auth/handler.go
@@ -58,11 +58,13 @@ func (h *Handler) Register(w http.ResponseWriter, r *http.Request) {
 		response.Error(w, http.StatusBadRequest, response.CodeBadRequest, "invalid request body")
 		return
 	}
-	if req.Email == "" || req.Password == "" || req.FullName == "" {
+	email := strings.TrimSpace(req.Email)
+	fullName := strings.TrimSpace(req.FullName)
+	if email == "" || req.Password == "" || fullName == "" {
 		response.Error(w, http.StatusBadRequest, response.CodeBadRequest, "email, password, and full_name are required")
 		return
 	}
-	if !ValidateEmail(req.Email) {
+	if !ValidateEmail(email) {
 		response.Error(w, http.StatusBadRequest, response.CodeBadRequest, "invalid email format")
 		return
 	}
@@ -70,7 +72,7 @@ func (h *Handler) Register(w http.ResponseWriter, r *http.Request) {
 		response.Error(w, http.StatusBadRequest, response.CodeBadRequest, err.Error())
 		return
 	}
-	res, err := h.service.Register(r.Context(), req.Email, req.Password, req.FullName)
+	res, err := h.service.Register(r.Context(), email, req.Password, fullName)
 	if err != nil {
 		if err == ErrEmailExists {
 			response.Error(w, http.StatusConflict, response.CodeConflict, "email already registered")
@@ -105,15 +107,19 @@ func (h *Handler) Setup(w http.ResponseWriter, r *http.Request) {
 		response.Error(w, http.StatusBadRequest, response.CodeBadRequest, "invalid request body")
 		return
 	}
-	if req.OrgName == "" || req.ContactEmail == "" || req.SchemeName == "" || req.SchemeAddress == "" || req.UnitCount <= 0 {
+	orgName := strings.TrimSpace(req.OrgName)
+	contactEmail := strings.TrimSpace(req.ContactEmail)
+	schemeName := strings.TrimSpace(req.SchemeName)
+	schemeAddress := strings.TrimSpace(req.SchemeAddress)
+	if orgName == "" || contactEmail == "" || schemeName == "" || schemeAddress == "" || req.UnitCount <= 0 {
 		response.Error(w, http.StatusBadRequest, response.CodeBadRequest, "org_name, contact_email, scheme_name, scheme_address, and unit_count are required")
 		return
 	}
-	if !ValidateEmail(req.ContactEmail) {
+	if !ValidateEmail(contactEmail) {
 		response.Error(w, http.StatusBadRequest, response.CodeBadRequest, "invalid contact_email format")
 		return
 	}
-	res, err := h.service.Setup(r.Context(), identity.OrgID, req.OrgName, req.ContactEmail, req.SchemeName, req.SchemeAddress, req.UnitCount)
+	res, err := h.service.Setup(r.Context(), identity.OrgID, orgName, contactEmail, schemeName, schemeAddress, req.UnitCount)
 	if err != nil {
 		if errors.Is(err, ErrSetupAlreadyComplete) {
 			response.Error(w, http.StatusConflict, response.CodeConflict, "onboarding setup has already been completed")

--- a/backend/internal/auth/handler_test.go
+++ b/backend/internal/auth/handler_test.go
@@ -152,6 +152,58 @@ func TestRegister_DuplicateEmail(t *testing.T) {
 	}
 }
 
+func TestRegister_TrimsLeadingAndTrailingWhitespace(t *testing.T) {
+	var capturedEmail, capturedFullName string
+	svc := &mockService{
+		registerFn: func(_ context.Context, email, _, fullName string) (*AuthResponse, error) {
+			capturedEmail = email
+			capturedFullName = fullName
+			return &AuthResponse{
+				AccessToken: "access",
+				RefreshToken: "refresh",
+				ExpiresIn:    900,
+				User:         UserInfo{ID: "u1", Email: email, FullName: fullName},
+				Session:      MeResponse{ID: "u1", Email: email, FullName: fullName, Org: OrgInfo{ID: "o1", Name: "Org"}, Role: "admin"},
+			}, nil
+		},
+	}
+	req := httptest.NewRequest(http.MethodPost, "/register", body(t, map[string]string{
+		"email": "  a@b.com  ", "password": "Pass_1234", "full_name": "  New Name  ",
+	}))
+	w := httptest.NewRecorder()
+	NewHandler(svc).Register(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201", w.Code)
+	}
+	if capturedEmail != "a@b.com" {
+		t.Fatalf("capturedEmail = %q, want %q", capturedEmail, "a@b.com")
+	}
+	if capturedFullName != "New Name" {
+		t.Fatalf("capturedFullName = %q, want %q", capturedFullName, "New Name")
+	}
+}
+
+func TestRegister_RejectsWhitespaceOnlyRequiredFields(t *testing.T) {
+	svcCalled := false
+	svc := &mockService{
+		registerFn: func(_ context.Context, _, _, _ string) (*AuthResponse, error) {
+			svcCalled = true
+			return nil, nil
+		},
+	}
+	req := httptest.NewRequest(http.MethodPost, "/register", body(t, map[string]string{
+		"email": "   ", "password": "Pass_1234", "full_name": "   ",
+	}))
+	w := httptest.NewRecorder()
+	NewHandler(svc).Register(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", w.Code)
+	}
+	if svcCalled {
+		t.Fatalf("service should not be called with whitespace-only required fields")
+	}
+}
+
 func TestRegister_Success(t *testing.T) {
 	svc := &mockService{
 		registerFn: func(_ context.Context, _, _, _ string) (*AuthResponse, error) {
@@ -184,6 +236,86 @@ func TestRegister_Success(t *testing.T) {
 	}
 	if resp.Data.Session.ID == "" {
 		t.Error("expected session in response")
+	}
+}
+
+func TestSetup_TrimsRequiredFieldsAndCallsService(t *testing.T) {
+	var capturedOrgName, capturedContactEmail, capturedSchemeName, capturedSchemeAddress string
+	var capturedUnitCount int32
+	svc := &mockService{
+		setupFn: func(_ context.Context, _, orgName, contactEmail, schemeName, schemeAddress string, unitCount int32) (*SetupResponse, error) {
+			capturedOrgName = orgName
+			capturedContactEmail = contactEmail
+			capturedSchemeName = schemeName
+			capturedSchemeAddress = schemeAddress
+			capturedUnitCount = unitCount
+			return &SetupResponse{
+				Org: OrgInfo{
+					ID:     "o1",
+					Name:   orgName,
+					ContactEmail: ptr("admin@org.com"),
+				},
+				Scheme: struct {
+					ID   string "json:\"id\""
+					Name string "json:\"name\""
+				}{ID: "s1", Name: "Scheme Name"},
+			}, nil
+		},
+	}
+	req := httptest.NewRequest(http.MethodPost, "/setup", body(t, map[string]interface{}{
+		"org_name":       "  Test Org  ",
+		"contact_email":  "  admin@org.com  ",
+		"scheme_name":    "  Scheme Name  ",
+		"scheme_address": "  10 Downing St  ",
+		"unit_count":     12,
+	}))
+	req = req.WithContext(ContextWithIdentity(req.Context(), "u1", "o1", string(RoleAdmin)))
+	w := httptest.NewRecorder()
+
+	NewHandler(svc).Setup(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201", w.Code)
+	}
+	if capturedOrgName != "Test Org" {
+		t.Fatalf("capturedOrgName = %q, want %q", capturedOrgName, "Test Org")
+	}
+	if capturedContactEmail != "admin@org.com" {
+		t.Fatalf("capturedContactEmail = %q, want %q", capturedContactEmail, "admin@org.com")
+	}
+	if capturedSchemeName != "Scheme Name" {
+		t.Fatalf("capturedSchemeName = %q, want %q", capturedSchemeName, "Scheme Name")
+	}
+	if capturedSchemeAddress != "10 Downing St" {
+		t.Fatalf("capturedSchemeAddress = %q, want %q", capturedSchemeAddress, "10 Downing St")
+	}
+	if capturedUnitCount != 12 {
+		t.Fatalf("capturedUnitCount = %d, want 12", capturedUnitCount)
+	}
+}
+
+func TestSetup_RejectsWhitespaceOnlyRequiredFields(t *testing.T) {
+	called := false
+	svc := &mockService{
+		setupFn: func(_ context.Context, _ string, _ string, _ string, _ string, _ string, _ int32) (*SetupResponse, error) {
+			called = true
+			return nil, nil
+		},
+	}
+	req := httptest.NewRequest(http.MethodPost, "/setup", body(t, map[string]interface{}{
+		"org_name":       "   ",
+		"contact_email":  "admin@org.com",
+		"scheme_name":    "   ",
+		"scheme_address": "   ",
+		"unit_count":     12,
+	}))
+	req = req.WithContext(ContextWithIdentity(req.Context(), "u1", "o1", string(RoleAdmin)))
+	w := httptest.NewRecorder()
+	NewHandler(svc).Setup(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", w.Code)
+	}
+	if called {
+		t.Fatal("service should not be called with whitespace-only required fields")
 	}
 }
 

--- a/backend/internal/auth/handler_test.go
+++ b/backend/internal/auth/handler_test.go
@@ -98,10 +98,14 @@ func (m *mockService) IssuePasswordResetURL(_ context.Context, _, _ string) (str
 
 // helpers
 
-func body(t *testing.T, m map[string]string) *bytes.Reader {
+func body(t *testing.T, m any) *bytes.Reader {
 	t.Helper()
 	b, _ := json.Marshal(m)
 	return bytes.NewReader(b)
+}
+
+func strPtr(s string) *string {
+	return &s
 }
 
 func TestRegister_UnknownFields(t *testing.T) {
@@ -159,7 +163,7 @@ func TestRegister_TrimsLeadingAndTrailingWhitespace(t *testing.T) {
 			capturedEmail = email
 			capturedFullName = fullName
 			return &AuthResponse{
-				AccessToken: "access",
+				AccessToken:  "access",
 				RefreshToken: "refresh",
 				ExpiresIn:    900,
 				User:         UserInfo{ID: "u1", Email: email, FullName: fullName},
@@ -251,9 +255,9 @@ func TestSetup_TrimsRequiredFieldsAndCallsService(t *testing.T) {
 			capturedUnitCount = unitCount
 			return &SetupResponse{
 				Org: OrgInfo{
-					ID:     "o1",
-					Name:   orgName,
-					ContactEmail: ptr("admin@org.com"),
+					ID:           "o1",
+					Name:         orgName,
+					ContactEmail: strPtr("admin@org.com"),
 				},
 				Scheme: struct {
 					ID   string "json:\"id\""

--- a/lib/account-api.ts
+++ b/lib/account-api.ts
@@ -2,7 +2,22 @@
 
 import { apiFetch } from "@/lib/api";
 import { readApiData, buildApiHttpError } from "@/lib/api-contract";
+import { readBrowserCSRFToken } from "@/lib/csrf";
 import type { SessionOrg, SessionUser } from "@/lib/session";
+
+async function refreshSession(): Promise<SessionUser> {
+  const csrfToken = readBrowserCSRFToken();
+  const res = await fetch("/api/session/refresh", {
+    method: "POST",
+    headers: csrfToken ? { "x-csrf-token": csrfToken } : undefined,
+  });
+
+  if (!res.ok) {
+    throw await buildApiHttpError(res, "Failed to refresh session");
+  }
+
+  return readApiData<SessionUser>(res);
+}
 
 export async function updateProfile(input: {
   email: string;
@@ -22,7 +37,12 @@ export async function updateProfile(input: {
     throw await buildApiHttpError(res, "Failed to update profile");
   }
 
-  return readApiData<SessionUser>(res);
+  const updated = await readApiData<SessionUser>(res);
+  try {
+    return await refreshSession();
+  } catch {
+    return updated;
+  }
 }
 
 export async function updateOrgSettings(input: {
@@ -46,7 +66,12 @@ export async function updateOrgSettings(input: {
     );
   }
 
-  return readApiData<SessionOrg>(res);
+  const updated = await readApiData<SessionOrg>(res);
+  try {
+    return (await refreshSession()).org ?? updated;
+  } catch {
+    return updated;
+  }
 }
 
 export async function changePassword(input: {


### PR DESCRIPTION
Closes #351 and Closes #358\n\n## What changed\n- Trim whitespace from Register and Setup request fields before validation and service calls.\n- Reject whitespace-only required fields at auth boundaries.\n- Refresh /api/session after successful profile/org updates to keep client session cache in sync with persisted data.\n