### PR TITLE
Handle audit log truncation

### DIFF
--- a/app/app/[schemeId]/audit/page.test.tsx
+++ b/app/app/[schemeId]/audit/page.test.tsx
@@ -95,4 +95,36 @@ describe("AuditPage", () => {
     expect(screen.getByText("Scheme Updated")).toBeInTheDocument();
     expect(screen.getByText("Details")).toBeInTheDocument();
   });
+
+  it("shows a truncation message and load more control when total exceeds limit", async () => {
+    mockUseAuthenticatedQuery.mockReturnValue({
+      data: {
+        events: Array.from({ length: 50 }, (_, i) => ({
+          id: `evt-${i + 1}`,
+          scheme_id: "scheme-1",
+          org_id: "org-1",
+          actor_user_id: "user-1",
+          actor_role: "admin",
+          resource_type: "scheme",
+          resource_id: "scheme-1",
+          action: "scheme.updated",
+          before_state: null,
+          after_state: null,
+          metadata: null,
+          occurred_at: "2026-04-29T10:00:00Z",
+        })),
+        total: 120,
+        limit: 50,
+      },
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+
+    const { default: AuditPage } = await import("@/app/app/[schemeId]/audit/page");
+    render(<AuditPage />);
+
+    expect(screen.getByText("Showing latest 50 of 120 audit events.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Show more events" })).toBeInTheDocument();
+  });
 });

--- a/app/app/[schemeId]/audit/page.test.tsx
+++ b/app/app/[schemeId]/audit/page.test.tsx
@@ -124,7 +124,7 @@ describe("AuditPage", () => {
     const { default: AuditPage } = await import("@/app/app/[schemeId]/audit/page");
     render(<AuditPage />);
 
-    expect(screen.getByText("Showing latest 50 of 120 audit events.")).toBeInTheDocument();
+    expect(screen.getByText("Showing latest 50 of 120 audit events. More older events are available.")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Show more events" })).toBeInTheDocument();
   });
 });

--- a/app/app/[schemeId]/audit/page.tsx
+++ b/app/app/[schemeId]/audit/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useParams } from 'next/navigation'
+import { useState } from 'react'
 
 import { useAuth } from '@/lib/auth'
 import { schemeKeys } from '@/lib/query-keys'
