### PR TITLE
Prevent active invitation leftovers on create failure

### DIFF
--- a/backend/db/migrations/00033_invitation_pending_unique.sql
+++ b/backend/db/migrations/00033_invitation_pending_unique.sql
@@ -1,0 +1,15 @@
+-- backend/db/migrations/00033_invitation_pending_unique.sql
+-- +goose Up
+
+CREATE UNIQUE INDEX invitations_org_scheme_unit_email_pending_idx
+ON invitations (
+    org_id,
+    scheme_id,
+    COALESCE(unit_id, '00000000-0000-0000-0000-000000000000'::uuid),
+    lower(email)
+)
+WHERE status = 'pending';
+
+-- +goose Down
+
+DROP INDEX IF EXISTS invitations_org_scheme_unit_email_pending_idx;

--- a/backend/internal/invitation/handler.go
+++ b/backend/internal/invitation/handler.go
@@ -66,6 +66,8 @@ func (h *Handler) Create(w http.ResponseWriter, r *http.Request) {
 			response.Error(w, http.StatusForbidden, response.CodeForbidden, "scheme belongs to a different org")
 		case err.Error() == "invalid scheme_id", err.Error() == "invalid unit_id":
 			response.Error(w, http.StatusBadRequest, response.CodeBadRequest, err.Error())
+		case err == ErrDuplicateInvite:
+			response.Error(w, http.StatusConflict, response.CodeConflict, "only one pending invitation allowed per recipient for this membership")
 		default:
 			response.Error(w, http.StatusInternalServerError, response.CodeInternalError, "failed to create invitation")
 		}

--- a/backend/internal/invitation/handler_test.go
+++ b/backend/internal/invitation/handler_test.go
@@ -62,6 +62,41 @@ func TestHandlerCreateReturnsForbiddenForForeignScheme(t *testing.T) {
 	}
 }
 
