### PR TITLE
Validate levy account route IDs

### DIFF
--- a/backend/internal/levy/handler.go
+++ b/backend/internal/levy/handler.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
 
 	"github.com/stratahq/backend/internal/auth"
 	"github.com/stratahq/backend/internal/platform/response"
@@ -196,7 +197,12 @@ func (h *Handler) CollectionEvents(w http.ResponseWriter, r *http.Request) {
 		response.Error(w, http.StatusUnauthorized, response.CodeUnauthorized, "missing auth context")
 		return
 	}
-	items, err := h.service.CollectionEvents(r.Context(), identity, chi.URLParam(r, "schemeId"), chi.URLParam(r, "accountId"))
+	accountID, err := accountIDFromRoute(r)
+	if err != nil {
+		writeLevyError(w, err, "invalid account id")
+		return
+	}
+	items, err := h.service.CollectionEvents(r.Context(), identity, chi.URLParam(r, "schemeId"), accountID)
 	if err != nil {
 		writeLevyError(w, err, "failed to load collection events")
 		return
@@ -228,7 +234,12 @@ func (h *Handler) RecordCollectionEvent(w http.ResponseWriter, r *http.Request) 
 		response.Error(w, http.StatusBadRequest, response.CodeBadRequest, "promise_to_pay requires amount and date")
 		return
 	}
