### PR TITLE
Validate audit event limit bounds

### DIFF
--- a/backend/internal/audit/handler.go
+++ b/backend/internal/audit/handler.go
@@ -31,6 +31,10 @@ func (h *Handler) ListSchemeEvents(w http.ResponseWriter, r *http.Request) {
 			response.ErrorWithRequest(w, r, http.StatusBadRequest, response.CodeBadRequest, "invalid limit")
 			return
 		}
+		if parsed < 1 || parsed > 200 {
+			response.ErrorWithRequest(w, r, http.StatusBadRequest, response.CodeBadRequest, "invalid limit")
+			return
+		}
 		limit = int32(parsed)
 	}
 	result, err := h.service.ListSchemeEvents(r.Context(), identity, chi.URLParam(r, "schemeId"), limit)

--- a/backend/internal/audit/handler_test.go
+++ b/backend/internal/audit/handler_test.go
@@ -1,0 +1,31 @@
+package audit
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stratahq/backend/internal/auth"
+)
+
+func TestListSchemeEventsRejectsInvalidLimits(t *testing.T) {
+	tests := []string{
+		"-1",
+		"0",
+		"201",
+		"4294967296",
+	}
+	for _, limit := range tests {
+		t.Run(limit, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/audit/schemes/s1/events?limit="+limit, nil)
+			req = req.WithContext(auth.ContextWithIdentity(req.Context(), "11111111-1111-1111-1111-111111111111", "22222222-2222-2222-2222-222222222222", string(auth.RoleAdmin)))
+			w := httptest.NewRecorder()
+
+			NewHandler(&ResourceService{}).ListSchemeEvents(w, req)
+
+			if w.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400", w.Code)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- reject audit event limits below 1 or above 200 before narrowing to int32
- add handler coverage for negative, zero, oversized, and overflow-sized limits

Closes #186

## Verification
- cd backend && go test ./internal/audit
- cd backend && go test ./internal/...
- cd backend && golangci-lint run ./internal/audit
- git diff --check