+func TestHandlerCreateReturnsConflictForDuplicatePendingInvitation(t *testing.T) {
+	h := NewHandler(&stubServicer{
+		createFn: func(context.Context, string, CreateParams, string) (*InvitationResponse, error) {
+			return nil, ErrDuplicateInvite
+		},
+	}, "http://localhost:3000")
+
+	body, _ := json.Marshal(map[string]string{
+		"email":     "user@example.com",
+		"full_name": "User Example",
+		"role":      "trustee",
+		"scheme_id": "11111111-1111-1111-1111-111111111111",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/invitations", bytes.NewReader(body))
+	req = req.WithContext(auth.ContextWithIdentity(req.Context(), uuidMustString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"), uuidMustString("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"), string(auth.RoleAdmin)))
+	w := httptest.NewRecorder()
+
+	h.Create(w, req)
+	if w.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusConflict)
+	}
+
+	var payload struct {
+		Error struct {
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&payload); err != nil {
+		t.Fatalf("response decode: %v", err)
+	}
+	if payload.Error.Message == "" {
+		t.Fatal("expected non-empty error message")
+	}
+}
+
 func uuidMustString(raw string) string {
 	return raw
 }

--- a/backend/internal/invitation/service.go
+++ b/backend/internal/invitation/service.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgtype"
 	"golang.org/x/crypto/bcrypt"
 
@@ -21,10 +22,12 @@ import (
 )
 
 var (
-	ErrNotFound     = errors.New("invitation not found")
-	ErrForbidden    = errors.New("invitation belongs to a different org")
-	ErrInvalidToken = errors.New("invalid, expired, or already used invitation token")
-	ErrEmailExists  = errors.New("email already registered")
+	ErrNotFound        = errors.New("invitation not found")
+	ErrForbidden       = errors.New("invitation belongs to a different org")
+	ErrInvalidToken    = errors.New("invalid, expired, or already used invitation token")
+	ErrEmailExists     = errors.New("email already registered")
+	ErrDuplicateInvite = errors.New("a pending invitation for this recipient already exists")
+	ErrInvitationSend  = errors.New("failed to send invitation")
 )
 
 type CreateParams struct {
@@ -167,6 +170,10 @@ func (s *Service) Create(ctx context.Context, orgID string, p CreateParams, appB
 		ExpiresAt: expiresAt,
 	})
 	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" && pgErr.ConstraintName == "invitations_org_scheme_unit_email_pending_idx" {
+			return nil, ErrDuplicateInvite
+		}
 		return nil, err
 	}
 
@@ -191,7 +198,13 @@ func (s *Service) Create(ctx context.Context, orgID string, p CreateParams, appB
 
 	inviteURL := appBaseURL + "/auth/invite/" + token
 	if err := s.sender.SendInvitation(ctx, p.Email, p.FullName, inviteURL); err != nil {
-		return nil, err
+		if revokeErr := s.q.UpdateInvitationStatus(ctx, dbgen.UpdateInvitationStatusParams{
+			Status: "revoked",
+			ID:     inv.ID,
+		}); revokeErr != nil {
+			return nil, err
+		}
+		return nil, ErrInvitationSend
 	}
 
 	return toResponse(inv), nil

--- a/backend/internal/invitation/service_test.go
+++ b/backend/internal/invitation/service_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgtype"
 
 	dbgen "github.com/stratahq/backend/db/gen"
@@ -21,6 +22,7 @@ type fakeInvitationStore struct {
 	unit                  *dbgen.Unit
 	invitationByID        *dbgen.Invitation
 	invitationByToken     *dbgen.Invitation
+	createInvitationErr   error
 	createdUser           *dbgen.User
 	createdInvitation     *dbgen.CreateInvitationParams
 	updatedInvitation     *dbgen.UpdateInvitationTokenParams
@@ -67,6 +69,9 @@ func (a *fakeInvitationAuditor) RecordResourceEvent(_ context.Context, event aud
 }
 
 func (f *fakeInvitationStore) CreateInvitation(_ context.Context, arg dbgen.CreateInvitationParams) (dbgen.Invitation, error) {
+	if f.createInvitationErr != nil {
+		return dbgen.Invitation{}, f.createInvitationErr
+	}
 	f.createdInvitation = &arg
 	return dbgen.Invitation{
 		ID:        uuid.New(),
@@ -328,14 +333,53 @@ func TestServiceCreateRecordsAuditBeforeInvitationSendFailure(t *testing.T) {
 	if err == nil {
 		t.Fatal("Create() error = nil, want send failure")
 	}
+	if !errors.Is(err, ErrInvitationSend) {
+		t.Fatalf("Create() error = %v, want %v", err, ErrInvitationSend)
+	}
 	if sender.calls != 1 {
 		t.Fatalf("SendInvitation calls = %d, want 1", sender.calls)
+	}
+	if store.updatedInviteStatus == nil || store.updatedInviteStatus.Status != "revoked" {
+		t.Fatalf("invitation status update = %+v, want revoked", store.updatedInviteStatus)
 	}
 	if len(auditor.events) != 1 {
 		t.Fatalf("audit events = %d, want 1", len(auditor.events))
 	}
 	if auditor.events[0].Action != "invitation.created" {
 		t.Fatalf("audit action = %q, want invitation.created", auditor.events[0].Action)
+	}
+}
+
+func TestServiceCreateReturnsConflictForDuplicatePendingInvitation(t *testing.T) {
+	orgID := uuid.New()
+	schemeID := uuid.New()
+	store := &fakeInvitationStore{
+		scheme: &dbgen.Scheme{
+			ID:    schemeID,
+			OrgID: orgID,
+		},
+		createInvitationErr: &pgconn.PgError{
+			Code:           "23505",
+			ConstraintName: "invitations_org_scheme_unit_email_pending_idx",
+		},
+	}
+	svc := &Service{
+		q:             store,
+		withTx:        func(ctx context.Context, fn func(q txStore) error) error { return fn(store) },
+		sender:        &fakeInvitationSender{},
+		jwtSecret:     "unit-test-secret",
+		jwtExpiry:     15 * time.Minute,
+		refreshExpiry: 7 * 24 * time.Hour,
+	}
+
+	_, err := svc.Create(context.Background(), orgID.String(), CreateParams{
+		Email:    "user@example.com",
+		FullName: "Test User",
+		Role:     "trustee",
+		SchemeID: schemeID.String(),
+	}, "http://localhost:3000")
+	if !errors.Is(err, ErrDuplicateInvite) {
+		t.Fatalf("Create() error = %v, want %v", err, ErrDuplicateInvite)
 	}
 }
 


### PR DESCRIPTION
Closes #319

## Summary
- Added a DB-level uniqueness guard to block multiple active pending invites for the same org/scheme/unit/email while pending.
  - migration: `backend/db/migrations/00033_invitation_pending_unique.sql`
- On invitation create, mapped pending-duplicate violations to a client-facing conflict error.
- If invitation email send fails after create, invitation is revoked before returning an error.

## Verification
- `go test ./internal/invitation`
- `golangci-lint run ./internal/invitation`
