### PR TITLE
fix: prevent duplicate concurrent copilot streams

### DIFF
--- a/components/Copilot.test.tsx
+++ b/components/Copilot.test.tsx
@@ -1,5 +1,5 @@
-import { render } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { SessionUser } from "@/lib/session";
 import Copilot from "./Copilot";
@@ -40,10 +40,44 @@ function makeUser(overrides: Partial<SessionUser> = {}): SessionUser {
 }
 
 describe("Copilot", () => {
-  beforeEach(() => {
+  afterEach(() => {
     vi.restoreAllMocks();
+  });
+
+  beforeEach(() => {
     usePathname.mockReturnValue("/agent");
     Element.prototype.scrollIntoView = vi.fn();
+  });
+
+  it("prevents concurrent sends from the same session", async () => {
+    const responseStream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('hello'))
+        controller.close()
+      },
+    })
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(responseStream, { status: 200 }),
+    )
+
+    useAuth.mockReturnValue({ user: makeUser() });
+    usePathname.mockReturnValue('/app/scheme-1/financials');
+
+    const { getByRole } = render(<Copilot />);
+
+    fireEvent.click(getByRole('button', { name: 'Open AI Copilot' }));
+
+    const firstQuestion = getByRole('button', {
+      name: 'Which schemes have the lowest levy collection rates?',
+    });
+    fireEvent.click(firstQuestion);
+    fireEvent.click(firstQuestion);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+    await new Promise(resolve => setTimeout(resolve, 0));
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
   });
 
   it("preserves hook order when auth state changes from hidden to visible", () => {

--- a/components/Copilot.tsx
+++ b/components/Copilot.tsx
@@ -28,6 +28,7 @@ export default function Copilot() {
   const [error, setError] = useState<string | null>(null)
   const messagesEndRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLTextAreaElement>(null)
+  const requestInFlight = useRef(false)
   const schemeId = pathname.startsWith('/app/') ? pathname.split('/')[2] ?? null : null
   const isVisible = Boolean(user) && !isResidentRole(user?.role)
 
@@ -45,9 +46,11 @@ export default function Copilot() {
   if (!isVisible) return null
 
   async function sendMessage(text: string) {
-    if (!text.trim() || streaming) return
+    const payload = text.trim()
+    if (!payload || streaming || requestInFlight.current) return
 
-    const userMessage: Message = { role: 'user', content: text.trim() }
+    requestInFlight.current = true
+    const userMessage: Message = { role: 'user', content: payload }
     const history = messages
     setMessages(prev => [...prev, userMessage])
     setInput('')
@@ -65,7 +68,7 @@ export default function Copilot() {
       const response = await fetch('/api/copilot', {
         method: 'POST',
         headers,
-        body: JSON.stringify({ message: text.trim(), history, scheme_id: schemeId }),
+        body: JSON.stringify({ message: payload, history, scheme_id: schemeId }),
       })
 
       if (!response.ok || !response.body) {
@@ -92,6 +95,7 @@ export default function Copilot() {
       setError('Network error — check your connection and try again.')
     } finally {
       setStreaming(false)
+      requestInFlight.current = false
     }
   }
 
@@ -169,6 +173,7 @@ export default function Copilot() {
                   {SUGGESTED_QUESTIONS.map(q => (
                     <button
                       key={q}
+                      disabled={streaming}
                       onClick={() => sendMessage(q)}
                       className="w-full text-left text-[12px] text-ink bg-page border border-border rounded-lg px-3 py-2 hover:border-accent hover:bg-accent-dim transition-colors leading-snug"
                     >


### PR DESCRIPTION
Closes #288

## Summary
- guard  with a synchronous in-flight ref to block rapid duplicate submissions
- disable suggested question buttons while streaming
- add regression coverage to ensure rapid duplicate clicks do not issue duplicate  calls

## Verification
- npx vitest run components/Copilot.test.tsx