### PR TITLE
fix(#308): reject whitespace-only required config

### DIFF
--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -57,24 +57,25 @@ type ConfigInts struct {
 }
 
 func Load() (*Config, error) {
+	appBaseURL := strings.TrimSpace(os.Getenv("APP_BASE_URL"))
 	cfg := &Config{
 		ConfigStrings: ConfigStrings{
 			Port:                 getEnv("PORT", "8080"),
 			Env:                  getEnv("ENV", "development"),
-			DatabaseURL:          os.Getenv("DATABASE_URL"),
-			RedisURL:             os.Getenv("REDIS_URL"),
-			JWTSecret:            os.Getenv("JWT_SECRET"),
-			JWTIssuer:            getEnv("JWT_ISSUER", os.Getenv("APP_BASE_URL")),
+			DatabaseURL:          strings.TrimSpace(os.Getenv("DATABASE_URL")),
+			RedisURL:             strings.TrimSpace(os.Getenv("REDIS_URL")),
+			JWTSecret:            strings.TrimSpace(os.Getenv("JWT_SECRET")),
+			JWTIssuer:            getEnv("JWT_ISSUER", appBaseURL),
 			JWTAudience:          getEnv("JWT_AUDIENCE", "stratahq-api"),
 			StripeSecretKey:      os.Getenv("STRIPE_SECRET_KEY"),
 			StripeWebhookSecret:  os.Getenv("STRIPE_WEBHOOK_SECRET"),
 			StripePriceID:        os.Getenv("STRIPE_PRICE_ID"),
-			ResendAPIKey:         os.Getenv("RESEND_API_KEY"),
-			AIBaseURL:            os.Getenv("AI_BASE_URL"),
-			AIAPIKey:             os.Getenv("AI_API_KEY"),
-			AIModel:              os.Getenv("AI_MODEL"),
-			AppBaseURL:           os.Getenv("APP_BASE_URL"),
-			BackendBaseURL:       getEnv("BACKEND_BASE_URL", os.Getenv("APP_BASE_URL")),
+			ResendAPIKey:         strings.TrimSpace(os.Getenv("RESEND_API_KEY")),
+			AIBaseURL:            strings.TrimSpace(os.Getenv("AI_BASE_URL")),
+			AIAPIKey:             strings.TrimSpace(os.Getenv("AI_API_KEY")),
+			AIModel:              strings.TrimSpace(os.Getenv("AI_MODEL")),
+			AppBaseURL:           appBaseURL,
+			BackendBaseURL:       getEnv("BACKEND_BASE_URL", appBaseURL),
 			EmailFrom:            getEnv("EMAIL_FROM", "noreply@stratahq.co.za"),
 			AdminEmail:           os.Getenv("ADMIN_EMAIL"),
 			AdminSecret:          os.Getenv("ADMIN_SECRET"),
@@ -156,7 +157,7 @@ func (c *Config) validate() error {
 
 	var missing []string
 	for name, val := range required {
-		if val == "" {
+		if strings.TrimSpace(val) == "" {
 			missing = append(missing, name)
 		}
 	}

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"os"
+	"strings"
 	"testing"
 	"time"
 )
@@ -154,6 +155,33 @@ func TestLoad_MissingRequired(t *testing.T) {
 	_, err := Load()
 	if err == nil {
 		t.Fatal("expected error for missing required fields, got nil")
+	}
+}
+
+func TestLoad_WhitespaceOnlyRequired(t *testing.T) {
+	required := map[string]string{
+		"DATABASE_URL":   "postgres://user:pass@localhost:5432/db",
+		"REDIS_URL":      "redis://localhost:6379",
+		"JWT_SECRET":     "test-secret-that-is-long-enough-32ch",
+		"RESEND_API_KEY": "re_123",
+		"AI_BASE_URL":    "https://api.deepseek.com/v1",
+		"AI_API_KEY":     "sk-ai-123",
+		"AI_MODEL":       "deepseek-chat",
+		"APP_BASE_URL":   "http://localhost:3000",
+	}
+
+	for k, v := range required {
+		os.Setenv(k, v)
+		defer os.Unsetenv(k)
+	}
+
+	os.Setenv("DATABASE_URL", "   ")
+	_, err := Load()
+	if err == nil {
+		t.Fatal("expected error for whitespace-only required field, got nil")
+	}
+	if !strings.Contains(err.Error(), "DATABASE_URL") {
+		t.Fatalf("error = %q, want DATABASE_URL", err)
 	}
 }
 


### PR DESCRIPTION
Closes #308

## What changed
- Trim required string configuration values when loading backend config.
- Treat whitespace-only required config values as missing during validation.
- Added regression coverage for whitespace-only required environment variables.

## Verification
- go test ./internal/config -run TestLoad_WhitespaceOnlyRequired -count=1
- go test ./internal/config -count=1
