### PR TITLE
fix(#344): refresh early-access admin actions

### DIFF
--- a/lib/early-access-api.test.ts
+++ b/lib/early-access-api.test.ts
@@ -1,0 +1,135 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const refreshAuthSession = vi.fn();
+const clearAuthCookies = vi.fn();
+
+vi.mock("@/lib/server-auth", () => ({
+  refreshAuthSession,
+  clearAuthCookies,
+}));
+
+const mockAccessToken = { current: "expired-access-token" };
+
+vi.mock("next/headers", () => ({
+  cookies: vi.fn(async () => ({
+    get: vi.fn((name: string) => {
+      if (name === "sh_access") {
+        return { value: mockAccessToken.current };
+      }
+      return undefined;
+    }),
+  })),
+}));
+
+function mockRefreshSuccess(): void {
+  refreshAuthSession.mockImplementation(async () => {
+    mockAccessToken.current = "new-access-token";
+    return {
+      kind: "success",
+      session: {
+        id: "user-1",
+        email: "admin@example.com",
+        full_name: "Admin User",
+        phone: null,
+        role: "admin",
+        wizard_complete: true,
+        scheme_memberships: [],
+        org: { id: "org-1", name: "Org 1" },
+      },
+    };
+  });
+}
+
+describe("early access admin API", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    refreshAuthSession.mockReset();
+    clearAuthCookies.mockReset();
+    mockAccessToken.current = "expired-access-token";
+  });
+
+  it("retries the admin request list after refreshing an expired access token", async () => {
+    mockRefreshSuccess();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(null, { status: 401 }))
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: [
+              {
+                id: "request-1",
+                full_name: "Person Example",
+                email: "person@example.com",
+                scheme_name: "Example Scheme",
+                unit_count: 12,
+                status: "pending",
+                created_at: "2026-05-31T10:00:00Z",
+              },
+            ],
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        ),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { listEarlyAccessRequests } = await import("./early-access-api");
+    const requests = await listEarlyAccessRequests();
+
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.id).toBe("request-1");
+    expect(refreshAuthSession).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "http://localhost:8080/api/v1/admin/early-access",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer new-access-token",
+        }),
+      }),
+    );
+  });
+
+  it.each([
+    ["approve", "approveEarlyAccessRequest"],
+    ["reject", "rejectEarlyAccessRequest"],
+  ] as const)("retries %s after refreshing an expired access token", async (action, exportName) => {
+    mockRefreshSuccess();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(null, { status: 401 }))
+      .mockResolvedValueOnce(new Response(null, { status: 204 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const api = await import("./early-access-api");
+    const result = await api[exportName]("request-1");
+
+    expect(result).toEqual({ ok: true });
+    expect(refreshAuthSession).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      `http://localhost:8080/api/v1/admin/early-access/request-1/${action}`,
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          Authorization: "Bearer new-access-token",
+        }),
+      }),
+    );
+  });
+
+  it("clears auth cookies when refresh recovery is rejected", async () => {
+    refreshAuthSession.mockResolvedValue({ kind: "invalid" });
+    vi.stubGlobal("fetch", vi.fn(async () => new Response(null, { status: 401 })));
+
+    const { approveEarlyAccessRequest } = await import("./early-access-api");
+    await expect(approveEarlyAccessRequest("request-1")).resolves.toEqual({
+      error: "Not authenticated",
+    });
+
+    expect(clearAuthCookies).toHaveBeenCalledTimes(1);
+  });
+});

--- a/lib/early-access-api.ts
+++ b/lib/early-access-api.ts
@@ -1,9 +1,12 @@
 'use server'
 
 import { cookies } from 'next/headers'
-import { readApiData } from './api-contract'
+import { buildApiHttpError, readApiData, readApiError } from './api-contract'
+import { clearAuthCookies, refreshAuthSession } from './server-auth'
 
 const BACKEND = () => process.env.BACKEND_URL ?? 'http://localhost:8080'
