### PR TITLE
Handle malformed Copilot JSON

### DIFF
--- a/app/api/copilot/route.test.ts
+++ b/app/api/copilot/route.test.ts
@@ -13,6 +13,27 @@ vi.mock("next/headers", () => ({
 describe("copilot route", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("returns 400 for malformed JSON without contacting the backend", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { POST } = await import("./route");
+    const request = new Request("http://localhost/api/copilot", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-csrf-token": "csrf-token" },
+      body: "{not-json",
+    });
+
+    const response = await POST(
+      request as unknown as import("next/server").NextRequest,
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.text()).resolves.toContain("Invalid JSON");
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("returns 503 when backend copilot request aborts", async () => {

--- a/app/api/copilot/route.ts
+++ b/app/api/copilot/route.ts
@@ -22,7 +22,16 @@ export async function POST(request: NextRequest) {
     })
   }
 
-  const body = await request.json()
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return new Response('Invalid JSON request body.', {
+      status: 400,
+      headers: { 'Content-Type': 'text/plain' },
+    })
+  }
+
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), COPILOT_TIMEOUT_MS);
   let response: Response;


### PR DESCRIPTION
## Summary
- return a shaped 400 response when the Copilot route receives malformed JSON
- avoid contacting the backend when request parsing fails
- add route coverage for invalid request bodies

Closes #163

## Verification
- npm test -- app/api/copilot/route.test.ts
- npm test
- npm run lint
- npm run typecheck
- npm run build
- git diff --check