@@ -82,6 +83,7 @@ function EventRow({ event }: { event: AuditEventInfo }) {
 }
 
 export default function AuditPage() {
+  const [limit, setLimit] = useState(50)
   const { user } = useAuth()
   const params = useParams()
   const schemeId = params.schemeId as string
@@ -92,8 +94,8 @@ export default function AuditPage() {
     error,
     refetch,
   } = useAuthenticatedQuery<{ events: AuditEventInfo[]; total: number; limit: number }>({
-    queryKey: schemeKeys.audit(schemeId),
-    queryFn: () => getSchemeAuditEvents(schemeId),
+    queryKey: schemeKeys.audit(schemeId, limit),
+    queryFn: () => getSchemeAuditEvents(schemeId, limit),
     staleTime: 30_000,
   })
 
@@ -130,12 +132,39 @@ export default function AuditPage() {
   }
 
   const events = data?.events ?? []
+  const total = data?.total ?? 0
+  const responseLimit = data?.limit ?? limit
+  const truncated = total > responseLimit
+  const canLoadMore = total > responseLimit && responseLimit < 200
+  const hasMore = total > events.length
+
+  const loadMore = () => {
+    setLimit(total > 200 ? 200 : total)
+  }
 
   return (
     <div className="px-4 py-6 sm:px-8 sm:py-8 max-w-[900px]">
       <p className="text-[12px] text-muted mb-4">Scheme › Audit log</p>
       <h1 className="font-serif text-[28px] font-semibold text-ink mb-1">Audit log</h1>
-      <p className="text-[14px] text-muted mb-8">Scheme activity trail showing recent changes.</p>
+      <p className="text-[14px] text-muted mb-8">
+        Scheme activity trail showing recent changes.
+      </p>
+      {truncated && (
+        <p className="text-[12px] text-muted mb-6">
+          Showing latest {events.length} of {total} audit events.
+          {hasMore ? " More older events are available." : ""}
+        </p>
+      )}
+      {canLoadMore && (
+        <div className="mb-8">
+          <button
+            type="button"
+            onClick={loadMore}
+            className="text-[13px] font-medium text-accent hover:underline">
+            Show more events
+          </button>
+        </div>
+      )}
 
       {events.length === 0 ? (
         <div className="bg-surface border border-border rounded-lg px-6 py-12 text-center text-[14px] text-muted">

--- a/backend/db/migrations/00033_early_access_pending_requests_unique.sql
+++ b/backend/db/migrations/00033_early_access_pending_requests_unique.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_early_access_requests_email_pending
+ON early_access_requests (email)
+WHERE status = 'pending';
+
+-- +goose Down
+
+DROP INDEX IF EXISTS idx_early_access_requests_email_pending;

--- a/backend/internal/earlyaccess/service.go
+++ b/backend/internal/earlyaccess/service.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 
 	dbgen "github.com/stratahq/backend/db/gen"
 	"github.com/stratahq/backend/internal/auth"
@@ -84,6 +85,14 @@ func validateActionToken(secret, id, action, sig string, exp int64) bool {
 }
 
 func (s *Service) Submit(ctx context.Context, p SubmitParams) (*RequestResponse, error) {
+	pending, err := s.getPendingByEmail(ctx, p.Email)
+	if err != nil {
+		return nil, err
+	}
+	if pending != nil {
+		return toResponse(*pending), nil
+	}
+
 	row, err := s.db.CreateEarlyAccessRequest(ctx, dbgen.CreateEarlyAccessRequestParams{
 		FullName:   p.FullName,
 		Email:      p.Email,
@@ -91,6 +100,15 @@ func (s *Service) Submit(ctx context.Context, p SubmitParams) (*RequestResponse,
 		UnitCount:  p.UnitCount,
 	})
 	if err != nil {
+		if isUniqueViolation(err) {
+			pending, lookupErr := s.getPendingByEmail(ctx, p.Email)
+			if lookupErr == nil && pending != nil {
+				return toResponse(*pending), nil
+			}
+			if lookupErr != nil {
+				return nil, lookupErr
+			}
+		}
 		return nil, err
 	}
 
@@ -105,6 +123,26 @@ func (s *Service) Submit(ctx context.Context, p SubmitParams) (*RequestResponse,
 	}
 
 	return toResponse(row), nil
+}
+
+func (s *Service) getPendingByEmail(ctx context.Context, email string) (*dbgen.EarlyAccessRequest, error) {
+	rows, err := s.db.ListEarlyAccessRequests(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, req := range rows {
+		if req.Status == dbgen.EarlyAccessStatusPending && strings.EqualFold(req.Email, email) {
+			return &req, nil
+		}
+	}
+
+	return nil, nil
+}
+
+func isUniqueViolation(err error) bool {
+	var pgErr *pgconn.PgError
+	return errors.As(err, &pgErr) && pgErr.Code == "23505"
 }
 
 func (s *Service) List(ctx context.Context) ([]RequestResponse, error) {

--- a/backend/tests/integration/earlyaccess_test.go
+++ b/backend/tests/integration/earlyaccess_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -170,5 +171,52 @@ func TestEarlyAccess_SignedApprovalRejectsEmptyAdminSecret(t *testing.T) {
 	}
 	if got := loadEarlyAccessStatus(t, requestID); got != "pending" {
 		t.Fatalf("status after empty-secret POST=%s, want pending", got)
+	}
+}
+
+func TestEarlyAccess_SubmitReturnsExistingPendingRequestOnDuplicateEmail(t *testing.T) {
+	h := newEarlyAccessHandler(t, "platform-admin@test.example.com", "platform-secret")
+	router := h.PublicRoutes()
+
+	email := uniqueEmail(t)
+	body := `{"full_name":"Person Example","email":"` + email + `","scheme_name":"Green View Estate","unit_count":12}`
+
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	first := httptest.NewRecorder()
+	router.ServeHTTP(first, req)
+	if first.Code != http.StatusCreated {
+		t.Fatalf("first submit status=%d body=%s, want 201", first.Code, first.Body.String())
+	}
+	firstResp := decodeSuccess[earlyaccess.RequestResponse](t, first)
+
+	req = httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	second := httptest.NewRecorder()
+	router.ServeHTTP(second, req)
+	if second.Code != http.StatusCreated {
+		t.Fatalf("second submit status=%d body=%s, want 201", second.Code, second.Body.String())
+	}
+	secondResp := decodeSuccess[earlyaccess.RequestResponse](t, second)
+
+	if firstResp.ID != secondResp.ID {
+		t.Fatalf("expected duplicate submission to return same request id, got %q and %q", firstResp.ID, secondResp.ID)
+	}
+	if firstResp.Status != "pending" || secondResp.Status != "pending" {
+		t.Fatalf("expected pending statuses, got %q and %q", firstResp.Status, secondResp.Status)
+	}
+
+	rows, err := testQ.ListEarlyAccessRequests(context.Background())
+	if err != nil {
+		t.Fatalf("ListEarlyAccessRequests: %v", err)
+	}
+	pendingCount := 0
+	for _, row := range rows {
+		if row.Email == email && row.Status == dbgen.EarlyAccessStatusPending {
+			pendingCount++
+		}
+	}
+	if pendingCount != 1 {
+		t.Fatalf("expected one pending request for email %q, got %d", email, pendingCount)
 	}
 }

--- a/lib/query-keys.test.ts
+++ b/lib/query-keys.test.ts
@@ -21,6 +21,7 @@ describe("schemeKeys", () => {
       "scheme",
       "scheme-1",
       "audit",
+      "limit-50",
     ])
   })
 })

--- a/lib/query-keys.ts
+++ b/lib/query-keys.ts
@@ -25,5 +25,6 @@ export const schemeKeys = {
   levy: (schemeId: string) => ["scheme", schemeId, "levy"] as const,
   agm: (schemeId: string) => ["scheme", schemeId, "agm"] as const,
   agmMembers: (schemeId: string) => ["scheme", schemeId, "agm", "members"] as const,
-  audit: (schemeId: string) => ["scheme", schemeId, "audit"] as const,
+  audit: (schemeId: string, limit = 50) =>
+    ["scheme", schemeId, "audit", `limit-${limit}`] as const,
 }


### PR DESCRIPTION
## Summary
- detect when audit events are truncated and show explicit context
- add a load-more control that increases the audit event fetch window up to backend max
- include audit limit in query keys to keep cached pages scoped correctly
- add tests for audit truncation message and query-key shape
- prevent duplicate pending early-access requests by returning existing pending requests
- enforce duplicate-prevention at storage level with a partial unique pending-email index
- add integration coverage for duplicate early-access form submissions

Closes #334
Closes #340
