### PR TITLE
fix(#339): validate collection reminder channel content

### DIFF
--- a/backend/internal/levy/attention.go
+++ b/backend/internal/levy/attention.go
@@ -3,6 +3,7 @@ package levy
 import (
 	"fmt"
 	"sort"
+	"strings"
 	"time"
 )
 
@@ -165,6 +166,27 @@ func validateCollectionEventInput(input RecordCollectionEventInput) error {
 	default:
 		return ErrInvalidInput
 	}
+}
+
+func normalizeSendReminderInput(input SendReminderInput) SendReminderInput {
+	input.Email.Subject = strings.TrimSpace(input.Email.Subject)
+	input.Email.Body = strings.TrimSpace(input.Email.Body)
+	input.WhatsApp.Body = strings.TrimSpace(input.WhatsApp.Body)
+	return input
+}
+
+func validateSendReminderInput(input SendReminderInput) error {
+	input = normalizeSendReminderInput(input)
+	if !input.Email.Enabled && !input.WhatsApp.Enabled {
+		return ErrInvalidInput
+	}
+	if input.Email.Enabled && (input.Email.Subject == "" || input.Email.Body == "") {
+		return ErrInvalidInput
+	}
+	if input.WhatsApp.Enabled && input.WhatsApp.Body == "" {
+		return ErrInvalidInput
+	}
+	return nil
 }
 
 func sortAttentionItems(items []AttentionItem) {

--- a/backend/internal/levy/attention_test.go
+++ b/backend/internal/levy/attention_test.go
@@ -173,6 +173,40 @@ func TestBuildReminderDraftGeneratesDeterministicBodies(t *testing.T) {
 	}
 }
 
