### PR TITLE
fix(#289): enforce render-phase state lint

### DIFF
--- a/app/app/[schemeId]/agm/page.tsx
+++ b/app/app/[schemeId]/agm/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useParams } from 'next/navigation'
 
 import Modal from '@/components/Modal'
@@ -89,7 +89,7 @@ export default function AgmVotingPage() {
     [members, upcomingMeeting?.user_proxy_grantee_id],
   )
 
-  useMemo(() => {
+  useEffect(() => {
     setProxyUserId(upcomingMeeting?.user_proxy_grantee_id ?? '')
   }, [upcomingMeeting?.user_proxy_grantee_id])
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -23,7 +23,6 @@ export default tseslint.config(
     rules: {
       ...reactHooks.configs.recommended.rules,
       "react-hooks/set-state-in-effect": "off",
-      "react-hooks/set-state-in-render": "off",
     },
   },
 );


### PR DESCRIPTION
Closes #289

## What changed
- Re-enabled the React Hooks lint rule that rejects setState during render.
- Moved the AGM proxy selector sync from useMemo to useEffect so lint can stay enabled.

## Verification
- npm run lint
- npm run typecheck