### PR TITLE
Include worker and migrations in Docker runtime

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,16 +1,20 @@
 # Stage 1: Build
 FROM golang:1.25-alpine AS builder
 
+ARG GOOSE_VERSION=v3.27.1
+
 RUN apk add --no-cache git ca-certificates
 
 WORKDIR /app
 
 COPY go.mod go.sum ./
 RUN go mod download
+RUN CGO_ENABLED=0 GOOS=linux go install github.com/pressly/goose/v3/cmd/goose@${GOOSE_VERSION}
 
 COPY . .
 
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /app/bin/server ./cmd/server/
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /app/bin/worker ./cmd/worker/
 
 # Stage 2: Runtime
 FROM alpine:3.21
@@ -20,6 +24,8 @@ RUN apk add --no-cache ca-certificates tzdata
 WORKDIR /app
 
 COPY --from=builder /app/bin/server .
+COPY --from=builder /app/bin/worker .
+COPY --from=builder /go/bin/goose .
 COPY --from=builder /app/db/migrations ./db/migrations
 
 EXPOSE 8080

--- a/backend/README.md
+++ b/backend/README.md
@@ -97,7 +97,8 @@ backend/
 | Command | Description |
 |---------|-------------|
 | `make run` | Run the server locally |
-| `make build` | Build binary to `bin/server` |
+| `make worker` | Run the background worker locally |
+| `make build` | Build API and worker binaries to `bin/server` and `bin/worker` |
 | `make test` | Run unit tests |
 | `make test-integration` | Run integration tests (requires Docker services) |
 | `make test-all` | Run all tests |
@@ -110,7 +111,7 @@ backend/
 | `make migrate-status` | Show migration status |
 | `make docker-up` | Start Postgres + Redis containers |
 | `make docker-down` | Stop containers |
-| `make docker-all` | Build and start all services |
+| `make docker-all` | Build, migrate, and start the API, worker, Postgres, and Redis services |
 | `make seed` | Seed the development database |
 
 ## Load Testing

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -1,9 +1,23 @@
 services:
+  migrate:
+    build: .
+    depends_on:
+      postgres:
+        condition: service_healthy
+    env_file:
+      - .env
+    environment:
+      - DATABASE_URL=postgres://stratahq:stratahq@postgres:5432/stratahq?sslmode=disable
+    entrypoint: ["./goose"]
+    command: ["-dir", "db/migrations", "postgres", "postgres://stratahq:stratahq@postgres:5432/stratahq?sslmode=disable", "up"]
+
   backend:
     build: .
     ports:
       - "8080:8080"
     depends_on:
+      migrate:
+        condition: service_completed_successfully
       postgres:
         condition: service_healthy
       redis:
@@ -13,6 +27,22 @@ services:
     environment:
       - DATABASE_URL=postgres://stratahq:stratahq@postgres:5432/stratahq?sslmode=disable
       - REDIS_URL=redis://redis:6379
+
+  worker:
+    build: .
+    depends_on:
+      migrate:
+        condition: service_completed_successfully
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    env_file:
+      - .env
+    environment:
+      - DATABASE_URL=postgres://stratahq:stratahq@postgres:5432/stratahq?sslmode=disable
+      - REDIS_URL=redis://redis:6379
+    entrypoint: ["./worker"]
 
   postgres:
     image: postgres:17-alpine


### PR DESCRIPTION
## Summary
- build and copy the worker binary into the backend Docker image
- include a pinned goose binary and migrations in the runtime image for migration jobs
- add a one-shot compose migrate service and make API/worker wait for it
- add a compose worker service that runs ./worker from the same image
- update backend command docs for worker/build/docker-all behavior

Closes #193
Closes #194

## Verification
- cd backend && go test ./internal/...
- cd backend && docker compose config
- cd backend && docker build -t stratahq-backend-runtime-test .
- docker run --rm --entrypoint /bin/sh stratahq-backend-runtime-test -c 'test -x ./server && test -x ./worker && test -x ./goose && ./goose -version && test -d ./db/migrations'\n- git diff --check\n\nNote: compose config was verified with backend/.env temporarily populated from backend/.env.example, then removed.\n