### PR TITLE
Return bad request for invalid compliance item status and due-date inputs

### DIFF
--- a/backend/internal/compliance/handler.go
+++ b/backend/internal/compliance/handler.go
@@ -2,6 +2,7 @@ package compliance
 
 import (
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -95,9 +96,11 @@ func (h *Handler) CreateItem(w http.ResponseWriter, r *http.Request) {
 	var dueDate *time.Time
 	if req.DueDate != "" {
 		t, err := time.Parse("2006-01-02", req.DueDate)
-		if err == nil {
-			dueDate = &t
+		if err != nil {
+			response.Error(w, http.StatusBadRequest, response.CodeBadRequest, "invalid request")
+			return
 		}
+		dueDate = &t
 	}
 
 	item, err := h.service.CreateItem(r.Context(), identity, chi.URLParam(r, "schemeId"), CreateItemInput{
@@ -130,15 +133,25 @@ func (h *Handler) UpdateItem(w http.ResponseWriter, r *http.Request) {
 	}
 
 	input := UpdateItemInput{
-		Status:  req.Status,
-		Detail:  req.Detail,
-		Action:  req.Action,
+		Status: req.Status,
+		Detail: req.Detail,
+		Action: req.Action,
 	}
 	if req.DueDate != nil {
 		t, err := time.Parse("2006-01-02", *req.DueDate)
-		if err == nil {
-			input.DueDate = &t
+		if err != nil {
+			response.Error(w, http.StatusBadRequest, response.CodeBadRequest, "invalid request")
+			return
 		}
+		input.DueDate = &t
+	}
+	if req.Status != nil {
+		status := strings.TrimSpace(*req.Status)
+		if !validStatus(status) {
+			response.Error(w, http.StatusBadRequest, response.CodeBadRequest, "invalid request")
+			return
+		}
+		input.Status = &status
 	}
 
 	item, err := h.service.UpdateItem(r.Context(), identity, chi.URLParam(r, "schemeId"), chi.URLParam(r, "itemId"), input)


### PR DESCRIPTION
Closes #196\n\nThis makes compliance create/update handlers fail fast on invalid due-date formats and invalid status values instead of silently ignoring them.