### PR TITLE
Make rate limits expire atomically

### DIFF
--- a/backend/internal/middleware/metrics.go
+++ b/backend/internal/middleware/metrics.go
@@ -27,6 +27,14 @@ var (
 		},
 		[]string{"method", "path"},
 	)
+
+	rateLimitBlockedTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "rate_limit_blocked_total",
+			Help: "Total number of requests blocked by rate limiting",
+		},
+		[]string{"endpoint"},
+	)
 )
 
 func Metrics(next http.Handler) http.Handler {
@@ -55,4 +63,11 @@ func routeLabel(r *http.Request) string {
 		}
 	}
 	return "unmatched"
+}
+
+func recordRateLimitBlocked(endpoint string) {
+	if endpoint == "" {
+		endpoint = "global"
+	}
+	rateLimitBlockedTotal.WithLabelValues(endpoint).Inc()
 }

--- a/backend/internal/middleware/ratelimit.go
+++ b/backend/internal/middleware/ratelimit.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"net/http"
@@ -12,6 +13,14 @@ import (
 	"github.com/redis/go-redis/v9"
 	"github.com/stratahq/backend/internal/platform/response"
 )
+
+var incrementRateLimitScript = redis.NewScript(`
+local count = redis.call("INCR", KEYS[1])
+if count == 1 then
+	redis.call("PEXPIRE", KEYS[1], ARGV[1])
+end
+return count
+`)
 
 func RateLimit(rdb *redis.Client, limit int, window time.Duration) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
@@ -25,17 +34,14 @@ func RateLimit(rdb *redis.Client, limit int, window time.Duration) func(http.Han
 			key := fmt.Sprintf("ratelimit:%s", ip)
 			ctx := r.Context()
 
-			count, err := rdb.Incr(ctx, key).Result()
+			count, err := incrementRateLimit(ctx, rdb, key, window)
 			if err != nil {
 				next.ServeHTTP(w, r)
 				return
 			}
 
-			if count == 1 {
-				rdb.Expire(ctx, key, window)
-			}
-
 			if count > int64(limit) {
+				recordRateLimitBlocked("global")
 				response.ErrorWithRequest(w, r, http.StatusTooManyRequests, "RATE_LIMITED", "too many requests")
 				return
 			}
@@ -59,17 +65,14 @@ func PerEndpointRateLimit(rdb *redis.Client, prefix string, limit int, window ti
 			key := fmt.Sprintf("ratelimit:%s:%s", prefix, ip)
 			ctx := r.Context()
 
-			count, err := rdb.Incr(ctx, key).Result()
+			count, err := incrementRateLimit(ctx, rdb, key, window)
 			if err != nil {
 				next.ServeHTTP(w, r)
 				return
 			}
 
-			if count == 1 {
-				rdb.Expire(ctx, key, window)
-			}
-
 			if count > int64(limit) {
+				recordRateLimitBlocked(prefix)
 				response.ErrorWithRequest(w, r, http.StatusTooManyRequests, "RATE_LIMITED", "too many requests")
 				return
 			}
@@ -77,6 +80,14 @@ func PerEndpointRateLimit(rdb *redis.Client, prefix string, limit int, window ti
 			next.ServeHTTP(w, r)
 		})
 	}
+}
+
+func incrementRateLimit(ctx context.Context, rdb *redis.Client, key string, window time.Duration) (int64, error) {
+	windowMillis := window.Milliseconds()
+	if window > 0 && windowMillis == 0 {
+		windowMillis = 1
+	}
+	return incrementRateLimitScript.Run(ctx, rdb, []string{key}, windowMillis).Int64()
 }
 
 func clientIP(r *http.Request) string {

--- a/backend/internal/middleware/ratelimit_test.go
+++ b/backend/internal/middleware/ratelimit_test.go
@@ -2,14 +2,17 @@ package middleware
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/alicebob/miniredis/v2"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/redis/go-redis/v9"
 )
 
@@ -32,6 +35,134 @@ func newTestRedis(t *testing.T) *redis.Client {
 		_ = rdb.Close()
 	})
 	return rdb
