### PR TITLE
Handle missing API client revoke as not found

### DIFF
--- a/backend/internal/integrations/service.go
+++ b/backend/internal/integrations/service.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 
 	dbgen "github.com/stratahq/backend/db/gen"
@@ -157,6 +158,9 @@ func (s *Service) RevokeAPIClient(ctx context.Context, identity auth.Identity, c
 	}
 	row, err := s.db.Q.RevokeIntegrationAPIClient(ctx, dbgen.RevokeIntegrationAPIClientParams{ID: cid, OrgID: orgID})
 	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrNotFound
+		}
 		return nil, err
 	}
 	info, err := s.mapClient(ctx, row)


### PR DESCRIPTION
Closes #218\n\nThis maps pgx.ErrNoRows from RevokeIntegrationAPIClient to ErrNotFound so revoke returns 404 when the client is absent instead of a 500.\n\n