### PR TITLE
fix: use stable metric label for unmatched routes

### DIFF
--- a/backend/internal/middleware/metrics.go
+++ b/backend/internal/middleware/metrics.go
@@ -54,5 +54,5 @@ func routeLabel(r *http.Request) string {
 			return pattern
 		}
 	}
-	return r.URL.Path
+	return "unmatched"
 }

--- a/backend/internal/middleware/metrics_test.go
+++ b/backend/internal/middleware/metrics_test.go
@@ -19,10 +19,10 @@ func TestRouteLabelUsesChiPatternWhenAvailable(t *testing.T) {
 	}
 }
 
-func TestRouteLabelFallsBackToURLPath(t *testing.T) {
-	req := httptest.NewRequest("GET", "/healthz", nil)
+func TestRouteLabelFallsBackToUnmatched(t *testing.T) {
+	req := httptest.NewRequest("GET", "/healthz/abc/def", nil)
 
-	if got := routeLabel(req); got != "/healthz" {
-		t.Fatalf("route label = %q, want %q", got, "/healthz")
+	if got := routeLabel(req); got != "unmatched" {
+		t.Fatalf("route label = %q, want %q", got, "unmatched")
 	}
 }


### PR DESCRIPTION
Closes #290

## Summary
- normalize middleware metric  label for requests without a Chi route pattern
- return  instead of raw URL path to prevent unbounded label cardinality
- update unit test coverage for fallback label behavior

## Verification
- go test ./...