+}
+
+type failingCommandHook struct {
+	err      error
+	commands map[string]struct{}
+}
+
+func (h failingCommandHook) DialHook(next redis.DialHook) redis.DialHook {
+	return next
+}
+
+func (h failingCommandHook) ProcessHook(next redis.ProcessHook) redis.ProcessHook {
+	return func(ctx context.Context, cmd redis.Cmder) error {
+		if _, ok := h.commands[strings.ToLower(cmd.Name())]; ok {
+			return h.err
+		}
+		return next(ctx, cmd)
+	}
+}
+
+func (h failingCommandHook) ProcessPipelineHook(next redis.ProcessPipelineHook) redis.ProcessPipelineHook {
+	return func(ctx context.Context, cmds []redis.Cmder) error {
+		for _, cmd := range cmds {
+			if _, ok := h.commands[strings.ToLower(cmd.Name())]; ok {
+				return h.err
+			}
+		}
+		return next(ctx, cmds)
+	}
+}
+
+func TestRateLimitSetsTTLWhenStandaloneExpireFails(t *testing.T) {
+	tests := []struct {
+		name    string
+		key     string
+		handler func(*redis.Client) http.Handler
+	}{
+		{
+			name: "global",
+			key:  "ratelimit:192.0.2.20",
+			handler: func(rdb *redis.Client) http.Handler {
+				return RateLimit(rdb, 5, time.Minute)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					w.WriteHeader(http.StatusNoContent)
+				}))
+			},
+		},
+		{
+			name: "endpoint",
+			key:  "ratelimit:auth-login:192.0.2.20",
+			handler: func(rdb *redis.Client) http.Handler {
+				return PerEndpointRateLimit(rdb, "auth-login", 5, time.Minute)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					w.WriteHeader(http.StatusNoContent)
+				}))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rdb := newTestRedis(t)
+			rdb.AddHook(failingCommandHook{
+				err: errors.New("expire unavailable"),
+				commands: map[string]struct{}{
+					"expire":  {},
+					"pexpire": {},
+				},
+			})
+			handler := tt.handler(rdb)
+
+			req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+			req.RemoteAddr = "192.0.2.20:12345"
+			rec := httptest.NewRecorder()
+
+			handler.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusNoContent {
+				t.Fatalf("status = %d, want %d", rec.Code, http.StatusNoContent)
+			}
+
+			ttl, err := rdb.TTL(context.Background(), tt.key).Result()
+			if err != nil {
+				t.Fatalf("read ttl for %s: %v", tt.key, err)
+			}
+			if ttl <= 0 {
+				t.Fatalf("ttl for %s = %s, want a positive expiration", tt.key, ttl)
+			}
+		})
+	}
+}
+
+func TestPerEndpointRateLimitIncrementsBlockedMetric(t *testing.T) {
+	rdb := newTestRedis(t)
+	endpoint := "test-blocked-metric"
+	before := counterValue(t, rateLimitBlockedTotal.WithLabelValues(endpoint))
+
+	handler := PerEndpointRateLimit(rdb, endpoint, 1, time.Minute)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	for i := 0; i < 2; i++ {
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/login", nil)
+		req.RemoteAddr = "192.0.2.30:12345"
+		rec := httptest.NewRecorder()
+
+		handler.ServeHTTP(rec, req)
+
+		if i == 0 && rec.Code != http.StatusNoContent {
+			t.Fatalf("first request status = %d, want %d", rec.Code, http.StatusNoContent)
+		}
+		if i == 1 && rec.Code != http.StatusTooManyRequests {
+			t.Fatalf("blocked request status = %d, want %d", rec.Code, http.StatusTooManyRequests)
+		}
+	}
+
+	after := counterValue(t, rateLimitBlockedTotal.WithLabelValues(endpoint))
+	if got := after - before; got != 1 {
+		t.Fatalf("rate_limit_blocked_total increment = %v, want 1", got)
+	}
+}
+
+func counterValue(t *testing.T, metric interface{ Write(*dto.Metric) error }) float64 {
+	t.Helper()
+
+	var out dto.Metric
+	if err := metric.Write(&out); err != nil {
+		t.Fatalf("read metric value: %v", err)
+	}
+	return out.GetCounter().GetValue()
 }
 
 func TestPerEndpointRateLimitUsesDistinctPrefixes(t *testing.T) {


### PR DESCRIPTION
## Summary
- replace split Redis INCR/EXPIRE rate-limit updates with a single Redis script that sets the first counter TTL atomically
- add regression coverage proving counters still receive a TTL when standalone EXPIRE/PEXPIRE commands are unavailable
- register and increment the documented rate_limit_blocked_total counter for blocked global and per-endpoint limiter requests

Closes #181
Closes #187

## Verification
- go test ./internal/middleware -run TestRateLimitSetsTTLWhenStandaloneExpireFails -count=1
- go test ./internal/middleware -run TestPerEndpointRateLimitIncrementsBlockedMetric -count=1
- go test ./internal/middleware -count=1
- go test ./...
- go build ./cmd/server ./cmd/worker
- golangci-lint run ./...
- git diff --check