### PR TITLE
Surface WhatsApp intake action errors

### DIFF
--- a/app/app/[schemeId]/whatsapp/page.tsx
+++ b/app/app/[schemeId]/whatsapp/page.tsx
@@ -329,19 +329,33 @@ function OperatorView({
   }
 
   async function createTicketFromIntake(intake: WhatsAppMaintenanceIntake) {
-    await createMaintenanceRequestFromWhatsAppMessage(schemeId, intake.message_id, {
-      title: intake.title,
-      description: intake.description,
-      category: intake.category,
-    })
-    await onReload()
-    addToast('Maintenance ticket created from WhatsApp.', 'success')
+    try {
+      await createMaintenanceRequestFromWhatsAppMessage(schemeId, intake.message_id, {
+        title: intake.title,
+        description: intake.description,
+        category: intake.category,
+      })
+      await onReload()
+      addToast('Maintenance ticket created from WhatsApp.', 'success')
+    } catch (error) {
+      addToast(
+        error instanceof Error ? error.message : 'Failed to create maintenance ticket from WhatsApp.',
+        'error',
+      )
+    }
   }
 
   async function dismissIntake(intake: WhatsAppMaintenanceIntake) {
-    await dismissWhatsAppMaintenanceIntake(schemeId, intake.id)
-    await onReload()
-    addToast('WhatsApp maintenance intake dismissed.', 'success')
+    try {
+      await dismissWhatsAppMaintenanceIntake(schemeId, intake.id)
+      await onReload()
+      addToast('WhatsApp maintenance intake dismissed.', 'success')
+    } catch (error) {
+      addToast(
+        error instanceof Error ? error.message : 'Failed to dismiss WhatsApp maintenance intake.',
+        'error',
+      )
+    }
   }
 
   return (


### PR DESCRIPTION
Closes #310

## Summary
- Wrap WhatsApp maintenance intake actions (`Create ticket`, `Dismiss`) in `try/catch`.
- Show backend/API error messages via toast when actions fail.
- Keep success toasts behind successful mutation + dashboard reload completion.

## Verification
- `pnpm exec eslint "app/app/[schemeId]/whatsapp/page.tsx` (network-reliant install in this environment prevented full completion)