+func TestValidateSendReminderInputRejectsBlankEnabledChannelContent(t *testing.T) {
+	tests := []struct {
+		name  string
+		input SendReminderInput
+	}{
+		{
+			name: "email subject",
+			input: SendReminderInput{
+				Email: ReminderChannelInput{Enabled: true, Subject: " ", Body: "Please pay"},
+			},
+		},
+		{
+			name: "email body",
+			input: SendReminderInput{
+				Email: ReminderChannelInput{Enabled: true, Subject: "Levy reminder", Body: " "},
+			},
+		},
+		{
+			name: "whatsapp body",
+			input: SendReminderInput{
+				WhatsApp: ReminderChannelInput{Enabled: true, Body: " "},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := validateSendReminderInput(tt.input); err != ErrInvalidInput {
+				t.Fatalf("validateSendReminderInput error = %v, want ErrInvalidInput", err)
+			}
+		})
+	}
+}
+
 func TestScoreAttentionItemSuppressesReminderForActivePromise(t *testing.T) {
 	now := time.Date(2026, 4, 16, 0, 0, 0, 0, time.UTC)
 	item := attentionAccount{

--- a/backend/internal/levy/handler.go
+++ b/backend/internal/levy/handler.go
@@ -278,15 +278,16 @@ func (h *Handler) SendReminder(w http.ResponseWriter, r *http.Request) {
 		response.Error(w, http.StatusBadRequest, response.CodeBadRequest, "invalid request body")
 		return
 	}
-	if !req.Email.Enabled && !req.WhatsApp.Enabled {
-		response.Error(w, http.StatusBadRequest, response.CodeBadRequest, "at least one channel must be enabled")
+	input := normalizeSendReminderInput(SendReminderInput{
+		Email:    ReminderChannelInput{Enabled: req.Email.Enabled, Subject: req.Email.Subject, Body: req.Email.Body},
+		WhatsApp: ReminderChannelInput{Enabled: req.WhatsApp.Enabled, Body: req.WhatsApp.Body},
+	})
+	if err := validateSendReminderInput(input); err != nil {
+		response.Error(w, http.StatusBadRequest, response.CodeBadRequest, "enabled reminder channels require message content")
 		return
 	}
 
-	event, err := h.service.SendReminder(r.Context(), identity, chi.URLParam(r, "schemeId"), chi.URLParam(r, "accountId"), SendReminderInput{
-		Email:    ReminderChannelInput{Enabled: req.Email.Enabled, Subject: strings.TrimSpace(req.Email.Subject), Body: strings.TrimSpace(req.Email.Body)},
-		WhatsApp: ReminderChannelInput{Enabled: req.WhatsApp.Enabled, Body: strings.TrimSpace(req.WhatsApp.Body)},
-	})
+	event, err := h.service.SendReminder(r.Context(), identity, chi.URLParam(r, "schemeId"), chi.URLParam(r, "accountId"), input)
 	if err != nil {
 		writeLevyError(w, err, "failed to send reminder")
 		return
@@ -328,7 +329,7 @@ func (h *Handler) ImportBankStatement(w http.ResponseWriter, r *http.Request) {
 	import_, err := h.service.ImportBankStatement(r.Context(), identity, chi.URLParam(r, "schemeId"), BankStatementImportInput{
 		BankName:         bank,
 		OriginalFilename: header.Filename,
-		RawCSV:          rawCSV,
+		RawCSV:           rawCSV,
 	})
 	if err != nil {
 		writeLevyError(w, err, "failed to import bank statement")

--- a/backend/internal/levy/handler_test.go
+++ b/backend/internal/levy/handler_test.go
@@ -154,3 +154,48 @@ func TestSendReminderRejectsMissingChannels(t *testing.T) {
 		t.Fatalf("status = %d, want %d", w.Code, http.StatusBadRequest)
 	}
 }
+
+func TestSendReminderRejectsBlankEnabledChannelContent(t *testing.T) {
+	tests := []struct {
+		name string
+		body []byte
+	}{
+		{
+			name: "email subject",
+			body: []byte(`{"email":{"enabled":true,"subject":"  ","body":"Please pay"},"whatsapp":{"enabled":false}}`),
+		},
+		{
+			name: "email body",
+			body: []byte(`{"email":{"enabled":true,"subject":"Levy reminder","body":"  "},"whatsapp":{"enabled":false}}`),
+		},
+		{
+			name: "whatsapp body",
+			body: []byte(`{"email":{"enabled":false},"whatsapp":{"enabled":true,"body":"  "}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := &fakeAttentionService{}
+			h := NewHandlerWithService(svc)
+
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/levies/scheme-1/accounts/account-1/reminders", bytes.NewReader(tt.body))
+			req = req.WithContext(auth.ContextWithIdentity(req.Context(), "user-1", "org-1", "trustee"))
+
+			rctx := chi.NewRouteContext()
+			rctx.URLParams.Add("schemeId", "scheme-1")
+			rctx.URLParams.Add("accountId", "account-1")
+			req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+
+			w := httptest.NewRecorder()
+			h.SendReminder(w, req)
+
+			if w.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d body=%s, want %d", w.Code, w.Body.String(), http.StatusBadRequest)
+			}
+			if svc.sendCalled {
+				t.Fatalf("service should not be called for blank enabled %s", tt.name)
+			}
+		})
+	}
+}

--- a/backend/internal/levy/service.go
+++ b/backend/internal/levy/service.go
@@ -1127,7 +1127,8 @@ func (s *Service) ReminderDraft(ctx context.Context, identity auth.Identity, sch
 }
 
 func (s *Service) SendReminder(ctx context.Context, identity auth.Identity, schemeID, accountID string, input SendReminderInput) (*CollectionEvent, error) {
-	if !input.Email.Enabled && !input.WhatsApp.Enabled {
+	input = normalizeSendReminderInput(input)
+	if err := validateSendReminderInput(input); err != nil {
 		return nil, ErrInvalidInput
 	}
 


### PR DESCRIPTION
## Summary
- normalize reminder channel input before validation and enqueueing
- require enabled email reminders to include both subject and body
- require enabled WhatsApp reminders to include a body
- reject invalid reminder requests in the handler before the service records events or queues jobs
- add handler and pure validation coverage for blank enabled channel content

Closes #339

## Tests
- go test ./internal/levy -run TestSendReminderRejectsBlankEnabledChannelContent -count=1
- go test ./internal/levy -run TestValidateSendReminderInputRejectsBlankEnabledChannelContent -count=1
- go test ./internal/levy -count=1
- go test ./internal/... -count=1
- make test