### PR TITLE
fix: return errors when whatsapp sender is disabled

### DIFF
--- a/app/app/[schemeId]/financials/page.test.tsx
+++ b/app/app/[schemeId]/financials/page.test.tsx
@@ -110,4 +110,35 @@ describe("FinancialsPage predictive levy analytics", () => {
     });
     expect(mockAddToast).toHaveBeenCalledWith("Budget line saved", "success");
   });
+
+  it("requires budget and actual amounts when saving a budget line", async () => {
+    mockUseAuth.mockReturnValue({ user: { role: "admin" } });
+    mockUpsertBudgetLine.mockResolvedValueOnce(undefined);
+    const { default: FinancialsPage } = await import("@/app/app/[schemeId]/financials/page");
+
+    render(<FinancialsPage />);
+
+    fireEvent.click(screen.getByRole("button", { name: "+ Budget line" }));
+    const textboxes = screen.getAllByRole("textbox");
+    const categoryInput = textboxes.at(0);
+    const periodInput = textboxes.at(1);
+    if (!categoryInput || !periodInput) throw new Error("missing budget text inputs");
+    fireEvent.change(categoryInput, { target: { value: "Maintenance" } });
+    fireEvent.change(periodInput, { target: { value: "2027" } });
+    const amountInputs = screen.getAllByRole("spinbutton");
+    const budgetAmountInput = amountInputs.at(0);
+    const actualAmountInput = amountInputs.at(1);
+    if (!budgetAmountInput || !actualAmountInput) throw new Error("missing budget amount inputs");
+    fireEvent.change(budgetAmountInput, { target: { value: "" } });
+    fireEvent.change(actualAmountInput, { target: { value: "" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(mockAddToast).toHaveBeenCalledWith(
+        "Enter a category, period, budget amount, and actual amount",
+        "error",
+      );
+    });
+    expect(mockUpsertBudgetLine).not.toHaveBeenCalled();
+  });
 });

--- a/app/app/[schemeId]/financials/page.tsx
+++ b/app/app/[schemeId]/financials/page.tsx
@@ -18,6 +18,16 @@ function formatRand(cents: number): string {
   return `R ${(cents / 100).toLocaleString('en-ZA', { minimumFractionDigits: 0 })}`
 }
 
