### PR TITLE
Fail readiness when schema migrations are missing

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -125,7 +125,7 @@ func main() {
 
 	// Handlers
 	handlers := server.Handlers{
-		Health:          health.New(db, &redisChecker{rdb}),
+		Health:          health.New(db, &redisChecker{rdb}, db),
 		Auth:            auth.NewHandler(authService),
 		Audit:           audit.NewHandler(resourceAuditService),
 		Agm:             agm.NewHandler(agmService),

--- a/backend/internal/platform/database/database.go
+++ b/backend/internal/platform/database/database.go
@@ -11,6 +11,9 @@ import (
 	dbgen "github.com/stratahq/backend/db/gen"
 )
 
+// Keep this aligned with the latest migration in backend/db/migrations.
+const minimumMigrationVersion = 32
+
 // Pool wraps pgxpool.Pool together with a ready-to-use *dbgen.Queries so
 // callers only need to carry one value.
 type Pool struct {
@@ -63,4 +66,19 @@ func newPoolConfig(databaseURL string) (*pgxpool.Config, error) {
 // health handler.
 func (p *Pool) Ping(ctx context.Context) error {
 	return p.Pool.Ping(ctx)
+}
+
+func (p *Pool) CheckMigrations(ctx context.Context) error {
+	const query = "SELECT COALESCE(MAX(version_id), 0) FROM goose_db_version"
+
+	var version int64
+	if err := p.QueryRow(ctx, query).Scan(&version); err != nil {
+		return fmt.Errorf("database migration check failed: %w", err)
+	}
+
+	if version < minimumMigrationVersion {
+		return fmt.Errorf("database migration check failed: expected version %d, got %d", minimumMigrationVersion, version)
+	}
+
+	return nil
 }

--- a/backend/internal/platform/health/handler.go
+++ b/backend/internal/platform/health/handler.go
@@ -12,13 +12,18 @@ type Checker interface {
 	Ping(ctx context.Context) error
 }
 
-type Handler struct {
-	db    Checker
-	cache Checker
+type MigrationChecker interface {
+	CheckMigrations(ctx context.Context) error
 }
 
-func New(db Checker, cache Checker) *Handler {
-	return &Handler{db: db, cache: cache}
+type Handler struct {
+	db               Checker
+	cache            Checker
+	migrationChecker MigrationChecker
+}
+
+func New(db Checker, cache Checker, migrationChecker MigrationChecker) *Handler {
+	return &Handler{db: db, cache: cache, migrationChecker: migrationChecker}
 }
 
 func (h *Handler) Healthz(w http.ResponseWriter, r *http.Request) {
@@ -47,6 +52,15 @@ func (h *Handler) Readyz(w http.ResponseWriter, r *http.Request) {
 			healthy = false
 		} else {
 			checks["cache"] = "ok"
+		}
+	}
+
+	if h.migrationChecker != nil {
+		if err := h.migrationChecker.CheckMigrations(ctx); err != nil {
+			checks["database_migrations"] = err.Error()
+			healthy = false
+		} else {
+			checks["database_migrations"] = "ok"
 		}
 	}
 

--- a/backend/internal/platform/health/handler_test.go
+++ b/backend/internal/platform/health/handler_test.go
@@ -1,6 +1,7 @@
 package health
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -8,7 +9,7 @@ import (
 )
 
 func TestHealthz(t *testing.T) {
-	h := New(nil, nil)
+	h := New(nil, nil, nil)
 	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
 	w := httptest.NewRecorder()
 
@@ -26,5 +27,80 @@ func TestHealthz(t *testing.T) {
 	}
 	if resp.Data["status"] != "ok" {
 		t.Errorf("data.status = %q, want %q", resp.Data["status"], "ok")
+	}
+}
+
+type fakeChecker struct {
+	pingErr      error
+	migrationErr error
+}
+
+func (f *fakeChecker) Ping(context.Context) error {
+	return f.pingErr
+}
+
+func (f *fakeChecker) CheckMigrations(context.Context) error {
+	return f.migrationErr
+}
+
+func TestReadyz_IntegrationLikeDependencyChecks(t *testing.T) {
+	healthDB := &fakeChecker{}
+	cache := &fakeChecker{}
+	cache.pingErr = nil
+
+	h := New(healthDB, cache, &fakeChecker{})
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	w := httptest.NewRecorder()
+
+	h.Readyz(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+
+	var resp struct {
+		Data map[string]string `json:"data"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	if got := resp.Data["database"]; got != "ok" {
+		t.Errorf("database check = %q, want ok", got)
+	}
+	if got := resp.Data["cache"]; got != "ok" {
+		t.Errorf("cache check = %q, want ok", got)
+	}
+	if got := resp.Data["database_migrations"]; got != "ok" {
+		t.Errorf("database_migrations check = %q, want ok", got)
+	}
+}
+
+func TestReadyz_IntegrationLikeMigrationsFailure(t *testing.T) {
+	db := &fakeChecker{}
+	cache := &fakeChecker{}
+	migrations := &fakeChecker{migrationErr: context.Canceled}
+
+	h := New(db, cache, migrations)
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	w := httptest.NewRecorder()
+
+	h.Readyz(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusServiceUnavailable)
+	}
+
+	var resp struct {
+		Err struct {
+			Code string `json:"code"`
+		} `json:"error"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	if resp.Err.Code != "NOT_READY" {
+		t.Fatalf("error code = %q, want %q", resp.Err.Code, "NOT_READY")
 	}
 }

--- a/backend/tests/integration/health_test.go
+++ b/backend/tests/integration/health_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestHealthz_Integration(t *testing.T) {
-	h := health.New(testDB, &redisChecker{testRedis})
+	h := health.New(testPool, &redisChecker{testRedis}, testPool)
 	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
 	w := httptest.NewRecorder()
 
@@ -24,7 +24,7 @@ func TestHealthz_Integration(t *testing.T) {
 }
 
 func TestReadyz_Integration(t *testing.T) {
-	h := health.New(testDB, &redisChecker{testRedis})
+	h := health.New(testPool, &redisChecker{testRedis}, testPool)
 	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
 	w := httptest.NewRecorder()
 
@@ -47,5 +47,8 @@ func TestReadyz_Integration(t *testing.T) {
 	}
 	if data["cache"] != "ok" {
 		t.Errorf("cache = %v, want ok", data["cache"])
+	}
+	if data["database_migrations"] != "ok" {
+		t.Errorf("database_migrations = %v, want ok", data["database_migrations"])
 	}
 }


### PR DESCRIPTION
Closes #312

## Summary
- Extend readiness checks to validate migration state, not just connection liveness.
- Add `database.CheckMigrations()` to query `goose_db_version` and require a minimum migration version.
- Thread migration check into `health.Handler` via a new optional `MigrationChecker` dependency.
- Wire `health.New` in server startup to use the database pool as the migration checker.
- Add unit/integration coverage for migration-aware `/readyz` behavior.

## Verification
- `go test ./internal/platform/health ./internal/platform/database ./cmd/server`
- `go test ./...` (backend)
- `golangci-lint run ./internal/platform/health ./internal/platform/database ./cmd/server`