+const NOT_AUTHENTICATED = 'Not authenticated'
+const TEMPORARY_UNAVAILABLE = 'Temporary service issue. Please retry.'
 
 export type EarlyAccessRequest = {
   id: string
@@ -21,35 +24,70 @@ async function getAccessToken(): Promise<string | null> {
   return cookieStore.get('sh_access')?.value ?? null
 }
 
-export async function listEarlyAccessRequests(): Promise<EarlyAccessRequest[]> {
+function apiErrorResponse(status: number, message: string): Response {
+  return new Response(JSON.stringify({ error: { message } }), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+function withAuthHeader(headers: HeadersInit | undefined, token: string): Record<string, string> {
+  return {
+    ...Object.fromEntries(new Headers(headers).entries()),
+    Authorization: `Bearer ${token}`,
+  }
+}
+
+async function fetchAdmin(path: string, init: RequestInit = {}): Promise<Response> {
+  const send = (token: string) => {
+    const { headers, ...rest } = init
+    return fetch(`${BACKEND()}${path}`, {
+      ...rest,
+      headers: withAuthHeader(headers, token),
+    })
+  }
+
   const token = await getAccessToken()
-  if (!token) return []
-  const res = await fetch(`${BACKEND()}/api/v1/admin/early-access`, {
-    headers: { Authorization: `Bearer ${token}` },
+  if (!token) return apiErrorResponse(401, NOT_AUTHENTICATED)
+
+  const res = await send(token)
+  if (res.status !== 401) return res
+
+  const refreshed = await refreshAuthSession()
+  if (refreshed.kind === 'invalid') {
+    await clearAuthCookies()
+    return apiErrorResponse(401, NOT_AUTHENTICATED)
+  }
+  if (refreshed.kind !== 'success') {
+    return apiErrorResponse(503, TEMPORARY_UNAVAILABLE)
+  }
+
+  const refreshedToken = await getAccessToken()
+  if (!refreshedToken) return apiErrorResponse(401, NOT_AUTHENTICATED)
+
+  return send(refreshedToken)
+}
+
+export async function listEarlyAccessRequests(): Promise<EarlyAccessRequest[]> {
+  const res = await fetchAdmin('/api/v1/admin/early-access', {
     cache: 'no-store',
   })
-  if (!res.ok) return []
+  if (!res.ok) throw await buildApiHttpError(res, 'Failed to load early access requests')
   return readApiData<EarlyAccessRequest[]>(res)
 }
 
 export async function approveEarlyAccessRequest(id: string): Promise<{ ok: true } | { error: string }> {
-  const token = await getAccessToken()
-  if (!token) return { error: 'Not authenticated' }
-  const res = await fetch(`${BACKEND()}/api/v1/admin/early-access/${id}/approve`, {
+  const res = await fetchAdmin(`/api/v1/admin/early-access/${id}/approve`, {
     method: 'POST',
-    headers: { Authorization: `Bearer ${token}` },
   })
-  if (!res.ok) return { error: 'Failed to approve' }
+  if (!res.ok) return { error: await readApiError(res, 'Failed to approve') }
   return { ok: true }
 }
 
 export async function rejectEarlyAccessRequest(id: string): Promise<{ ok: true } | { error: string }> {
-  const token = await getAccessToken()
-  if (!token) return { error: 'Not authenticated' }
-  const res = await fetch(`${BACKEND()}/api/v1/admin/early-access/${id}/reject`, {
+  const res = await fetchAdmin(`/api/v1/admin/early-access/${id}/reject`, {
     method: 'POST',
-    headers: { Authorization: `Bearer ${token}` },
   })
-  if (!res.ok) return { error: 'Failed to reject' }
+  if (!res.ok) return { error: await readApiError(res, 'Failed to reject') }
   return { ok: true }
 }


### PR DESCRIPTION
## Summary
- retry early-access admin list/approve/reject once after refreshing an expired access token
- clear auth cookies when refresh recovery is rejected instead of silently showing an empty queue
- preserve shaped backend error messages for approve/reject failures
- add Vitest coverage for list, approve, reject, and invalid-refresh behavior

Closes #344

## Tests
- npm test -- lib/early-access-api.test.ts
- npm test -- lib/early-access-api.test.ts lib/server-api.test.ts 'app/api/proxy/[...path]/route.test.ts'
- npm run lint
- npm run typecheck
- npm test