+function parseAmountCents(value: string): number | null {
+  const trimmed = value.trim()
+  if (!trimmed) return null
+
+  const numeric = Number(trimmed)
+  if (!Number.isFinite(numeric) || Number.isNaN(numeric)) return null
+
+  return Math.round(numeric * 100)
+}
+
 function forecastStatusLabel(status: string): string {
   switch (status) {
     case 'shortfall_risk':
@@ -119,9 +129,16 @@ export default function FinancialsPage() {
   }
 
   async function handleBudgetSave() {
-    const budgetedCents = Math.round(Number(budgetForm.budget_amount) * 100)
-    const actualCents = Math.round(Number(budgetForm.actual_amount) * 100)
-    if (!budgetForm.category.trim() || !budgetForm.period_label.trim() || budgetedCents < 0 || actualCents < 0) {
+    const budgetedCents = parseAmountCents(budgetForm.budget_amount)
+    const actualCents = parseAmountCents(budgetForm.actual_amount)
+    if (
+      !budgetForm.category.trim() ||
+      !budgetForm.period_label.trim() ||
+      budgetedCents === null ||
+      actualCents === null ||
+      budgetedCents < 0 ||
+      actualCents < 0
+    ) {
       addToast('Enter a category, period, budget amount, and actual amount', 'error')
       return
     }

--- a/app/app/[schemeId]/levy/page.tsx
+++ b/app/app/[schemeId]/levy/page.tsx
@@ -393,6 +393,7 @@ export default function LevyPaymentsPage() {
           periodLabel={currentPeriod.label}
           onConfirm={handleReconcileConfirm}
           onClose={() => !reconciling && setReconcileOpen(false)}
+          allowSampleStatement={process.env.NODE_ENV !== 'production'}
         />
       )}
 

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -101,8 +101,8 @@ func main() {
 		sender = twilio.NewClient(cfg.TwilioAccountSID, cfg.TwilioAuthToken, cfg.TwilioWhatsAppNumber)
 		logger.Info("twilio whatsapp enabled", "number", cfg.TwilioWhatsAppNumber)
 	} else {
-		sender = whatsapp.NewNoOpSender()
-		logger.Info("twilio whatsapp disabled, using no-op sender")
+		sender = whatsapp.NewDisabledSender()
+		logger.Info("twilio whatsapp disabled, using disabled sender")
 	}
 	jobService := jobs.NewService(db.Q, jobs.Registry{}, logger, jobs.RealClock{}, jobs.Config{
 		WorkerID:  "api-enqueuer",

--- a/backend/cmd/worker/main.go
+++ b/backend/cmd/worker/main.go
@@ -46,7 +46,8 @@ func main() {
 	if cfg.TwilioAccountSID != "" && cfg.TwilioAuthToken != "" && cfg.TwilioWhatsAppNumber != "" {
 		sender = twilio.NewClient(cfg.TwilioAccountSID, cfg.TwilioAuthToken, cfg.TwilioWhatsAppNumber)
 	} else {
-		sender = whatsapp.NewNoOpSender()
+		sender = whatsapp.NewDisabledSender()
+		logger.Info("twilio whatsapp disabled, using disabled sender")
 	}
 
 	levyService := levy.NewService(db, nil, nil)

--- a/backend/internal/agm/service.go
+++ b/backend/internal/agm/service.go
@@ -155,6 +155,13 @@ func (s *Service) ScheduleMeeting(ctx context.Context, identity auth.Identity, s
 	if input.MeetingDate.IsZero() || input.QuorumRequired <= 0 {
 		return nil, ErrInvalidInput
 	}
+	totalEligible, err := s.totalEligibleVoters(ctx, access.scheme.ID)
+	if err != nil {
+		return nil, err
+	}
+	if totalEligible <= 0 || input.QuorumRequired > totalEligible {
+		return nil, ErrInvalidInput
+	}
 
 	tx, err := s.db.Begin(ctx)
 	if err != nil {
@@ -168,11 +175,6 @@ func (s *Service) ScheduleMeeting(ctx context.Context, identity auth.Identity, s
 		MeetingDate:    dateValue(input.MeetingDate),
 		QuorumRequired: input.QuorumRequired,
 	})
-	if err != nil {
-		return nil, err
-	}
-
-	totalEligible, err := s.totalEligibleVoters(ctx, access.scheme.ID)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/auth/service.go
+++ b/backend/internal/auth/service.go
@@ -22,15 +22,33 @@ import (
 
 // Sentinel errors.
 var (
-	ErrEmailExists        = errors.New("email already registered")
-	ErrInvalidCredentials = errors.New("invalid credentials")
-	ErrInvalidToken       = errors.New("invalid or expired token")
-	ErrWrongPassword      = errors.New("current password is incorrect")
+	ErrEmailExists          = errors.New("email already registered")
+	ErrInvalidCredentials   = errors.New("invalid credentials")
+	ErrInvalidToken         = errors.New("invalid or expired token")
+	ErrWrongPassword        = errors.New("current password is incorrect")
 	ErrWeakPassword         = errors.New("password does not meet requirements")
 	ErrSetupAlreadyComplete = errors.New("setup already complete")
 )
 
 const passwordResetTTL = time.Hour
+const consumedResetToken = "__consumed_pwreset__"
+
+const consumeResetTokenScript = `
+local value = redis.call("GET", KEYS[1])
+if not value then
+	return nil
+end
+if value == "` + consumedResetToken + `" then
+	return value
+end
+local ttl = redis.call("PTTL", KEYS[1])
+if ttl < 0 then
+	redis.call("SET", KEYS[1], "` + consumedResetToken + `")
+else
+	redis.call("PSETEX", KEYS[1], ttl, "` + consumedResetToken + `")
+end
+return value
+`
 
 // Response types returned by the service.
 
@@ -536,8 +554,12 @@ func (s *Service) IssuePasswordResetURL(ctx context.Context, email, appBaseURL s
 
 func (s *Service) ResetPassword(ctx context.Context, token, password string) error {
 	key := "pwreset:" + HashRefreshToken(token)
-	userIDStr, err := s.cache.GetDel(ctx, key).Result()
+	rawUserID, err := s.cache.Eval(ctx, consumeResetTokenScript, []string{key}).Result()
 	if err != nil {
+		return ErrInvalidToken
+	}
+	userIDStr, ok := rawUserID.(string)
+	if !ok || userIDStr == "" || userIDStr == consumedResetToken {
 		return ErrInvalidToken
 	}
 

--- a/backend/internal/earlyaccess/handler.go
+++ b/backend/internal/earlyaccess/handler.go
@@ -159,7 +159,9 @@ func messagePage(title, body string) string {
 func (h *Handler) ApproveWithTokenPage(w http.ResponseWriter, r *http.Request) {
 	sig := r.URL.Query().Get("sig")
 	expStr := r.URL.Query().Get("exp")
-	if _, err := strconv.ParseInt(expStr, 10, 64); err != nil || sig == "" {
+	id := chi.URLParam(r, "id")
+	exp, err := strconv.ParseInt(expStr, 10, 64)
+	if err != nil || sig == "" || h.service.ValidateActionToken(id, "approve", sig, exp) != nil {
 		writeHTML(w, http.StatusBadRequest, messagePage("Invalid link", "This link is malformed."))
 		return
 	}
@@ -196,7 +198,9 @@ func (h *Handler) ApproveWithToken(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) RejectWithTokenPage(w http.ResponseWriter, r *http.Request) {
 	sig := r.URL.Query().Get("sig")
 	expStr := r.URL.Query().Get("exp")
-	if _, err := strconv.ParseInt(expStr, 10, 64); err != nil || sig == "" {
+	id := chi.URLParam(r, "id")
+	exp, err := strconv.ParseInt(expStr, 10, 64)
+	if err != nil || sig == "" || h.service.ValidateActionToken(id, "reject", sig, exp) != nil {
 		writeHTML(w, http.StatusBadRequest, messagePage("Invalid link", "This link is malformed."))
 		return
 	}

--- a/backend/internal/earlyaccess/handler_test.go
+++ b/backend/internal/earlyaccess/handler_test.go
@@ -24,6 +24,8 @@ type stubService struct {
 	rejectByTokenFn     func(id, sig string, exp int64) (*RequestResponse, error)
 	approveByTokenCalls int
 	rejectByTokenCalls  int
+	validateTokenFn     func(id, action, sig string, exp int64) error
+	validateTokenCalls  int
 }
 
 func (s *stubService) Submit(_ context.Context, params SubmitParams) (*RequestResponse, error) {
@@ -68,6 +70,14 @@ func (s *stubService) RejectByToken(_ context.Context, id, sig string, exp int64
 	return &RequestResponse{ID: id, Status: "rejected"}, nil
 }
 
+func (s *stubService) ValidateActionToken(id, action, sig string, exp int64) error {
+	s.validateTokenCalls++
+	if s.validateTokenFn != nil {
+		return s.validateTokenFn(id, action, sig, exp)
+	}
+	return nil
+}
+
 func TestPublicRoutes_GetApproveDoesNotMutate(t *testing.T) {
 	svc := &stubService{}
 	router := NewHandler(svc).PublicRoutes()
@@ -83,6 +93,9 @@ func TestPublicRoutes_GetApproveDoesNotMutate(t *testing.T) {
 	}
 	if svc.approveByTokenCalls != 0 {
 		t.Fatalf("approveByTokenCalls=%d, want 0", svc.approveByTokenCalls)
+	}
+	if svc.validateTokenCalls != 1 {
+		t.Fatalf("validateTokenCalls=%d, want 1", svc.validateTokenCalls)
 	}
 }
 
@@ -116,6 +129,30 @@ func TestPublicRoutes_ApprovePageHasNoInlineStyles(t *testing.T) {
 
 	if strings.Contains(w.Body.String(), "style=") {
 		t.Fatalf("approve page should not render inline styles: %s", w.Body.String())
+	}
+}
+
+func TestPublicRoutes_GetApproveRejectsInvalidSignature(t *testing.T) {
+	svc := &stubService{
+		validateTokenFn: func(id, action, sig string, _ int64) error {
+			if action != "approve" || id != "request-123" || sig == "" {
+				t.Fatalf("unexpected validate params: id=%s action=%s sig=%s", id, action, sig)
+			}
+			return ErrInvalidToken
+		},
+	}
+	router := NewHandler(svc).PublicRoutes()
+
+	exp := time.Now().Add(15 * time.Minute).Unix()
+	req := httptest.NewRequest(http.MethodGet, "/request-123/approve?exp="+strconv.FormatInt(exp, 10)+"&sig=bad-signature", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d, want 400", w.Code)
+	}
+	if svc.validateTokenCalls != 1 {
+		t.Fatalf("validateTokenCalls=%d, want 1", svc.validateTokenCalls)
 	}
 }
 

--- a/backend/internal/earlyaccess/service.go
+++ b/backend/internal/earlyaccess/service.go
@@ -51,6 +51,7 @@ type Servicer interface {
 	Reject(ctx context.Context, id string) (*RequestResponse, error)
 	ApproveByToken(ctx context.Context, id, sig string, exp int64) (*RequestResponse, error)
 	RejectByToken(ctx context.Context, id, sig string, exp int64) (*RequestResponse, error)
+	ValidateActionToken(id, action, sig string, exp int64) error
 }
 
 type Service struct {
@@ -167,6 +168,13 @@ func (s *Service) RejectByToken(ctx context.Context, id, sig string, exp int64) 
 		return nil, ErrInvalidToken
 	}
 	return s.rejectWithoutContextAuth(ctx, id)
+}
+
+func (s *Service) ValidateActionToken(id, action, sig string, exp int64) error {
+	if !validateActionToken(s.adminSecret, id, action, sig, exp) {
+		return ErrInvalidToken
+	}
+	return nil
 }
 
 func (s *Service) authorizeProtectedAdmin(ctx context.Context) error {

--- a/backend/internal/whatsapp/sender.go
+++ b/backend/internal/whatsapp/sender.go
@@ -1,10 +1,15 @@
 package whatsapp
 
-import "log/slog"
+import (
+	"errors"
+	"log/slog"
+)
 
 type MessageSender interface {
 	SendWhatsAppMessage(to, body string) error
 }
+
+var ErrNotConfigured = errors.New("whatsapp sender not configured")
 
 type NoOpSender struct{}
 
@@ -13,4 +18,13 @@ func NewNoOpSender() *NoOpSender { return &NoOpSender{} }
 func (n *NoOpSender) SendWhatsAppMessage(to, body string) error {
 	slog.Info("whatsapp: no-op send", "to", to, "body_len", len(body))
 	return nil
+}
+
+type DisabledSender struct{}
+
+func NewDisabledSender() *DisabledSender { return &DisabledSender{} }
+
+func (n *DisabledSender) SendWhatsAppMessage(to, body string) error {
+	slog.Warn("whatsapp sender not configured", "to", to, "body_len", len(body))
+	return ErrNotConfigured
 }

--- a/backend/internal/whatsapp/sender_test.go
+++ b/backend/internal/whatsapp/sender_test.go
@@ -1,0 +1,20 @@
+package whatsapp
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestNoOpSenderReturnsNil(t *testing.T) {
+	err := NewNoOpSender().SendWhatsAppMessage("+27820000000", "hello")
+	if err != nil {
+		t.Fatalf("no-op sender error = %v", err)
+	}
+}
+
+func TestDisabledSenderReturnsNotConfigured(t *testing.T) {
+	err := NewDisabledSender().SendWhatsAppMessage("+27820000000", "hello")
+	if !errors.Is(err, ErrNotConfigured) {
+		t.Fatalf("error = %v, want %q", err, ErrNotConfigured)
+	}
+}

--- a/backend/internal/whatsapp/webhook.go
+++ b/backend/internal/whatsapp/webhook.go
@@ -262,6 +262,11 @@ func (h *WebhookHandler) processMessageAfterSave(ctx context.Context, phoneNumbe
 		}
 	}
 
+	if sendErr := h.sender.SendWhatsAppMessage(phoneNumber, reply); sendErr != nil {
+		h.logger.Error("failed to send WhatsApp reply", "phone", phoneNumber, "error", sendErr)
+		return
+	}
+
 	if _, replyErr := h.db.Q.CreateWhatsAppMessage(ctx, dbgen.CreateWhatsAppMessageParams{
 		ThreadID:             thread.ID,
 		Sender:               dbgen.WhatsappMessageSenderBot,
@@ -271,10 +276,6 @@ func (h *WebhookHandler) processMessageAfterSave(ctx context.Context, phoneNumbe
 	}); replyErr != nil {
 		h.logger.Error("failed to save bot response", "error", replyErr)
 		return
-	}
-
-	if sendErr := h.sender.SendWhatsAppMessage(phoneNumber, reply); sendErr != nil {
-		h.logger.Error("failed to send WhatsApp reply", "phone", phoneNumber, "error", sendErr)
 	}
 }
 

--- a/backend/internal/whatsapp/webhook.go
+++ b/backend/internal/whatsapp/webhook.go
@@ -283,9 +283,19 @@ func findBestThread(threads []dbgen.WhatsappThread) *dbgen.WhatsappThread {
 	if len(threads) == 0 {
 		return nil
 	}
-	best := &threads[0]
+	var best *dbgen.WhatsappThread
 	for i := range threads {
-		if threads[i].LastActiveAt.After(best.LastActiveAt) {
+		thread := &threads[i]
+		if best == nil {
+			best = thread
+			continue
+		}
+		bestHasResident := best.ResidentUserID.Valid
+		threadHasResident := thread.ResidentUserID.Valid
+		switch {
+		case threadHasResident && !bestHasResident:
+			best = thread
+		case threadHasResident == bestHasResident && thread.LastActiveAt.After(best.LastActiveAt):
 			best = &threads[i]
 		}
 	}

--- a/backend/tests/integration/agm_test.go
+++ b/backend/tests/integration/agm_test.go
@@ -127,3 +127,63 @@ func TestAgm_ScheduleVoteAndAssignProxy(t *testing.T) {
 		t.Fatalf("delegating member should not see a direct vote recorded, got %+v", updatedDashboard.Upcoming.Resolutions[0])
 	}
 }
+
+func TestAgm_ScheduleMeetingRejectsInvalidQuorum(t *testing.T) {
+	h := newAgmHandler(t)
+	accessToken, orgID := setupAgent(t)
+	schemeID := setupScheme(t, accessToken)
+
+	createBody, _ := json.Marshal(map[string]any{
+		"date":            "2026-11-20",
+		"quorum_required": 3,
+		"resolutions": []map[string]any{
+			{
+				"title":       "Adopt financials",
+				"description": "Approve the proposed maintenance budget.",
+			},
+		},
+	})
+	req := httptest.NewRequest(http.MethodPost, "/agm/"+schemeID+"/meetings", bytes.NewReader(createBody))
+	req = withRouteParams(req, map[string]string{"schemeId": schemeID})
+	req = withAuthContext(req, accessToken, testJWTSigningKey)
+	w := httptest.NewRecorder()
+	h.ScheduleMeeting(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("schedule meeting with zero eligible voters: status=%d body=%s", w.Code, w.Body)
+	}
+
+	unitResidentID := createUnitRecord(t, schemeID, "2A")
+	residentEmail := uniqueEmail(t)
+	createMemberRecord(t, orgID, schemeID, residentEmail, "Resident Owner", string(auth.RoleResident), &unitResidentID)
+
+	req = httptest.NewRequest(http.MethodPost, "/agm/"+schemeID+"/meetings", bytes.NewReader(createBody))
+	req = withRouteParams(req, map[string]string{"schemeId": schemeID})
+	req = withAuthContext(req, accessToken, testJWTSigningKey)
+	w = httptest.NewRecorder()
+	h.ScheduleMeeting(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("quorum higher than eligible voters expected 400: status=%d body=%s", w.Code, w.Body)
+	}
+
+	committeeUserID := uniqueEmail(t)
+	createMemberRecord(t, orgID, schemeID, committeeUserID, "Trustee Member", string(auth.RoleTrustee), nil)
+
+	validBody, _ := json.Marshal(map[string]any{
+		"date":            "2026-11-20",
+		"quorum_required": 2,
+		"resolutions": []map[string]any{
+			{
+				"title":       "Adopt financials",
+				"description": "Approve the proposed maintenance budget.",
+			},
+		},
+	})
+	req = httptest.NewRequest(http.MethodPost, "/agm/"+schemeID+"/meetings", bytes.NewReader(validBody))
+	req = withRouteParams(req, map[string]string{"schemeId": schemeID})
+	req = withAuthContext(req, accessToken, testJWTSigningKey)
+	w = httptest.NewRecorder()
+	h.ScheduleMeeting(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("schedule meeting after adding second eligible voter should succeed: status=%d body=%s", w.Code, w.Body)
+	}
+}

--- a/backend/tests/integration/agm_test.go
+++ b/backend/tests/integration/agm_test.go
@@ -31,7 +31,7 @@ func TestAgm_ScheduleVoteAndAssignProxy(t *testing.T) {
 
 	createBody, _ := json.Marshal(map[string]any{
 		"date":            "2026-11-20",
-		"quorum_required": 3,
+		"quorum_required": 2,
 		"resolutions": []map[string]any{
 			{
 				"title":       "Approve 2027 maintenance budget",

--- a/backend/tests/integration/whatsapp_test.go
+++ b/backend/tests/integration/whatsapp_test.go
@@ -173,7 +173,7 @@ func TestWhatsAppDashboardAndBroadcast(t *testing.T) {
 	req = withRouteParams(req, map[string]string{"schemeId": schemeID})
 	req = req.WithContext(auth.ContextWithIdentity(req.Context(), residentUserID, orgID, string(auth.RoleResident)))
 	w = httptest.NewRecorder()
-		h.CreateBroadcast(w, req)
+	h.CreateBroadcast(w, req)
 	if w.Code != http.StatusForbidden {
 		t.Fatalf("resident create broadcast should be forbidden: status=%d body=%s", w.Code, w.Body)
 	}
@@ -251,9 +251,14 @@ func TestWhatsAppBroadcastReportsFailedRecipients(t *testing.T) {
 
 func newWhatsAppWebhookHandler(t *testing.T) *whatsapp.WebhookHandler {
 	t.Helper()
+	return newWhatsAppWebhookHandlerWithSender(t, whatsapp.NewNoOpSender())
+}
+
+func newWhatsAppWebhookHandlerWithSender(t *testing.T, sender whatsapp.MessageSender) *whatsapp.WebhookHandler {
+	t.Helper()
 	svc := whatsapp.NewService(testPool, whatsapp.NewNoOpSender(), slog.Default())
 	bot := whatsapp.NewBot(testPool)
-	h := whatsapp.NewWebhookHandler(testPool, whatsapp.NewNoOpSender(), bot, svc, slog.Default(), "twilio-token")
+	h := whatsapp.NewWebhookHandler(testPool, sender, bot, svc, slog.Default(), "twilio-token")
 	h.SetSkipSigVerify(true)
 	return h
 }
@@ -362,6 +367,70 @@ func TestWhatsAppWebhookCreatesMaintenanceTicketWithMedia(t *testing.T) {
 	}
 	if ticketIntake == nil {
 		t.Fatalf("expected intake with ticket_created status, got %d intakes", len(intakes))
+	}
+}
+
+func TestWhatsAppWebhookDoesNotPersistBotReplyWhenProviderFails(t *testing.T) {
+	h := newWhatsAppWebhookHandlerWithSender(t, &scriptedWhatsAppSender{
+		failOnNth: 1,
+		failErr:   errors.New("whatsapp provider unavailable"),
+	})
+
+	accessToken, orgID := setupAgent(t)
+	schemeID := setupScheme(t, accessToken)
+
+	unitID := createUnitRecord(t, schemeID, "6B")
+	residentEmail := uniqueEmail(t)
+	residentUserID := createMemberRecord(t, orgID, schemeID, residentEmail, "Resident User", string(auth.RoleResident), &unitID)
+
+	schemeUUID := mustParseUUID(schemeID)
+	residentUnitUUID := mustParseUUID(unitID)
+	residentUserUUID := mustParseUUID(residentUserID)
+	now := time.Now().UTC()
+
+	if _, err := testQ.CreateWhatsAppThread(t.Context(), dbgen.CreateWhatsAppThreadParams{
+		SchemeID:       schemeUUID,
+		UnitID:         residentUnitUUID,
+		ResidentUserID: pgtype.UUID{Bytes: residentUserUUID, Valid: true},
+		PhoneNumber:    pgtype.Text{String: "+27715550408", Valid: true},
+		Connected:      true,
+		ConsentedAt:    pgtype.Timestamptz{Time: now.Add(-24 * time.Hour), Valid: true},
+		UnreadCount:    0,
+		LastActiveAt:   now,
+	}); err != nil {
+		t.Fatalf("create connected thread: %v", err)
+	}
+
+	threads, err := testQ.GetConnectedWhatsAppThreadByPhone(t.Context(), pgtype.Text{String: "+27715550408", Valid: true})
+	if err != nil || len(threads) == 0 {
+		t.Fatalf("find thread by phone: err=%v count=%d", err, len(threads))
+	}
+	threadID := threads[0].ID
+
+	form := url.Values{}
+	form.Set("From", "whatsapp:+27715550408")
+	form.Set("Body", "how are the rates")
+
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/whatsapp/webhooks", strings.NewReader(form.Encode()))
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	h.Inbound(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("webhook: status=%d body=%s", w.Code, w.Body)
+	}
+
+	time.Sleep(200 * time.Millisecond)
+
+	messages, err := testQ.ListWhatsAppMessagesByThread(t.Context(), threadID)
+	if err != nil {
+		t.Fatalf("list messages: %v", err)
+	}
+	if len(messages) != 1 {
+		t.Fatalf("expected only resident inbound message when send fails, got %d messages", len(messages))
+	}
+	if messages[0].Sender != dbgen.WhatsappMessageSenderResident {
+		t.Fatalf("expected inbound message sender resident, got %q", messages[0].Sender)
 	}
 }
 

--- a/components/FeaturesSection.tsx
+++ b/components/FeaturesSection.tsx
@@ -72,7 +72,7 @@ function FeatureBlock({ tag, heading, body, items, MockPanel, flip = false, acce
 
 export default function FeaturesSection() {
   return (
-    <>
+    <section id="features">
       <FeatureBlock
         tag="Levy & Payments"
         heading={<>Automate collections.<br />Eliminate the chase.</>}
@@ -116,6 +116,6 @@ export default function FeaturesSection() {
         ]}
         MockPanel={AGMMockPanel}
       />
-    </>
+    </section>
   )
 }

--- a/components/ProblemSection.tsx
+++ b/components/ProblemSection.tsx
@@ -35,7 +35,7 @@ const timeline = [
 
 export default function ProblemSection() {
   return (
-    <section id="features" className="padding-section">
+    <section id="problem" className="padding-section">
       <div className="max-w-[1080px] mx-auto px-container">
         <div className="grid grid-cols-1 lg:grid-cols-[380px_1fr] gap-[clamp(40px,6vw,80px)] items-start">
 

--- a/components/ReconcileModal.test.tsx
+++ b/components/ReconcileModal.test.tsx
@@ -1,0 +1,41 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import ReconcileModal from './ReconcileModal';
+
+const baseProps = {
+  levyAccounts: [],
+  periodLabel: 'October 2026',
+  onClose: vi.fn(),
+  onConfirm: vi.fn(),
+};
+
+describe('ReconcileModal', () => {
+  it('does not render sample statement load in production mode by default', () => {
+    render(
+      <ReconcileModal
+        {...baseProps}
+        onConfirm={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText(/Upload your bank statement CSV\./i)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /load sample statement/i })).not.toBeInTheDocument();
+  });
+
+  it('renders and processes sample statement when explicitly enabled', async () => {
+    render(
+      <ReconcileModal
+        {...baseProps}
+        allowSampleStatement
+        onConfirm={vi.fn()}
+      />
+    );
+
+    const button = screen.getByRole('button', { name: /load sample statement/i });
+    fireEvent.click(button);
+
+    expect(await screen.findByText(/sample-statement\.csv/i)).toBeInTheDocument();
+    expect(screen.getByText(/7 transactions/i)).toBeInTheDocument();
+  });
+});

--- a/components/ReconcileModal.tsx
+++ b/components/ReconcileModal.tsx
@@ -10,6 +10,7 @@ interface ReconcileModalProps {
   periodLabel: string
   onConfirm: (payments: ReconcilePaymentInput[]) => void
   onClose: () => void
+  allowSampleStatement?: boolean
 }
 
 type Step = 'upload' | 'review' | 'confirm'
@@ -34,6 +35,7 @@ export default function ReconcileModal({
   periodLabel,
   onConfirm,
   onClose,
+  allowSampleStatement = false,
 }: ReconcileModalProps) {
   const [step, setStep] = useState<Step>('upload')
   const [matches, setMatches] = useState<ReconcileMatch[]>([])
@@ -197,12 +199,14 @@ export default function ReconcileModal({
                 <div className="flex-1 h-px bg-border" />
               </div>
 
-              <button
-                onClick={handleLoadSample}
-                className="mt-4 w-full text-[13px] text-accent font-medium border border-accent rounded-lg px-4 py-3 hover:bg-accent-dim transition-colors"
-              >
-                Load sample statement (demo)
-              </button>
+              {allowSampleStatement && (
+                <button
+                  onClick={handleLoadSample}
+                  className="mt-4 w-full text-[13px] text-accent font-medium border border-accent rounded-lg px-4 py-3 hover:bg-accent-dim transition-colors"
+                >
+                  Load sample statement
+                </button>
+              )}
             </div>
           )}
 

--- a/lib/audit-api.ts
+++ b/lib/audit-api.ts
@@ -9,7 +9,7 @@ export async function getSchemeAuditEvents(
   limit = 50,
 ): Promise<AuditEventsResponse> {
   const response = await apiFetch(
-    `/audit/schemes/${schemeId}/events?limit=${limit}`,
+    `/api/v1/audit/schemes/${schemeId}/events?limit=${limit}`,
   );
   if (!response.ok) {
     throw await buildApiHttpError(response, "Failed to load audit events");

--- a/lib/auth-actions.test.ts
+++ b/lib/auth-actions.test.ts
@@ -220,4 +220,27 @@ describe("auth actions", () => {
       session: expect.objectContaining({ id: "user-1" }),
     });
   });
+
+  it("awaits the forgot-password request before returning", async () => {
+    let resolveFetch: (value: Response) => void;
+    const fetchPromise = new Promise<Response>((resolve) => {
+      resolveFetch = resolve;
+    });
+    const fetchMock = vi.fn(() => fetchPromise);
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { forgotPasswordAction } = await import("./auth-actions");
+    let resolved = false;
+    const action = forgotPasswordAction("person@example.com").then(() => {
+      resolved = true;
+    });
+
+    await Promise.resolve();
+    expect(resolved).toBe(false);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    resolveFetch!(new Response(null, { status: 200 }));
+    await action;
+    expect(resolved).toBe(true);
+  });
 });

--- a/lib/auth-actions.ts
+++ b/lib/auth-actions.ts
@@ -209,11 +209,15 @@ export async function setupAction(data: {
 // ─── Forgot password ──────────────────────────────────────────────────────────
 
 export async function forgotPasswordAction(email: string): Promise<void> {
-  fetchWithTimeout(`${BACKEND()}/api/v1/auth/forgot-password`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ email }),
-  }).catch(() => {});
+  try {
+    await fetchWithTimeout(`${BACKEND()}/api/v1/auth/forgot-password`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email }),
+    });
+  } catch {
+    // Intentionally ignore; endpoint returns a generic response for UX + anti-enumeration.
+  }
   // Always succeeds from the client's perspective (no email enumeration)
 }
 


### PR DESCRIPTION
Closes #293
Closes #294
Closes #295
Closes #325
Closes #282
Closes #283
Closes #285
Closes #299
Closes #302
Closes #303
Closes #307
Closes #279

## Summary
- resolve WhatsApp-disabled sender failures by using a disabled sender when Twilio config is missing
- ensure forgot-password and reset-token flows consume tokens transactionally and await async action completion
- gate early-access approve/reject pages with full token validation before rendering
- validate AGM quorum against actual eligible voter count and reject impossible values before persistence
- route inbound WhatsApp replies to resident-owned threads when multiple threads share one phone
- fix audit event fetch path through `/api/v1` so proxy allows it
- fix landing anchors so `#features` points to the features section
- enforce required financial amount inputs are non-empty numbers instead of coercing blank to zero
- disable sample bank-statement reconciliation in production reconciliation flow, with opt-in behavior for local/test contexts

## Verification
- go test ./... (backend)
- npm test
- npm run lint
- npm run typecheck