### PR TITLE
Fix auth and invitation email normalization

### DIFF
--- a/backend/internal/auth/email.go
+++ b/backend/internal/auth/email.go
@@ -1,23 +1,54 @@
 package auth
 
 import (
+	"errors"
 	"net/mail"
 	"strings"
 )
 
-func ValidateEmail(email string) bool {
+// NormalizeEmail trims and validates email syntax into a canonical lowercase address.
+func NormalizeEmail(raw string) (string, error) {
+	email := strings.TrimSpace(raw)
 	if email == "" {
-		return false
+		return "", errors.New("email is required")
 	}
 	if len(email) > 254 {
-		return false
+		return "", errors.New("email is too long")
 	}
-	if _, err := mail.ParseAddress(email); err != nil {
-		return false
+
+	addr, err := mail.ParseAddress(email)
+	if err != nil {
+		return "", err
 	}
-	if !strings.Contains(email, "@") {
-		return false
+	// Reject display-name forms such as "Bob <bob@example.com>".
+	if addr.Name != "" || addr.Address != email {
+		return "", errors.New("invalid email format")
 	}
-	local := strings.SplitN(email, "@", 2)[0]
-	return local != ""
+
+	local := strings.SplitN(addr.Address, "@", 2)[0]
+	if local == "" || !strings.Contains(addr.Address, "@") {
+		return "", errors.New("invalid email format")
+	}
+
+	return strings.ToLower(addr.Address), nil
+}
+
+func NormalizeOptionalEmail(raw *string) (*string, error) {
+	if raw == nil {
+		return nil, nil
+	}
+	trimmed := strings.TrimSpace(*raw)
+	if trimmed == "" {
+		return nil, nil
+	}
+	normalized, err := NormalizeEmail(trimmed)
+	if err != nil {
+		return nil, err
+	}
+	return &normalized, nil
+}
+
+func ValidateEmail(email string) bool {
+	_, err := NormalizeEmail(email)
+	return err == nil
 }

--- a/backend/internal/auth/email_test.go
+++ b/backend/internal/auth/email_test.go
@@ -24,10 +24,21 @@ func TestValidateEmail_Invalid(t *testing.T) {
 		"user@",
 		"user@.com",
 		"user..double@example.com",
+		"User Example <user@example.com>",
 	}
 	for _, e := range invalid {
 		if ValidateEmail(e) {
 			t.Errorf("ValidateEmail(%q) = true, want false", e)
 		}
+	}
+}
+
+func TestNormalizeEmail_CanonicalizesMailboxAddress(t *testing.T) {
+	email, err := NormalizeEmail("  User.Name+Tag@Example.COM  ")
+	if err != nil {
+		t.Fatalf("NormalizeEmail() error = %v", err)
+	}
+	if email != "user.name+tag@example.com" {
+		t.Fatalf("NormalizeEmail() = %q, want %q", email, "user.name+tag@example.com")
 	}
 }

--- a/backend/internal/auth/handler.go
+++ b/backend/internal/auth/handler.go
@@ -58,18 +58,18 @@ func (h *Handler) Register(w http.ResponseWriter, r *http.Request) {
 		response.Error(w, http.StatusBadRequest, response.CodeBadRequest, "invalid request body")
 		return
 	}
-	email := strings.TrimSpace(req.Email)
+	email, err := NormalizeEmail(req.Email)
+	if err != nil {
+		response.Error(w, http.StatusBadRequest, response.CodeBadRequest, "invalid email format")
+		return
+	}
 	fullName := strings.TrimSpace(req.FullName)
 	if email == "" || req.Password == "" || fullName == "" {
 		response.Error(w, http.StatusBadRequest, response.CodeBadRequest, "email, password, and full_name are required")
 		return
 	}
-	if !ValidateEmail(email) {
-		response.Error(w, http.StatusBadRequest, response.CodeBadRequest, "invalid email format")
-		return
-	}
-	if err := ValidatePassword(req.Password); err != nil {
-		response.Error(w, http.StatusBadRequest, response.CodeBadRequest, err.Error())
+	if passwordErr := ValidatePassword(req.Password); passwordErr != nil {
+		response.Error(w, http.StatusBadRequest, response.CodeBadRequest, passwordErr.Error())
 		return
 	}
 	res, err := h.service.Register(r.Context(), email, req.Password, fullName)
@@ -108,15 +108,15 @@ func (h *Handler) Setup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	orgName := strings.TrimSpace(req.OrgName)
-	contactEmail := strings.TrimSpace(req.ContactEmail)
+	contactEmail, err := NormalizeEmail(req.ContactEmail)
+	if err != nil {
+		response.Error(w, http.StatusBadRequest, response.CodeBadRequest, "invalid contact_email format")
+		return
+	}
 	schemeName := strings.TrimSpace(req.SchemeName)
 	schemeAddress := strings.TrimSpace(req.SchemeAddress)
 	if orgName == "" || contactEmail == "" || schemeName == "" || schemeAddress == "" || req.UnitCount <= 0 {
 		response.Error(w, http.StatusBadRequest, response.CodeBadRequest, "org_name, contact_email, scheme_name, scheme_address, and unit_count are required")
-		return
-	}
-	if !ValidateEmail(contactEmail) {
-		response.Error(w, http.StatusBadRequest, response.CodeBadRequest, "invalid contact_email format")
 		return
 	}
 	res, err := h.service.Setup(r.Context(), identity.OrgID, orgName, contactEmail, schemeName, schemeAddress, req.UnitCount)
@@ -137,6 +137,11 @@ func (h *Handler) ForgotPassword(w http.ResponseWriter, r *http.Request) {
 	}
 	if err := response.DecodeJSON(r.Body, &req); err != nil {
 		req.Email = ""
+	}
+	if req.Email != "" {
+		if normalized, err := NormalizeEmail(req.Email); err == nil {
+			req.Email = normalized
+		}
 	}
 	_ = h.service.ForgotPassword(r.Context(), req.Email)
 	response.JSON(w, http.StatusOK, map[string]string{
@@ -178,12 +183,17 @@ func (h *Handler) Login(w http.ResponseWriter, r *http.Request) {
 		response.Error(w, http.StatusBadRequest, response.CodeBadRequest, "invalid request body")
 		return
 	}
-	if req.Email == "" || req.Password == "" {
+	email, err := NormalizeEmail(req.Email)
+	if err != nil {
+		response.Error(w, http.StatusBadRequest, response.CodeBadRequest, "invalid email format")
+		return
+	}
+	if email == "" || req.Password == "" {
 		response.Error(w, http.StatusBadRequest, response.CodeBadRequest, "email and password are required")
 		return
 	}
 
-	res, err := h.service.Login(r.Context(), req.Email, req.Password)
+	res, err := h.service.Login(r.Context(), email, req.Password)
 	if err != nil {
 		if err == ErrInvalidCredentials {
 			response.Error(w, http.StatusUnauthorized, response.CodeUnauthorized, "invalid credentials")
@@ -273,7 +283,8 @@ func (h *Handler) UpdateProfile(w http.ResponseWriter, r *http.Request) {
 		response.Error(w, http.StatusBadRequest, response.CodeBadRequest, "email and full_name are required")
 		return
 	}
-	if !ValidateEmail(email) {
+	email, err := NormalizeEmail(email)
+	if err != nil {
 		response.Error(w, http.StatusBadRequest, response.CodeBadRequest, "invalid email format")
 		return
 	}
@@ -318,8 +329,13 @@ func (h *Handler) UpdateOrg(w http.ResponseWriter, r *http.Request) {
 		response.Error(w, http.StatusBadRequest, response.CodeBadRequest, "name is required")
 		return
 	}
+	contactEmail, err := NormalizeOptionalEmail(req.ContactEmail)
+	if err != nil {
+		response.Error(w, http.StatusBadRequest, response.CodeBadRequest, "invalid contact_email format")
+		return
+	}
 
-	res, err := h.service.UpdateOrg(r.Context(), identity.OrgID, name, normalizeOptionalString(req.ContactEmail), normalizeOptionalString(req.ContactPhone))
+	res, err := h.service.UpdateOrg(r.Context(), identity.OrgID, name, contactEmail, normalizeOptionalString(req.ContactPhone))
 	if err != nil {
 		response.Error(w, http.StatusInternalServerError, response.CodeInternalError, "failed to update organisation settings")
 		return

--- a/backend/internal/auth/handler_test.go
+++ b/backend/internal/auth/handler_test.go
@@ -172,7 +172,7 @@ func TestRegister_TrimsLeadingAndTrailingWhitespace(t *testing.T) {
 		},
 	}
 	req := httptest.NewRequest(http.MethodPost, "/register", body(t, map[string]string{
-		"email": "  a@b.com  ", "password": "Pass_1234", "full_name": "  New Name  ",
+		"email": "  A@B.COM  ", "password": "Pass_1234", "full_name": "  New Name  ",
 	}))
 	w := httptest.NewRecorder()
 	NewHandler(svc).Register(w, req)
@@ -184,6 +184,27 @@ func TestRegister_TrimsLeadingAndTrailingWhitespace(t *testing.T) {
 	}
 	if capturedFullName != "New Name" {
 		t.Fatalf("capturedFullName = %q, want %q", capturedFullName, "New Name")
+	}
+}
+
+func TestRegister_RejectsDisplayNameEmail(t *testing.T) {
+	svcCalled := false
+	svc := &mockService{
+		registerFn: func(_ context.Context, _, _, _ string) (*AuthResponse, error) {
+			svcCalled = true
+			return nil, nil
+		},
+	}
+	req := httptest.NewRequest(http.MethodPost, "/register", body(t, map[string]string{
+		"email": "User Example <user@example.com>", "password": "Pass_1234", "full_name": "User Example",
+	}))
+	w := httptest.NewRecorder()
+	NewHandler(svc).Register(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", w.Code)
+	}
+	if svcCalled {
+		t.Fatal("service should not be called for display-name email addresses")
 	}
 }
 
@@ -336,8 +357,10 @@ func TestLogin_BadJSON(t *testing.T) {
 }
 
 func TestLogin_ReturnsSession(t *testing.T) {
+	var capturedEmail string
 	svc := &mockService{
-		loginFn: func(_ context.Context, _, _ string) (*AuthResponse, error) {
+		loginFn: func(_ context.Context, email, _ string) (*AuthResponse, error) {
+			capturedEmail = email
 			return &AuthResponse{
 				AccessToken:  "access",
 				RefreshToken: "refresh",
@@ -353,7 +376,7 @@ func TestLogin_ReturnsSession(t *testing.T) {
 		},
 	}
 	req := httptest.NewRequest(http.MethodPost, "/login", body(t, map[string]string{
-		"email": "a@b.com", "password": "pass",
+		"email": " A@B.COM ", "password": "pass",
 	}))
 	w := httptest.NewRecorder()
 	NewHandler(svc).Login(w, req)
@@ -374,6 +397,9 @@ func TestLogin_ReturnsSession(t *testing.T) {
 	}
 	if resp.Data.Session.Org.ID == "" {
 		t.Error("expected session.org in login response")
+	}
+	if capturedEmail != "a@b.com" {
+		t.Fatalf("capturedEmail = %q, want %q", capturedEmail, "a@b.com")
 	}
 }
 
@@ -568,7 +594,7 @@ func TestUpdateProfile_Success(t *testing.T) {
 	}
 
 	req := httptest.NewRequest(http.MethodPatch, "/profile", body(t, map[string]string{
-		"email":     " new@example.com ",
+		"email":     " New@Example.COM ",
 		"full_name": " New Name ",
 		"phone":     "082 555 0101",
 	}))
@@ -578,6 +604,58 @@ func TestUpdateProfile_Success(t *testing.T) {
 	NewHandler(svc).UpdateProfile(w, req)
 	if w.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200", w.Code)
+	}
+}
+
+func TestUpdateOrg_RejectsInvalidContactEmail(t *testing.T) {
+	called := false
+	svc := &mockService{
+		updateOrgFn: func(context.Context, string, string, *string, *string) (*OrgInfo, error) {
+			called = true
+			return nil, nil
+		},
+	}
+	raw := "not-an-email"
+	req := httptest.NewRequest(http.MethodPatch, "/org", body(t, map[string]any{
+		"name":          "Updated Org",
+		"contact_email": raw,
+	}))
+	req = req.WithContext(ContextWithIdentity(req.Context(), "u1", "o1", string(RoleAdmin)))
+	w := httptest.NewRecorder()
+
+	NewHandler(svc).UpdateOrg(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", w.Code)
+	}
+	if called {
+		t.Fatal("service should not be called for invalid contact_email")
+	}
+}
+
+func TestUpdateOrg_NormalizesContactEmail(t *testing.T) {
+	var capturedContactEmail *string
+	svc := &mockService{
+		updateOrgFn: func(_ context.Context, orgID, name string, contactEmail, contactPhone *string) (*OrgInfo, error) {
+			if orgID != "o1" || name != "Updated Org" {
+				t.Fatalf("unexpected org update: orgID=%s name=%s", orgID, name)
+			}
+			capturedContactEmail = contactEmail
+			return &OrgInfo{ID: orgID, Name: name, ContactEmail: contactEmail, ContactPhone: contactPhone}, nil
+		},
+	}
+	req := httptest.NewRequest(http.MethodPatch, "/org", body(t, map[string]string{
+		"name":          " Updated Org ",
+		"contact_email": " Admin@Example.COM ",
+	}))
+	req = req.WithContext(ContextWithIdentity(req.Context(), "u1", "o1", string(RoleAdmin)))
+	w := httptest.NewRecorder()
+
+	NewHandler(svc).UpdateOrg(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	if capturedContactEmail == nil || *capturedContactEmail != "admin@example.com" {
+		t.Fatalf("contactEmail = %#v, want admin@example.com", capturedContactEmail)
 	}
 }
 

--- a/backend/internal/auth/service.go
+++ b/backend/internal/auth/service.go
@@ -154,7 +154,11 @@ func NewService(db *database.Pool, cache *redis.Client, sender notification.Send
 }
 
 func (s *Service) Register(ctx context.Context, email, password, fullName string) (*AuthResponse, error) {
-	_, err := s.db.Q.GetUserByEmail(ctx, email)
+	email, err := NormalizeEmail(email)
+	if err != nil {
+		return nil, err
+	}
+	_, err = s.db.Q.GetUserByEmail(ctx, email)
 	if err == nil {
 		return nil, ErrEmailExists
 	}
@@ -199,6 +203,10 @@ func (s *Service) Register(ctx context.Context, email, password, fullName string
 }
 
 func (s *Service) Login(ctx context.Context, email, password string) (*AuthResponse, error) {
+	email, err := NormalizeEmail(email)
+	if err != nil {
+		return nil, ErrInvalidCredentials
+	}
 	user, err := s.db.Q.GetUserByEmail(ctx, email)
 	if err != nil {
 		return nil, ErrInvalidCredentials
@@ -380,6 +388,10 @@ func (s *Service) Me(ctx context.Context, userID, orgID string) (*MeResponse, er
 }
 
 func (s *Service) UpdateProfile(ctx context.Context, userID, orgID, email, fullName string, phone *string) (*MeResponse, error) {
+	email, err := NormalizeEmail(email)
+	if err != nil {
+		return nil, ErrInvalidCredentials
+	}
 	uid, err := uuid.Parse(userID)
 	if err != nil {
 		return nil, ErrInvalidToken
@@ -402,6 +414,10 @@ func (s *Service) UpdateProfile(ctx context.Context, userID, orgID, email, fullN
 }
 
 func (s *Service) UpdateOrg(ctx context.Context, orgID, name string, contactEmail, contactPhone *string) (*OrgInfo, error) {
+	contactEmail, err := NormalizeOptionalEmail(contactEmail)
+	if err != nil {
+		return nil, err
+	}
 	oid, err := uuid.Parse(orgID)
 	if err != nil {
 		return nil, ErrInvalidToken
@@ -510,6 +526,11 @@ func (s *Service) Setup(ctx context.Context, orgID, orgName, contactEmail, schem
 }
 
 func (s *Service) ForgotPassword(ctx context.Context, email string) error {
+	normalizedEmail, normalizeErr := NormalizeEmail(email)
+	if normalizeErr != nil {
+		return nil //nolint:nilerr // Preserve non-enumerating forgot-password responses for malformed input.
+	}
+	email = normalizedEmail
 	user, err := s.db.Q.GetUserByEmail(ctx, email)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil // silent — no enumeration
@@ -536,6 +557,10 @@ func (s *Service) ForgotPassword(ctx context.Context, email string) error {
 // IssuePasswordResetURL generates a password reset token and returns the URL
 // without sending any email. Used by earlyaccess approval flow.
 func (s *Service) IssuePasswordResetURL(ctx context.Context, email, appBaseURL string) (string, error) {
+	email, err := NormalizeEmail(email)
+	if err != nil {
+		return "", err
+	}
 	user, err := s.db.Q.GetUserByEmail(ctx, email)
 	if err != nil {
 		return "", err

--- a/backend/internal/invitation/handler.go
+++ b/backend/internal/invitation/handler.go
@@ -3,6 +3,7 @@ package invitation
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/stratahq/backend/internal/auth"
@@ -40,25 +41,35 @@ func (h *Handler) Create(w http.ResponseWriter, r *http.Request) {
 		response.Error(w, http.StatusBadRequest, response.CodeBadRequest, "invalid request body")
 		return
 	}
-	if req.Email == "" || req.FullName == "" || req.Role == "" || req.SchemeID == "" {
+	email := strings.TrimSpace(req.Email)
+	fullName := strings.TrimSpace(req.FullName)
+	role := strings.TrimSpace(req.Role)
+	schemeID := strings.TrimSpace(req.SchemeID)
+	unitID := strings.TrimSpace(req.UnitID)
+	if email == "" || fullName == "" || role == "" || schemeID == "" {
 		response.Error(w, http.StatusBadRequest, response.CodeBadRequest, "email, full_name, role, and scheme_id are required")
 		return
 	}
-	if !auth.IsInvitableRole(req.Role) {
+	normalizedEmail, err := auth.NormalizeEmail(email)
+	if err != nil {
+		response.Error(w, http.StatusBadRequest, response.CodeBadRequest, "invalid email format")
+		return
+	}
+	if !auth.IsInvitableRole(role) {
 		response.Error(w, http.StatusBadRequest, response.CodeBadRequest, "role must be trustee or resident")
 		return
 	}
-	if req.Role == "resident" && req.UnitID == "" {
+	if role == "resident" && unitID == "" {
 		response.Error(w, http.StatusBadRequest, response.CodeBadRequest, "unit_id is required for residents")
 		return
 	}
 
 	inv, err := h.service.Create(r.Context(), identity.OrgID, CreateParams{
-		Email:    req.Email,
-		FullName: req.FullName,
-		Role:     req.Role,
-		SchemeID: req.SchemeID,
-		UnitID:   req.UnitID,
+		Email:    normalizedEmail,
+		FullName: fullName,
+		Role:     role,
+		SchemeID: schemeID,
+		UnitID:   unitID,
 	}, h.appBaseURL)
 	if err != nil {
 		switch {
@@ -66,6 +77,8 @@ func (h *Handler) Create(w http.ResponseWriter, r *http.Request) {
 			response.Error(w, http.StatusForbidden, response.CodeForbidden, "scheme belongs to a different org")
 		case err.Error() == "invalid scheme_id", err.Error() == "invalid unit_id":
 			response.Error(w, http.StatusBadRequest, response.CodeBadRequest, err.Error())
+		case err == ErrInvalidEmail:
+			response.Error(w, http.StatusBadRequest, response.CodeBadRequest, "invalid email format")
 		case err == ErrDuplicateInvite:
 			response.Error(w, http.StatusConflict, response.CodeConflict, "only one pending invitation allowed per recipient for this membership")
 		default:
@@ -114,6 +127,8 @@ func (h *Handler) Resend(w http.ResponseWriter, r *http.Request) {
 			response.Error(w, http.StatusForbidden, response.CodeForbidden, "invitation belongs to a different org")
 		case ErrInvalidToken:
 			response.Error(w, http.StatusConflict, response.CodeConflict, "only pending invitations can be resent")
+		case ErrInvalidEmail:
+			response.Error(w, http.StatusConflict, response.CodeConflict, "invitation email is invalid")
 		default:
 			response.Error(w, http.StatusInternalServerError, response.CodeInternalError, "failed to resend invitation")
 		}

--- a/backend/internal/invitation/handler_test.go
+++ b/backend/internal/invitation/handler_test.go
@@ -130,6 +130,65 @@ func TestHandlerCreateReturnsConflictForDuplicatePendingInvitation(t *testing.T)
 	}
 }
 
+func TestHandlerCreateRejectsInvalidEmail(t *testing.T) {
+	called := false
+	h := NewHandler(&stubServicer{
+		createFn: func(context.Context, string, CreateParams, string) (*InvitationResponse, error) {
+			called = true
+			return nil, nil
+		},
+	}, "http://localhost:3000")
+
+	body, _ := json.Marshal(map[string]string{
+		"email":     "User Example <user@example.com>",
+		"full_name": "User Example",
+		"role":      "trustee",
+		"scheme_id": "11111111-1111-1111-1111-111111111111",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/invitations", bytes.NewReader(body))
+	req = req.WithContext(auth.ContextWithIdentity(req.Context(), "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb", string(auth.RoleAdmin)))
+	w := httptest.NewRecorder()
+
+	h.Create(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+	if called {
+		t.Fatal("service should not be called for invalid invitation email")
+	}
+}
+
+func TestHandlerCreateNormalizesEmailAndFullName(t *testing.T) {
+	var captured CreateParams
+	h := NewHandler(&stubServicer{
+		createFn: func(_ context.Context, _ string, p CreateParams, _ string) (*InvitationResponse, error) {
+			captured = p
+			return &InvitationResponse{ID: "i1", Email: p.Email, FullName: p.FullName, Role: p.Role, SchemeID: p.SchemeID}, nil
+		},
+	}, "http://localhost:3000")
+
+	body, _ := json.Marshal(map[string]string{
+		"email":     " Trustee@Example.COM ",
+		"full_name": " Trustee User ",
+		"role":      "trustee",
+		"scheme_id": "11111111-1111-1111-1111-111111111111",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/invitations", bytes.NewReader(body))
+	req = req.WithContext(auth.ContextWithIdentity(req.Context(), "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb", string(auth.RoleAdmin)))
+	w := httptest.NewRecorder()
+
+	h.Create(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusCreated)
+	}
+	if captured.Email != "trustee@example.com" {
+		t.Fatalf("email = %q, want trustee@example.com", captured.Email)
+	}
+	if captured.FullName != "Trustee User" {
+		t.Fatalf("fullName = %q, want Trustee User", captured.FullName)
+	}
+}
+
 func uuidMustString(raw string) string {
 	return raw
 }

--- a/backend/internal/invitation/service.go
+++ b/backend/internal/invitation/service.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"errors"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -26,6 +27,7 @@ var (
 	ErrForbidden       = errors.New("invitation belongs to a different org")
 	ErrInvalidToken    = errors.New("invalid, expired, or already used invitation token")
 	ErrEmailExists     = errors.New("email already registered")
+	ErrInvalidEmail    = errors.New("invalid email")
 	ErrDuplicateInvite = errors.New("a pending invitation for this recipient already exists")
 	ErrInvitationSend  = errors.New("failed to send invitation")
 )
@@ -137,6 +139,12 @@ func generateToken() (string, error) {
 }
 
 func (s *Service) Create(ctx context.Context, orgID string, p CreateParams, appBaseURL string) (*InvitationResponse, error) {
+	email, err := auth.NormalizeEmail(p.Email)
+	if err != nil {
+		return nil, ErrInvalidEmail
+	}
+	fullName := strings.TrimSpace(p.FullName)
+
 	oid, err := uuid.Parse(orgID)
 	if err != nil {
 		return nil, ErrForbidden
@@ -163,8 +171,8 @@ func (s *Service) Create(ctx context.Context, orgID string, p CreateParams, appB
 		OrgID:     oid,
 		SchemeID:  sid,
 		UnitID:    unitID,
-		Email:     p.Email,
-		FullName:  p.FullName,
+		Email:     email,
+		FullName:  fullName,
 		Role:      p.Role,
 		Token:     token,
 		ExpiresAt: expiresAt,
@@ -197,7 +205,7 @@ func (s *Service) Create(ctx context.Context, orgID string, p CreateParams, appB
 	}
 
 	inviteURL := appBaseURL + "/auth/invite/" + token
-	if err := s.sender.SendInvitation(ctx, p.Email, p.FullName, inviteURL); err != nil {
+	if err := s.sender.SendInvitation(ctx, email, fullName, inviteURL); err != nil {
 		if revokeErr := s.q.UpdateInvitationStatus(ctx, dbgen.UpdateInvitationStatusParams{
 			Status: "revoked",
 			ID:     inv.ID,
@@ -249,6 +257,11 @@ func (s *Service) Resend(ctx context.Context, orgID, invitationID, appBaseURL st
 	if existing.Status != "pending" {
 		return nil, ErrInvalidToken
 	}
+	email, err := auth.NormalizeEmail(existing.Email)
+	if err != nil {
+		return nil, ErrInvalidEmail
+	}
+	fullName := strings.TrimSpace(existing.FullName)
 
 	token, err := generateToken()
 	if err != nil {
@@ -256,7 +269,7 @@ func (s *Service) Resend(ctx context.Context, orgID, invitationID, appBaseURL st
 	}
 	expiresAt := time.Now().Add(7 * 24 * time.Hour)
 	inviteURL := appBaseURL + "/auth/invite/" + token
-	if err = s.sender.SendInvitation(ctx, existing.Email, existing.FullName, inviteURL); err != nil {
+	if err = s.sender.SendInvitation(ctx, email, fullName, inviteURL); err != nil {
 		return nil, err
 	}
 

--- a/backend/internal/invitation/service_test.go
+++ b/backend/internal/invitation/service_test.go
@@ -38,12 +38,16 @@ type fakeInvitationStore struct {
 }
 
 type fakeInvitationSender struct {
-	sendErr error
-	calls   int
+	sendErr      error
+	calls        int
+	lastEmail    string
+	lastFullName string
 }
 
-func (s *fakeInvitationSender) SendInvitation(context.Context, string, string, string) error {
+func (s *fakeInvitationSender) SendInvitation(_ context.Context, email, fullName, _ string) error {
 	s.calls++
+	s.lastEmail = email
+	s.lastFullName = fullName
 	return s.sendErr
 }
 
@@ -300,6 +304,67 @@ func TestServiceCreateRejectsUnitOutsideScheme(t *testing.T) {
 	}
 	if store.createdInvitation != nil {
 		t.Fatal("Create() created invitation for unit outside scheme")
+	}
+}
+
+func TestServiceCreateNormalizesInvitationEmailBeforePersistenceAndSend(t *testing.T) {
+	orgID := uuid.New()
+	schemeID := uuid.New()
+	store := &fakeInvitationStore{
+		scheme: &dbgen.Scheme{
+			ID:    schemeID,
+			OrgID: orgID,
+		},
+	}
+	sender := &fakeInvitationSender{}
+	svc := newTestService(store)
+	svc.sender = sender
+
+	resp, err := svc.Create(context.Background(), orgID.String(), CreateParams{
+		Email:    " Resident@Example.COM ",
+		FullName: " Resident User ",
+		Role:     "trustee",
+		SchemeID: schemeID.String(),
+	}, "http://localhost:3000")
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	if resp.Email != "resident@example.com" {
+		t.Fatalf("response email = %q, want resident@example.com", resp.Email)
+	}
+	if store.createdInvitation == nil || store.createdInvitation.Email != "resident@example.com" {
+		t.Fatalf("created invitation email = %#v, want resident@example.com", store.createdInvitation)
+	}
+	if sender.lastEmail != "resident@example.com" {
+		t.Fatalf("sent email = %q, want resident@example.com", sender.lastEmail)
+	}
+	if sender.lastFullName != "Resident User" {
+		t.Fatalf("sent full name = %q, want Resident User", sender.lastFullName)
+	}
+}
+
+func TestServiceCreateRejectsInvalidInvitationEmail(t *testing.T) {
+	orgID := uuid.New()
+	schemeID := uuid.New()
+	store := &fakeInvitationStore{
+		scheme: &dbgen.Scheme{
+			ID:    schemeID,
+			OrgID: orgID,
+		},
+	}
+	svc := newTestService(store)
+
+	_, err := svc.Create(context.Background(), orgID.String(), CreateParams{
+		Email:    "Resident User <resident@example.com>",
+		FullName: "Resident User",
+		Role:     "trustee",
+		SchemeID: schemeID.String(),
+	}, "http://localhost:3000")
+	if !errors.Is(err, ErrInvalidEmail) {
+		t.Fatalf("Create() error = %v, want ErrInvalidEmail", err)
+	}
+	if store.createdInvitation != nil {
+		t.Fatal("Create() created invitation for invalid email")
 	}
 }
 


### PR DESCRIPTION
## Summary
- normalize auth account emails at register, login, forgot-password, profile update, setup, and service entry points
- reject display-name mailbox strings for account and invitation emails
- validate and normalize invitation recipient emails before persistence and send
- validate and normalize optional organisation contact emails while preserving clear-to-empty behavior

Closes #178
Closes #179
Closes #180
Closes #268

## Verification
- cd backend && go test ./internal/auth ./internal/invitation
- cd backend && go test ./internal/...
- cd backend && go build ./cmd/server ./cmd/worker
- cd backend && golangci-lint run ./...