-	created, err := h.service.RecordCollectionEvent(r.Context(), identity, chi.URLParam(r, "schemeId"), chi.URLParam(r, "accountId"), RecordCollectionEventInput{
+	accountID, err := accountIDFromRoute(r)
+	if err != nil {
+		writeLevyError(w, err, "invalid account id")
+		return
+	}
+	created, err := h.service.RecordCollectionEvent(r.Context(), identity, chi.URLParam(r, "schemeId"), accountID, RecordCollectionEventInput{
 		EventType:          strings.TrimSpace(req.EventType),
 		Note:               normalizeOptionalString(req.Note),
 		PromiseAmountCents: req.PromiseAmountCents,
@@ -258,7 +269,12 @@ func (h *Handler) ReminderDraft(w http.ResponseWriter, r *http.Request) {
 		response.Error(w, http.StatusUnauthorized, response.CodeUnauthorized, "missing auth context")
 		return
 	}
-	draft, err := h.service.ReminderDraft(r.Context(), identity, chi.URLParam(r, "schemeId"), chi.URLParam(r, "accountId"))
+	accountID, err := accountIDFromRoute(r)
+	if err != nil {
+		writeLevyError(w, err, "invalid account id")
+		return
+	}
+	draft, err := h.service.ReminderDraft(r.Context(), identity, chi.URLParam(r, "schemeId"), accountID)
 	if err != nil {
 		writeLevyError(w, err, "failed to load reminder draft")
 		return
@@ -287,7 +303,12 @@ func (h *Handler) SendReminder(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	event, err := h.service.SendReminder(r.Context(), identity, chi.URLParam(r, "schemeId"), chi.URLParam(r, "accountId"), input)
+	accountID, err := accountIDFromRoute(r)
+	if err != nil {
+		writeLevyError(w, err, "invalid account id")
+		return
+	}
+	event, err := h.service.SendReminder(r.Context(), identity, chi.URLParam(r, "schemeId"), accountID, input)
 	if err != nil {
 		writeLevyError(w, err, "failed to send reminder")
 		return
@@ -401,6 +422,14 @@ func (h *Handler) ApplyBankStatementImport(w http.ResponseWriter, r *http.Reques
 	}
 
 	response.JSON(w, http.StatusOK, result)
+}
+
+func accountIDFromRoute(r *http.Request) (string, error) {
+	accountID := chi.URLParam(r, "accountId")
+	if _, err := uuid.Parse(accountID); err != nil {
+		return "", ErrInvalidInput
+	}
+	return accountID, nil
 }
 
 func writeLevyError(w http.ResponseWriter, err error, fallback string) {

--- a/backend/internal/levy/handler_test.go
+++ b/backend/internal/levy/handler_test.go
@@ -121,6 +121,83 @@ func TestRecordCollectionEventRejectsMissingPromiseDate(t *testing.T) {
 	}
 }
 
+func TestAccountEndpointsRejectMalformedAccountID(t *testing.T) {
+	tests := []struct {
+		name      string
+		method    string
+		path      string
+		body      []byte
+		call      func(*Handler, http.ResponseWriter, *http.Request)
+		wasCalled func(*fakeAttentionService) bool
+		accountID string
+		schemeID  string
+	}{
+		{
+			name:      "collection events",
+			method:    http.MethodGet,
+			path:      "/api/v1/levies/scheme-1/accounts/not-a-uuid/events",
+			call:      (*Handler).CollectionEvents,
+			wasCalled: func(svc *fakeAttentionService) bool { return svc.eventsCalled },
+			accountID: "not-a-uuid",
+			schemeID:  "scheme-1",
+		},
+		{
+			name:      "record collection event",
+			method:    http.MethodPost,
+			path:      "/api/v1/levies/scheme-1/accounts/not-a-uuid/events",
+			body:      []byte(`{"event_type":"follow_up_logged","note":"called owner"}`),
+			call:      (*Handler).RecordCollectionEvent,
+			wasCalled: func(svc *fakeAttentionService) bool { return svc.recordCalled },
+			accountID: "not-a-uuid",
+			schemeID:  "scheme-1",
+		},
+		{
+			name:      "reminder draft",
+			method:    http.MethodGet,
+			path:      "/api/v1/levies/scheme-1/accounts/not-a-uuid/reminder-draft",
+			call:      (*Handler).ReminderDraft,
+			wasCalled: func(svc *fakeAttentionService) bool { return svc.draftCalled },
+			accountID: "not-a-uuid",
+			schemeID:  "scheme-1",
+		},
+		{
+			name:      "send reminder",
+			method:    http.MethodPost,
+			path:      "/api/v1/levies/scheme-1/accounts/not-a-uuid/reminders",
+			body:      []byte(`{"email":{"enabled":true,"subject":"Levy reminder","body":"Please pay"},"whatsapp":{"enabled":false}}`),
+			call:      (*Handler).SendReminder,
+			wasCalled: func(svc *fakeAttentionService) bool { return svc.sendCalled },
+			accountID: "not-a-uuid",
+			schemeID:  "scheme-1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := &fakeAttentionService{}
+			h := NewHandlerWithService(svc)
+
+			req := httptest.NewRequest(tt.method, tt.path, bytes.NewReader(tt.body))
+			req = req.WithContext(auth.ContextWithIdentity(req.Context(), "user-1", "org-1", "trustee"))
+
+			rctx := chi.NewRouteContext()
+			rctx.URLParams.Add("schemeId", tt.schemeID)
+			rctx.URLParams.Add("accountId", tt.accountID)
+			req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+
+			w := httptest.NewRecorder()
+			tt.call(h, w, req)
+
+			if w.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d body=%s, want %d", w.Code, w.Body.String(), http.StatusBadRequest)
+			}
+			if tt.wasCalled(svc) {
+				t.Fatalf("service should not be called for malformed accountId")
+			}
+		})
+	}
+}
+
 func TestReminderDraftRequiresAuth(t *testing.T) {
 	svc := &fakeAttentionService{}
 	h := NewHandlerWithService(svc)


### PR DESCRIPTION
## Summary
- validate malformed levy accountId route params before calling account event/reminder services
- return shaped 400 BAD_REQUEST responses for collection events, event creation, reminder draft, and reminder send routes
- add regression coverage for malformed accountId across the affected endpoints

Closes #170

## Verification
- go test ./internal/levy -run TestAccountEndpointsRejectMalformedAccountID -count=1
- go test ./internal/levy -count=1
- go test ./internal/...
- go build ./cmd/server ./cmd/worker
- golangci-lint run ./internal/levy
- go test ./...
- golangci-lint run ./...
- git diff --check