### PR TITLE
fix: assign stable unique IDs for rapid toasts

### DIFF
--- a/lib/toast.test.tsx
+++ b/lib/toast.test.tsx
@@ -12,6 +12,18 @@ function ToastTrigger() {
   )
 }
 
+function DoubleToastTrigger() {
+  const { addToast } = useToast()
+  return (
+    <button type="button" onClick={() => {
+      addToast('Saved', 'success')
+      addToast('Saved again', 'info')
+    }}>
+      Add two toasts
+    </button>
+  )
+}
+
 describe('ToastProvider', () => {
   afterEach(() => {
     vi.useRealTimers()
@@ -33,5 +45,25 @@ describe('ToastProvider', () => {
     unmount()
 
     expect(clearTimeoutSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('assigns unique ids for rapid toasts', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    render(
+      <ToastProvider>
+        <DoubleToastTrigger />
+      </ToastProvider>,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add two toasts' }))
+
+    expect(screen.getByText('Saved')).toBeInTheDocument()
+    expect(screen.getByText('Saved again')).toBeInTheDocument()
+    expect(errorSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining('Encountered two children with the same key'),
+    )
+    
+    errorSpy.mockRestore()
   })
 })

--- a/lib/toast.tsx
+++ b/lib/toast.tsx
@@ -2,7 +2,7 @@
 import { createContext, useContext, useState, useCallback, useEffect, useRef, type ReactNode } from 'react'
 
 interface Toast {
-  id: number
+  id: string
   message: string
   type: 'success' | 'info' | 'error'
 }
@@ -16,9 +16,10 @@ const ToastContext = createContext<ToastContextValue>({ addToast: () => {} })
 export function ToastProvider({ children }: { children: ReactNode }) {
   const [toasts, setToasts] = useState<Toast[]>([])
   const dismissalTimers = useRef<Set<ReturnType<typeof setTimeout>>>(new Set())
+  const nextToastID = useRef(0)
 
   const addToast = useCallback((message: string, type: Toast['type'] = 'success') => {
-    const id = Date.now()
+    const id = `${nextToastID.current++}-${Date.now()}`
     setToasts(prev => [...prev, { id, message, type }])
     const timer = setTimeout(() => {
       dismissalTimers.current.delete(timer)


### PR DESCRIPTION
Closes #287

## Summary
- replace timestamp-only toast IDs with monotonic + timestamp composite IDs
- prevent duplicate React keys and timer collisions when multiple toasts are added in rapid succession
- add a regression test that ensures rapid dual-toast adds render both messages without duplicate-key behavior

## Verification
- npx vitest run lib/toast.test.tsx