### PR TITLE
fix(#306): exclude local worktrees from typecheck

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -37,6 +37,9 @@
     ".next/dev/types/**/*.ts"
   ],
   "exclude": [
-    "node_modules"
+    "node_modules",
+    ".worktrees",
+    ".superpowers",
+    ".claude"
   ]
 }


### PR DESCRIPTION
Closes #306

## What changed
- Added explicit TypeScript exclusions for repo-local ignored tooling/workspace directories.
- Keeps local .worktrees, .superpowers, and .claude files out of active checkout typechecking.

## Verification
- npm run typecheck

Note: a temporary invalid .worktrees sentinel was not picked up by TypeScript in this checkout, but the exclusion now makes the intended local-only boundary explicit in tsconfig.json.