### PR TITLE
Reject invalid document visibility values

### DIFF
--- a/backend/internal/documents/service.go
+++ b/backend/internal/documents/service.go
@@ -153,6 +153,8 @@ func (s *Service) Create(ctx context.Context, identity auth.Identity, schemeID s
 		switch dbgen.DocumentVisibility(input.Visibility) {
 		case dbgen.DocumentVisibilityAll, dbgen.DocumentVisibilityTrustee, dbgen.DocumentVisibilityAdmin:
 			visibility = dbgen.DocumentVisibility(input.Visibility)
+		default:
+			return nil, ErrInvalidInput
 		}
 	}
 


### PR DESCRIPTION
Closes #195\n\nThis makes document uploads reject unknown visibility values with 400 instead of downgrading them to admin-only visibility.