### PR TITLE
fix(#348 #212): fail compliance assess when snapshot persistence fails

### DIFF
--- a/backend/internal/compliance/service.go
+++ b/backend/internal/compliance/service.go
@@ -49,14 +49,20 @@ type DashboardResponse struct {
 }
 
 type Service struct {
-	db                   *database.Pool
-	listSchemesByOrgFn   func(context.Context, uuid.UUID) ([]dbgen.Scheme, error)
-	dashboardForSchemeFn func(context.Context, uuid.UUID) (*DashboardResponse, error)
+	db                    *database.Pool
+	listSchemesByOrgFn    func(context.Context, uuid.UUID) ([]dbgen.Scheme, error)
+	dashboardForSchemeFn  func(context.Context, uuid.UUID) (*DashboardResponse, error)
+	dashboardFn           func(context.Context, auth.Identity, string) (*DashboardResponse, error)
+	resolveSchemeAccessFn func(context.Context, auth.Identity, string) (dbgen.Scheme, string, error)
+	createAssessmentFn    func(context.Context, dbgen.CreateComplianceAssessmentParams) (dbgen.ComplianceAssessment, error)
 }
 
 func NewService(db *database.Pool) *Service {
 	svc := &Service{db: db}
 	svc.dashboardForSchemeFn = svc.dashboardForScheme
+	svc.dashboardFn = svc.Dashboard
+	svc.resolveSchemeAccessFn = svc.resolveSchemeAccess
+	svc.createAssessmentFn = svc.db.Q.CreateComplianceAssessment
 	return svc
 }
 
@@ -344,24 +350,38 @@ func (s *Service) DeleteItem(ctx context.Context, identity auth.Identity, scheme
 }
 
 func (s *Service) Assess(ctx context.Context, identity auth.Identity, schemeID string) (*DashboardResponse, error) {
-	dashboard, err := s.Dashboard(ctx, identity, schemeID)
+	dashboardFn := s.dashboardFn
+	if dashboardFn == nil {
+		dashboardFn = s.Dashboard
+	}
+	dashboard, err := dashboardFn(ctx, identity, schemeID)
 	if err != nil {
 		return nil, err
 	}
 
-	scheme, _, err := s.resolveSchemeAccess(ctx, identity, schemeID)
+	resolveSchemeAccessFn := s.resolveSchemeAccessFn
+	if resolveSchemeAccessFn == nil {
+		resolveSchemeAccessFn = s.resolveSchemeAccess
+	}
+	scheme, _, err := resolveSchemeAccessFn(ctx, identity, schemeID)
 	if err != nil {
 		return nil, err
 	}
 
-	_, _ = s.db.Q.CreateComplianceAssessment(ctx, dbgen.CreateComplianceAssessmentParams{
+	createAssessmentFn := s.createAssessmentFn
+	if createAssessmentFn == nil {
+		createAssessmentFn = s.db.Q.CreateComplianceAssessment
+	}
+	if _, err := createAssessmentFn(ctx, dbgen.CreateComplianceAssessmentParams{
 		SchemeID:          scheme.ID,
 		Score:             int32(dashboard.Score),
 		TotalItems:        int32(dashboard.Total),
 		CompliantCount:    int32(dashboard.CompliantCount),
 		AtRiskCount:       int32(dashboard.AtRiskCount),
 		NonCompliantCount: int32(dashboard.NonCompliantCount),
-	})
+	}); err != nil {
+		return nil, err
+	}
 
 	return dashboard, nil
 }

--- a/backend/internal/compliance/service_test.go
+++ b/backend/internal/compliance/service_test.go
@@ -50,3 +50,67 @@ func TestPortfolioDashboardReturnsErrorWhenSchemeDashboardFails(t *testing.T) {
 		t.Fatalf("expected portfolio dashboard to fail with scheme dashboard error, got %v", err)
 	}
 }
+
+func TestAssessReturnsErrorWhenAssessmentSnapshotPersistenceFails(t *testing.T) {
+	t.Helper()
+
+	schemeID := uuid.New()
+	orgID := uuid.New()
+	identity := auth.Identity{
+		UserID: uuid.NewString(),
+		OrgID:  orgID.String(),
+		Role:   string(auth.RoleAdmin),
+	}
+	dashboard := &DashboardResponse{
+		Score:             50,
+		Total:             3,
+		CompliantCount:    1,
+		AtRiskCount:       1,
+		NonCompliantCount: 1,
+	}
+	persistErr := errors.New("assessment snapshot insert failed")
+	var persisted bool
+
+	svc := &Service{
+		dashboardFn: func(_ context.Context, gotIdentity auth.Identity, gotSchemeID string) (*DashboardResponse, error) {
+			if gotIdentity != identity {
+				t.Fatalf("dashboard identity = %+v, want %+v", gotIdentity, identity)
+			}
+			if gotSchemeID != schemeID.String() {
+				t.Fatalf("dashboard schemeID = %q, want %q", gotSchemeID, schemeID.String())
+			}
+			return dashboard, nil
+		},
+		resolveSchemeAccessFn: func(_ context.Context, gotIdentity auth.Identity, gotSchemeID string) (dbgen.Scheme, string, error) {
+			if gotIdentity != identity {
+				t.Fatalf("resolve identity = %+v, want %+v", gotIdentity, identity)
+			}
+			if gotSchemeID != schemeID.String() {
+				t.Fatalf("resolve schemeID = %q, want %q", gotSchemeID, schemeID.String())
+			}
+			return dbgen.Scheme{ID: schemeID, OrgID: orgID}, string(auth.RoleAdmin), nil
+		},
+		createAssessmentFn: func(_ context.Context, params dbgen.CreateComplianceAssessmentParams) (dbgen.ComplianceAssessment, error) {
+			persisted = true
+			if params.SchemeID != schemeID {
+				t.Fatalf("assessment schemeID = %s, want %s", params.SchemeID, schemeID)
+			}
+			if params.Score != 50 || params.TotalItems != 3 || params.CompliantCount != 1 ||
+				params.AtRiskCount != 1 || params.NonCompliantCount != 1 {
+				t.Fatalf("unexpected assessment params: %+v", params)
+			}
+			return dbgen.ComplianceAssessment{}, persistErr
+		},
+	}
+
+	got, err := svc.Assess(context.Background(), identity, schemeID.String())
+	if !errors.Is(err, persistErr) {
+		t.Fatalf("expected assessment persistence error, got result=%+v err=%v", got, err)
+	}
+	if got != nil {
+		t.Fatalf("expected no dashboard when assessment persistence fails, got %+v", got)
+	}
+	if !persisted {
+		t.Fatal("expected assessment snapshot persistence to be attempted")
+	}
+}


### PR DESCRIPTION
## Summary
- propagate compliance assessment snapshot persistence failures from the assess service
- add unit coverage for the false-success path with verified assessment payload values
- keep successful assess responses unchanged when snapshot persistence succeeds

Closes #348
Closes #212

## Tests
- go test ./internal/compliance -run TestAssessReturnsErrorWhenAssessmentSnapshotPersistenceFails -count=1
- go test ./internal/compliance -count=1
- go test ./internal/... -count=1
- make test