### PR TITLE
fix(#353 #354 #355 #356 #357): harden bank statement import parsing

### DIFF
--- a/backend/db/queries/levy.sql
+++ b/backend/db/queries/levy.sql
@@ -101,4 +101,4 @@ WHERE lp.scheme_id = $1
 ORDER BY lp.due_date DESC, u.identifier ASC;
 
 -- name: ClearBankStatementImportRawCsv :exec
-UPDATE bank_statement_imports SET raw_csv = NULL WHERE id = $1;
+UPDATE bank_statement_imports SET raw_csv = ''::bytea WHERE id = $1;

--- a/backend/internal/levy/bank_statement_import.go
+++ b/backend/internal/levy/bank_statement_import.go
@@ -175,7 +175,7 @@ func parseFNBStatementCSV(data []byte) ([]ParsedBankStatementRow, error) {
 			return nil, fmt.Errorf("row %d: cannot parse amount %q", row.RowNumber, amountStr)
 		}
 		if floatVal <= 0 {
-			return nil, fmt.Errorf("row %d: amount %q is not a positive credit (debits are not supported)", row.RowNumber, amountStr)
+			continue
 		}
 		cents := int64(floatVal * 100)
 		row.AmountCents = cents
@@ -217,7 +217,7 @@ func matchBankStatementRow(row ParsedBankStatementRow, accounts []candidateLevyA
 			continue
 		}
 		refContainsUnit := strings.Contains(normalRef, normalUnit)
-		unitContainsRef := strings.Contains(normalUnit, normalRef)
+		unitContainsRef := normalRef != "" && strings.Contains(normalUnit, normalRef)
 		descContainsUnit := strings.Contains(normalDesc, normalUnit)
 		if refContainsUnit || descContainsUnit || unitContainsRef || strings.Contains(normalRef, unitUpper) || strings.Contains(normalDesc, unitUpper) {
 			candidates = append(candidates, acct)
@@ -514,10 +514,10 @@ func (s *Service) ApplyBankStatementImport(ctx context.Context, identity auth.Id
 			return nil, ErrForbidden
 		}
 
-		paymentDate, parseErr := time.Parse("2006-01-02", match.PaymentDate)
-		if parseErr != nil {
+		if !row.TransactionDate.Valid {
 			return nil, ErrInvalidInput
 		}
+		paymentDate := row.TransactionDate.Time
 
 		var bankRef pgtype.Text
 		if match.BankRef != nil && *match.BankRef != "" {

--- a/backend/internal/levy/bank_statement_import_test.go
+++ b/backend/internal/levy/bank_statement_import_test.go
@@ -36,6 +36,41 @@ func TestParseFNBStatementCSV(t *testing.T) {
 	}
 }
 
+func TestParseFNBStatementCSVSkipsNonPositiveRows(t *testing.T) {
+	csvData := []byte(`Date,Description,Reference,Amount
+2026-04-01,EFT UNIT 12A,12A,2450.00
+2026-04-02,EFT UNIT 12A,12A,-2450.00
+2026-04-03,EFT UNIT 12A,12A,0.00
+2026-04-04,EFT UNIT 12A,12A,1200.00
+`)
+	rows, err := parseFNBStatementCSV(csvData)
+	if err != nil {
+		t.Fatalf("parse csv: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("rows = %d, want 2", len(rows))
+	}
+	if rows[0].RowNumber != 2 || rows[1].RowNumber != 5 {
+		t.Fatalf("row numbers = %d,%d, want 2,5", rows[0].RowNumber, rows[1].RowNumber)
+	}
+}
+
+func TestParseFNBStatementCSVSupportsDDMMYYYY(t *testing.T) {
+	csvData := []byte(`Date,Description,Reference,Amount
+01/04/2026,EFT UNIT 12A,12A,2450.00
+`)
+	rows, err := parseFNBStatementCSV(csvData)
+	if err != nil {
+		t.Fatalf("parse csv: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("rows = %d, want 1", len(rows))
+	}
+	if rows[0].TransactionDate != dateTime(2026, time.April, 1) {
+		t.Fatalf("date = %s, want 2026-04-01", rows[0].TransactionDate.Format("2006-01-02"))
+	}
+}
+
 func TestMatchBankStatementRowPrefersExactUnitToken(t *testing.T) {
 	account := candidateLevyAccount{
 		LevyAccountID:    uuid.New(),
@@ -54,6 +89,27 @@ func TestMatchBankStatementRowPrefersExactUnitToken(t *testing.T) {
 	}
 	if got.MatchedLevyAccountID == nil || *got.MatchedLevyAccountID != account.LevyAccountID {
 		t.Fatal("expected exact unit token match")
+	}
+}
+
+func TestMatchBankStatementRowDoesNotMatchWhenReferenceIsBlank(t *testing.T) {
+	account := candidateLevyAccount{
+		LevyAccountID:    uuid.New(),
+		UnitIdentifier:   "12A",
+		OwnerName:        "No Match",
+		OutstandingCents: 50000,
+	}
+	row := ParsedBankStatementRow{
+		AmountCents: 50000,
+		Reference:   "   ",
+		Description: "General ledger credit",
+	}
+	got := matchBankStatementRow(row, []candidateLevyAccount{account})
+	if got.Status != "unmatched" {
+		t.Fatalf("status = %q, want unmatched", got.Status)
+	}
+	if got.MatchedLevyAccountID != nil {
+		t.Fatal("blank reference should not create an initial unit match")
 	}
 }
 

--- a/components/ReconcileModal.tsx
+++ b/components/ReconcileModal.tsx
@@ -76,16 +76,30 @@ export default function ReconcileModal({
   }
 
   function handleConfirm() {
-    const payments = matches
-      .filter(m => m.account !== null)
-      .map((m, index) => ({
-        account_id: m.account!.id,
-        amount_cents: m.transaction.amount_cents,
-        payment_date: normalizeDate(m.transaction.date),
-        reference: buildReference(m.transaction.description, m.transaction.amount_cents, m.transaction.date, index),
-        bank_ref: m.transaction.description,
-      }))
-    onConfirm(payments)
+    setError(null)
+
+    try {
+      const payments = matches
+        .filter(m => m.account !== null)
+        .map((m, index) => {
+          const paymentDate = parseReconcileDate(m.transaction.date)
+
+          return {
+            account_id: m.account!.id,
+            amount_cents: m.transaction.amount_cents,
+            payment_date: paymentDate,
+            reference: buildReference(m.transaction.description, m.transaction.amount_cents, paymentDate, index),
+            bank_ref: m.transaction.description,
+          }
+        })
+      onConfirm(payments)
+    } catch (error) {
+      setError(
+        error instanceof Error
+          ? error.message
+          : 'Could not confirm reconciliation because one or more dates are invalid.',
+      )
+    }
   }
 
   const summary = matches.length > 0 ? summariseMatches(matches) : null
@@ -365,10 +379,35 @@ export default function ReconcileModal({
   )
 }
 
-function normalizeDate(value: string): string {
-  const parsed = new Date(value)
+function parseReconcileDate(value: string): string {
+  const trimmed = value.trim()
+  if (!trimmed) {
+    throw new Error('Transaction date is required for reconciliation payloads.')
+  }
+
+  const parseStrictDate = (year: number, month: number, day: number): string => {
+    const parsed = new Date(Date.UTC(year, month - 1, day))
+    if (parsed.getUTCFullYear() !== year || parsed.getUTCMonth() + 1 !== month || parsed.getUTCDate() !== day) {
+      throw new Error(`invalid transaction date: ${value}`)
+    }
+    return parsed.toISOString().slice(0, 10)
+  }
+
+  const ymdMatch = /^(\d{4})-(\d{2})-(\d{2})$/.exec(trimmed)
+  if (ymdMatch) {
+    const [, year, month, day] = ymdMatch
+    return parseStrictDate(Number(year), Number(month), Number(day))
+  }
+
+  const dmyMatch = /^(\d{2})\/(\d{2})\/(\d{4})$/.exec(trimmed)
+  if (dmyMatch) {
+    const [, day, month, year] = dmyMatch
+    return parseStrictDate(Number(year), Number(month), Number(day))
+  }
+
+  const parsed = new Date(trimmed)
   if (Number.isNaN(parsed.getTime())) {
-    return new Date().toISOString().slice(0, 10)
+    throw new Error(`invalid transaction date: ${value}`)
   }
   return parsed.toISOString().slice(0, 10)
 }
@@ -379,5 +418,5 @@ function buildReference(description: string, amountCents: number, date: string, 
     .replace(/[^A-Z0-9]+/g, '-')
     .replace(/^-+|-+$/g, '')
     .slice(0, 72)
-  return `${normalizeDate(date)}-${amountCents}-${index + 1}-${slug}`
+  return `${date}-${amountCents}-${index + 1}-${slug}`
 }


### PR DESCRIPTION
Closes #353\nCloses #354\nCloses #355\nCloses #356\nCloses #357\n\n## What changed\n- Hardened bank statement reconcile date parsing for DD/MM/YYYY inputs.\n- Prevented import of non-positive totals and blank references from being matched as valid entries.\n- Added regression coverage in bank statement import tests.\n