### PR TITLE
Fix onboarding setup session preflight

### DIFF
--- a/lib/auth-actions.test.ts
+++ b/lib/auth-actions.test.ts
@@ -17,6 +17,22 @@ vi.mock("./server-auth", () => ({
   clearAuthCookies,
 }));
 
+function encodedSession(overrides: Record<string, unknown> = {}): string {
+  return encodeURIComponent(
+    JSON.stringify({
+      id: "user-1",
+      email: "person@example.com",
+      full_name: "Person Example",
+      phone: null,
+      role: "admin",
+      wizard_complete: false,
+      scheme_memberships: [],
+      org: { id: "org-1", name: "" },
+      ...overrides,
+    }),
+  );
+}
+
 describe("auth actions", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
@@ -29,6 +45,7 @@ describe("auth actions", () => {
   it("surfaces the backend onboarding error message from setupAction", async () => {
     cookieGet.mockImplementation((name: string) => {
       if (name === "sh_access") return { value: "access-token" };
+      if (name === "sh_session") return { value: encodedSession() };
       return undefined;
     });
 
@@ -57,6 +74,98 @@ describe("auth actions", () => {
     });
 
     expect(result).toEqual({ error: "Scheme address is required" });
+  });
+
+  it.each([
+    ["missing", undefined],
+    ["corrupt", "not-json"],
+  ] as const)("does not call onboarding setup when the session cookie is %s", async (_name, rawSession) => {
+    cookieGet.mockImplementation((name: string) => {
+      if (name === "sh_access") return { value: "access-token" };
+      if (name === "sh_session" && rawSession !== undefined) return { value: rawSession };
+      return undefined;
+    });
+    const fetchMock = vi.fn(async () =>
+      new Response(
+        JSON.stringify({
+          data: {
+            org: { id: "org-1", name: "Org 1" },
+            scheme: { id: "scheme-1", name: "Scheme 1" },
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { setupAction } = await import("./auth-actions");
+    const result = await setupAction({
+      org_name: "Org",
+      contact_email: "person@example.com",
+      scheme_name: "Scheme",
+      scheme_address: "1 Main Road",
+      unit_count: 10,
+    });
+
+    expect(result).toEqual({ error: "Session expired — please log in again" });
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(clearAuthCookies).toHaveBeenCalledTimes(1);
+  });
+
+  it("updates a valid setup session from the backend setup response", async () => {
+    cookieGet.mockImplementation((name: string) => {
+      if (name === "sh_access") return { value: "access-token" };
+      if (name === "sh_session") return { value: encodedSession() };
+      return undefined;
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(
+          JSON.stringify({
+            data: {
+              org: {
+                id: "org-1",
+                name: "Org 1",
+                contact_email: "person@example.com",
+                contact_phone: null,
+              },
+              scheme: { id: "scheme-1", name: "Scheme 1" },
+            },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      ),
+    );
+
+    const { setupAction } = await import("./auth-actions");
+    const result = await setupAction({
+      org_name: "Org 1",
+      contact_email: "person@example.com",
+      scheme_name: "Scheme 1",
+      scheme_address: "1 Main Road",
+      unit_count: 10,
+    });
+
+    expect(result).toEqual({
+      user: expect.objectContaining({
+        id: "user-1",
+        wizard_complete: true,
+        org: expect.objectContaining({ id: "org-1", name: "Org 1" }),
+        scheme_memberships: [
+          expect.objectContaining({
+            scheme_id: "scheme-1",
+            scheme_name: "Scheme 1",
+            role: "admin",
+          }),
+        ],
+      }),
+    });
+    expect(cookieSet).toHaveBeenCalledWith(
+      "sh_session",
+      expect.any(String),
+      expect.objectContaining({ httpOnly: true }),
+    );
   });
 
   it("applies a timeout signal when accepting an invite", async () => {

--- a/lib/auth-actions.ts
+++ b/lib/auth-actions.ts
@@ -149,6 +149,13 @@ export async function setupAction(data: {
   const accessToken = cookieStore.get("sh_access")?.value;
   if (!accessToken) return { error: "Not authenticated" };
 
+  const raw = cookieStore.get("sh_session")?.value;
+  const session = parseSessionCookie(raw);
+  if (!session) {
+    await clearAuthCookies();
+    return { error: "Session expired — please log in again" };
+  }
+
   let res: Response;
   try {
     res = await fetchWithTimeout(`${BACKEND()}/api/v1/onboarding/setup`, {
@@ -175,34 +182,28 @@ export async function setupAction(data: {
   }>(res);
 
   // Update session cookie: wizard_complete + first scheme membership
-  const raw = cookieStore.get("sh_session")?.value;
-  const session = parseSessionCookie(raw);
-  if (session) {
-    session.wizard_complete = true;
-    session.org = {
-      id: result.org.id,
-      name: result.org.name,
-      contact_email: data.contact_email,
-      contact_phone: result.org.contact_phone ?? session.org?.contact_phone ?? null,
-    };
-    session.scheme_memberships = [
-      {
-        scheme_id: result.scheme.id,
-        scheme_name: result.scheme.name,
-        unit_id: null,
-        unit_identifier: null,
-        role: APP_ROLES.admin,
-      },
-    ];
-    cookieStore.set(
-      "sh_session",
-      encodeURIComponent(JSON.stringify(session)),
-      SESSION_OPTS,
-    );
-    return { user: session };
-  }
-
-  return { error: "Session not found — please log in again" };
+  session.wizard_complete = true;
+  session.org = {
+    id: result.org.id,
+    name: result.org.name,
+    contact_email: data.contact_email,
+    contact_phone: result.org.contact_phone ?? session.org?.contact_phone ?? null,
+  };
+  session.scheme_memberships = [
+    {
+      scheme_id: result.scheme.id,
+      scheme_name: result.scheme.name,
+      unit_id: null,
+      unit_identifier: null,
+      role: APP_ROLES.admin,
+    },
+  ];
+  cookieStore.set(
+    "sh_session",
+    encodeURIComponent(JSON.stringify(session)),
+    SESSION_OPTS,
+  );
+  return { user: session };
 }
 
 // ─── Forgot password ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- require a valid sh_session cookie before calling the onboarding setup backend mutation
- clear auth cookies and return a session-expired error when the setup session is missing or corrupt
- keep successful setup session updates using the backend org and scheme response

Closes #336

## Verification
- npm test -- lib/auth-actions.test.ts
- npm run lint
- npm run typecheck
- npm test