### PR TITLE
Fix launch gate default and Go build ignores

### DIFF
--- a/.github/workflows/production-launch-gate.yml
+++ b/.github/workflows/production-launch-gate.yml
@@ -19,7 +19,7 @@ on:
       http_req_duration_p95_ms:
         description: "Maximum allowed k6 http_req_duration p95 in milliseconds"
         required: true
-        default: "30000"
+        default: "1000"
         type: string
 
 permissions:

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,5 +1,7 @@
 # Binary
 bin/
+/server
+/worker
 server/
 worker/
 


### PR DESCRIPTION
## Summary
- ignore default backend/server and backend/worker binaries produced by natural Go build commands
- align production launch gate p95 latency default with the documented/load-test 1000ms threshold

Closes #168
Closes #191

## Verification
- git check-ignore -v backend/server backend/worker
- cd backend && go build ./cmd/server/ && go build ./cmd/worker/
- git status --short --untracked-files=all
- rg -n "default: \"(1000|30000)\"|http_req_duration_p95_ms|p95" .github/workflows/production-launch-gate.yml docs/production-reliability-runbook.md backend/tests/load/auth-and-dashboard-config.js
- git diff --check
