### PR TITLE
Fix authenticated query stale data and dashboard error states

### DIFF
--- a/app/app/[schemeId]/financials/page.test.tsx
+++ b/app/app/[schemeId]/financials/page.test.tsx
@@ -141,4 +141,19 @@ describe("FinancialsPage predictive levy analytics", () => {
     });
     expect(mockUpsertBudgetLine).not.toHaveBeenCalled();
   });
+
+  it("shows a retry state instead of zero balances when the dashboard load fails", async () => {
+    mockUseAuthenticatedQuery.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new Error("backend unavailable"),
+      refetch: vi.fn(),
+    });
+    const { default: FinancialsPage } = await import("@/app/app/[schemeId]/financials/page");
+
+    render(<FinancialsPage />);
+
+    expect(screen.getByText("Could not load financial data")).toBeInTheDocument();
+    expect(screen.queryByText("Total budget")).not.toBeInTheDocument();
+  });
 });

--- a/app/app/[schemeId]/financials/page.tsx
+++ b/app/app/[schemeId]/financials/page.tsx
@@ -4,6 +4,7 @@ import { useMemo, useState } from 'react'
 import { useParams } from 'next/navigation'
 
 import Modal from '@/components/Modal'
+import RetryState from '@/components/RetryState'
 import { useAuth } from '@/lib/auth'
 import { invalidateCache } from '@/lib/data-cache'
 import { getFinancialDashboard, updateReserveFund, upsertBudgetLine } from '@/lib/financials-api'
@@ -77,7 +78,7 @@ export default function FinancialsPage() {
 
   const canManage = user?.role === 'admin' || user?.role === 'trustee'
 
-  const { data: dashboard, isLoading: loading } = useAuthenticatedQuery<FinancialDashboard>({
+  const { data: dashboard, isLoading: loading, error, refetch } = useAuthenticatedQuery<FinancialDashboard>({
     queryKey: schemeKeys.financials(schemeId, selectedPeriod || 'current'),
     queryFn: () => getFinancialDashboard(schemeId, selectedPeriod || undefined),
     staleTime: 30_000,
@@ -217,6 +218,16 @@ export default function FinancialsPage() {
           Loading financial dashboard…
         </div>
       </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <RetryState
+        title="Could not load financial data"
+        message="Temporary service issue. Try again."
+        onRetry={refetch}
+      />
     )
   }
 

--- a/app/app/[schemeId]/levy/page.test.tsx
+++ b/app/app/[schemeId]/levy/page.test.tsx
@@ -1,0 +1,101 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockUseAuth = vi.hoisted(() => vi.fn());
+const mockUseAuthenticatedQuery = vi.hoisted(() => vi.fn());
+const mockInvalidateCache = vi.hoisted(() => vi.fn());
+const mockInvalidateQueries = vi.hoisted(() => vi.fn());
+const mockRefetch = vi.hoisted(() => vi.fn());
+const mockAddToast = vi.hoisted(() => vi.fn());
+const mockGetDraft = vi.hoisted(() => vi.fn());
+const mockSendReminder = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/auth", () => ({ useAuth: mockUseAuth }));
+vi.mock("next/navigation", () => ({ useParams: vi.fn(() => ({ schemeId: "scheme-1" })) }));
+vi.mock("@/hooks/useAuthenticatedQuery", () => ({ useAuthenticatedQuery: mockUseAuthenticatedQuery }));
+vi.mock("@/lib/toast", () => ({ useToast: vi.fn(() => ({ addToast: mockAddToast })) }));
+vi.mock("@/lib/data-cache", () => ({ invalidateCache: mockInvalidateCache }));
+vi.mock("@/lib/query-client", () => ({ queryClient: { invalidateQueries: mockInvalidateQueries } }));
+vi.mock("@/lib/levy-api", () => ({
+  createLevyPeriod: vi.fn(),
+  getLevyDashboard: vi.fn(),
+  reconcileLevyPayments: vi.fn(),
+}));
+vi.mock("@/lib/attention-api", () => ({
+  getCollectionReminderDraft: mockGetDraft,
+  sendCollectionReminder: mockSendReminder,
+}));
+
+const dashboard = {
+  current_period: {
+    id: "period-1",
+    scheme_id: "scheme-1",
+    label: "May 2026",
+    due_date: "2026-05-01",
+    amount_cents: 250000,
+    created_at: "2026-04-01T00:00:00Z",
+  },
+  my_account: null,
+  collection_trend: [],
+  levy_roll: [
+    {
+      id: "account-1",
+      unit_id: "unit-1",
+      unit_identifier: "1A",
+      owner_name: "Rose Example",
+      period_id: "period-1",
+      amount_cents: 250000,
+      paid_cents: 0,
+      status: "overdue" as const,
+      due_date: "2026-05-01",
+      paid_date: null,
+    },
+  ],
+  my_payments: [],
+  role: "admin",
+  collection_rate_pct: 0,
+  overdue_count: 1,
+  total_collected_cents: 0,
+};
+
+describe("LevyPaymentsPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseAuth.mockReturnValue({ user: { role: "admin", scheme_memberships: [] } });
+    mockUseAuthenticatedQuery.mockReturnValue({
+      data: dashboard,
+      isLoading: false,
+      error: null,
+      refetch: mockRefetch,
+    });
+    mockGetDraft.mockResolvedValue({
+      account_id: "account-1",
+      scheme_id: "scheme-1",
+      scheme_name: "Rosewood Estate",
+      unit_label: "Unit 1A",
+      owner_name: "Rose Example",
+      email: { enabled: true, to: "rose@example.com", subject: "Reminder", body: "Email body" },
+      whatsapp: { enabled: false, to: "", body: "", disabled_reason: "No WhatsApp connection" },
+    });
+    mockSendReminder.mockResolvedValue({ event_type: "reminder_sent" });
+  });
+
+  it("opens the collection reminder workflow from an overdue levy account", async () => {
+    const { default: LevyPaymentsPage } = await import("@/app/app/[schemeId]/levy/page");
+
+    render(<LevyPaymentsPage />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Remind" }));
+
+    expect(await screen.findByText("Send reminder")).toBeInTheDocument();
+    expect(await screen.findByDisplayValue("Email body")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Send reminder" }));
+
+    await waitFor(() => {
+      expect(mockSendReminder).toHaveBeenCalledWith("scheme-1", "account-1", {
+        email: { enabled: true, subject: "Reminder", body: "Email body" },
+        whatsapp: { enabled: false, body: "" },
+      });
+    });
+  });
+});

--- a/app/app/[schemeId]/levy/page.tsx
+++ b/app/app/[schemeId]/levy/page.tsx
@@ -6,6 +6,7 @@ import { useParams } from 'next/navigation'
 import Modal from '@/components/Modal'
 import ReconcileModal from '@/components/ReconcileModal'
 import BankStatementImportModal from '@/components/BankStatementImportModal'
+import CollectionExecutionModal from '@/components/CollectionExecutionModal'
 import RetryState from '@/components/RetryState'
 import { useAuth } from '@/lib/auth'
 import { invalidateCache } from '@/lib/data-cache'
@@ -46,6 +47,7 @@ export default function LevyPaymentsPage() {
   const [createOpen, setCreateOpen] = useState(false)
   const [creatingPeriod, setCreatingPeriod] = useState(false)
   const [reconciling, setReconciling] = useState(false)
+  const [reminderAccountId, setReminderAccountId] = useState<string | null>(null)
   const [periodForm, setPeriodForm] = useState(EMPTY_PERIOD_FORM)
 
   const isResident = user?.role === 'resident'
@@ -319,7 +321,7 @@ export default function LevyPaymentsPage() {
                         {account.status.charAt(0).toUpperCase() + account.status.slice(1)}
                       </span>
                       {account.status === 'overdue' && (
-                        <button onClick={() => addToast(`Reminder delivery will be wired with communications. Unit ${account.unit_identifier} flagged for follow-up.`, 'info')} className="text-[11px] text-accent font-medium hover:underline">
+                        <button onClick={() => setReminderAccountId(account.id)} className="text-[11px] text-accent font-medium hover:underline">
                           Remind
                         </button>
                       )}
@@ -407,6 +409,16 @@ export default function LevyPaymentsPage() {
             refreshDashboard()
           }}
           onClose={() => setImportOpen(false)}
+        />
+      )}
+
+      {reminderAccountId && (
+        <CollectionExecutionModal
+          open={true}
+          schemeId={schemeId}
+          accountId={reminderAccountId}
+          onClose={() => setReminderAccountId(null)}
+          onSent={refreshDashboard}
         />
       )}
     </div>

--- a/app/app/[schemeId]/whatsapp/page.test.tsx
+++ b/app/app/[schemeId]/whatsapp/page.test.tsx
@@ -1,10 +1,11 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 
 const mockUseAuth = vi.hoisted(() => vi.fn());
 const mockGetCached = vi.hoisted(() => vi.fn());
 const mockSetCached = vi.hoisted(() => vi.fn());
 const mockInvalidateCache = vi.hoisted(() => vi.fn());
+const mockGetWhatsAppDashboard = vi.hoisted(() => vi.fn());
 
 vi.mock("@/lib/auth", () => ({
   useAuth: mockUseAuth,
@@ -23,6 +24,13 @@ vi.mock("@/lib/data-cache", () => ({
   getCached: mockGetCached,
   setCached: mockSetCached,
   invalidateCache: mockInvalidateCache,
+}));
+
+vi.mock("@/lib/whatsapp-api", () => ({
+  createMaintenanceRequestFromWhatsAppMessage: vi.fn(),
+  createWhatsAppBroadcast: vi.fn(),
+  dismissWhatsAppMaintenanceIntake: vi.fn(),
+  getWhatsAppDashboard: mockGetWhatsAppDashboard,
 }));
 
 const mockDashboard = {
@@ -103,6 +111,7 @@ describe("WhatsAppPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockGetCached.mockReturnValue(mockDashboard);
+    mockGetWhatsAppDashboard.mockResolvedValue(mockDashboard);
     mockUseAuth.mockReturnValue({ user: { id: "user-1", role: "admin" } });
   });
 
@@ -168,5 +177,19 @@ describe("WhatsAppPage", () => {
     render(<WhatsAppPage />);
 
     expect(screen.getByText("No messages yet")).toBeInTheDocument();
+  });
+
+  it("shows a retry state when the dashboard request fails without cached data", async () => {
+    mockGetCached.mockReturnValue(null);
+    mockGetWhatsAppDashboard.mockRejectedValueOnce(new Error("service unavailable"));
+
+    const { default: WhatsAppPage } = await import("@/app/app/[schemeId]/whatsapp/page");
+    render(<WhatsAppPage />);
+
+    expect(await screen.findByText("Could not load WhatsApp data")).toBeInTheDocument();
+    expect(screen.queryByText("Loading WhatsApp…")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+
+    await waitFor(() => expect(mockGetWhatsAppDashboard).toHaveBeenCalledTimes(2));
   });
 });

--- a/app/app/[schemeId]/whatsapp/page.tsx
+++ b/app/app/[schemeId]/whatsapp/page.tsx
@@ -1,9 +1,10 @@
 'use client'
 
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { useParams } from 'next/navigation'
 
 import Modal from '@/components/Modal'
+import RetryState from '@/components/RetryState'
 import { useAuth } from '@/lib/auth'
 import { getCached, invalidateCache, setCached } from '@/lib/data-cache'
 import { useToast } from '@/lib/toast'
@@ -505,11 +506,17 @@ function OperatorView({
 export default function WhatsAppPage() {
   const { user } = useAuth()
   const { addToast } = useToast()
+  const addToastRef = useRef(addToast)
   const params = useParams()
   const schemeId = params.schemeId as string
 
   const [dashboard, setDashboard] = useState<WhatsAppDashboard | null>(null)
   const [loading, setLoading] = useState(true)
+  const [loadError, setLoadError] = useState('')
+
+  useEffect(() => {
+    addToastRef.current = addToast
+  }, [addToast])
 
   const loadDashboard = useCallback(async (invalidate = false) => {
     const userId = user?.id
@@ -527,24 +534,34 @@ export default function WhatsAppPage() {
     }
     try {
       setLoading(true)
+      setLoadError('')
       const result = await getWhatsAppDashboard(schemeId)
       setCached(key, result)
       setDashboard(result)
     } catch (error) {
-      addToast(
-        error instanceof Error ? error.message : 'Failed to load WhatsApp dashboard',
-        'error',
-      )
+      const message = error instanceof Error ? error.message : 'Failed to load WhatsApp dashboard'
+      setDashboard(null)
+      setLoadError(message)
+      addToastRef.current(message, 'error')
     } finally {
       setLoading(false)
     }
-  }, [addToast, schemeId, user?.id])
+  }, [schemeId, user?.id])
 
   useEffect(() => {
     loadDashboard()
   }, [loadDashboard])
 
   if (loading || !dashboard) {
+    if (loadError) {
+      return (
+        <RetryState
+          title="Could not load WhatsApp data"
+          message={loadError}
+          onRetry={() => loadDashboard(true)}
+        />
+      )
+    }
     return (
       <div className="px-4 py-6 sm:px-8 sm:py-8 max-w-[900px]">
         <div className="bg-surface border border-border rounded-lg px-6 py-12 text-center text-muted text-[14px]">

--- a/components/CollectionExecutionModal.test.tsx
+++ b/components/CollectionExecutionModal.test.tsx
@@ -1,22 +1,36 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import CollectionExecutionModal from "./CollectionExecutionModal";
 
+const mockGetCollectionReminderDraft = vi.hoisted(() => vi.fn());
+const mockSendCollectionReminder = vi.hoisted(() => vi.fn());
+const mockAddToast = vi.hoisted(() => vi.fn());
+
 vi.mock("@/lib/attention-api", () => ({
-  getCollectionReminderDraft: vi.fn().mockResolvedValue({
-    account_id: "acc-1",
-    scheme_id: "scheme-1",
-    scheme_name: "Rosewood Estate",
-    unit_label: "Unit 5C",
-    owner_name: "Rose Example",
-    email: { enabled: true, to: "rose@example.com", subject: "Levy arrears reminder for Rosewood Estate", body: "Email body" },
-    whatsapp: { enabled: true, to: "+27715550101", body: "WhatsApp body" },
-  }),
-  sendCollectionReminder: vi.fn().mockResolvedValue({ event_type: "reminder_sent" }),
+  getCollectionReminderDraft: mockGetCollectionReminderDraft,
+  sendCollectionReminder: mockSendCollectionReminder,
+}));
+
+vi.mock("@/lib/toast", () => ({
+  useToast: vi.fn(() => ({ addToast: mockAddToast })),
 }));
 
 describe("CollectionExecutionModal", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetCollectionReminderDraft.mockResolvedValue({
+      account_id: "acc-1",
+      scheme_id: "scheme-1",
+      scheme_name: "Rosewood Estate",
+      unit_label: "Unit 5C",
+      owner_name: "Rose Example",
+      email: { enabled: true, to: "rose@example.com", subject: "Levy arrears reminder for Rosewood Estate", body: "Email body" },
+      whatsapp: { enabled: true, to: "+27715550101", body: "WhatsApp body" },
+    });
+    mockSendCollectionReminder.mockResolvedValue({ event_type: "reminder_sent" });
+  });
+
   it("loads the reminder draft and submits edited email and WhatsApp bodies", async () => {
     const onSent = vi.fn();
 
@@ -35,5 +49,22 @@ describe("CollectionExecutionModal", () => {
     fireEvent.click(screen.getByRole("button", { name: /send reminder/i }));
 
     await waitFor(() => expect(onSent).toHaveBeenCalled());
+  });
+
+  it("shows a retryable error when the reminder draft cannot load", async () => {
+    mockGetCollectionReminderDraft.mockRejectedValueOnce(new Error("draft unavailable"));
+
+    render(
+      <CollectionExecutionModal
+        open={true}
+        schemeId="scheme-1"
+        accountId="acc-1"
+        onClose={vi.fn()}
+        onSent={vi.fn()}
+      />
+    );
+
+    expect(await screen.findByText("Could not load reminder draft")).toBeInTheDocument();
+    expect(screen.queryByText("Loading reminder draft…")).not.toBeInTheDocument();
   });
 });

--- a/components/CollectionExecutionModal.tsx
+++ b/components/CollectionExecutionModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import Modal from "@/components/Modal";
 import { useToast } from "@/lib/toast";
 import { getCollectionReminderDraft, sendCollectionReminder } from "@/lib/attention-api";
@@ -20,15 +20,35 @@ export default function CollectionExecutionModal({
   onSent: () => void;
 }) {
   const { addToast } = useToast();
+  const addToastRef = useRef(addToast);
   const [draft, setDraft] = useState<ReminderDraft | null>(null);
+  const [loadError, setLoadError] = useState("");
+  const [loading, setLoading] = useState(false);
   const [sending, setSending] = useState(false);
 
   useEffect(() => {
+    addToastRef.current = addToast;
+  }, [addToast]);
+
+  const loadDraft = useCallback(async () => {
+    setLoading(true);
+    setLoadError("");
+    setDraft(null);
+    try {
+      setDraft(await getCollectionReminderDraft(schemeId, accountId));
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Failed to load reminder draft";
+      setLoadError(message);
+      addToastRef.current(message, "error");
+    } finally {
+      setLoading(false);
+    }
+  }, [accountId, schemeId]);
+
+  useEffect(() => {
     if (!open) return;
-    getCollectionReminderDraft(schemeId, accountId)
-      .then(setDraft)
-      .catch((error) => addToast(error instanceof Error ? error.message : "Failed to load reminder draft", "error"));
-  }, [open, schemeId, accountId, addToast]);
+    void loadDraft();
+  }, [loadDraft, open]);
 
   async function handleSend() {
     if (!draft) return;
@@ -57,7 +77,19 @@ export default function CollectionExecutionModal({
 
   return (
     <Modal open={open} onClose={() => !sending && onClose()} title="Send reminder">
-      {!draft ? (
+      {loadError ? (
+        <div className="space-y-3 py-6 text-center">
+          <p className="text-sm font-semibold text-ink">Could not load reminder draft</p>
+          <p className="text-xs text-muted">{loadError}</p>
+          <button
+            onClick={loadDraft}
+            disabled={loading}
+            className="rounded-lg bg-ink px-4 py-2 text-sm font-semibold text-white disabled:opacity-40"
+          >
+            {loading ? "Retrying…" : "Try again"}
+          </button>
+        </div>
+      ) : !draft ? (
         <div className="py-8 text-center text-sm text-muted">Loading reminder draft…</div>
       ) : (
         <div className="space-y-4">

--- a/hooks/useAuthenticatedQuery.test.tsx
+++ b/hooks/useAuthenticatedQuery.test.tsx
@@ -1,0 +1,26 @@
+import { describe, expect, it, vi } from "vitest";
+
+const mockUseQuery = vi.hoisted(() => vi.fn());
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: mockUseQuery,
+}));
+
+describe("useAuthenticatedQuery", () => {
+  it("does not carry previous data across different authenticated query keys by default", async () => {
+    const { useAuthenticatedQuery } = await import("./useAuthenticatedQuery");
+    const queryFn = vi.fn();
+
+    useAuthenticatedQuery({
+      queryKey: ["scheme", "scheme-1", "financials"],
+      queryFn,
+      staleTime: 30_000,
+    });
+
+    expect(mockUseQuery).toHaveBeenCalledWith({
+      queryKey: ["scheme", "scheme-1", "financials"],
+      queryFn,
+      staleTime: 30_000,
+    });
+  });
+});

--- a/hooks/useAuthenticatedQuery.ts
+++ b/hooks/useAuthenticatedQuery.ts
@@ -15,7 +15,6 @@ export function useAuthenticatedQuery<T>(
   return useQuery<T>({
     queryKey,
     queryFn,
-    placeholderData: (previousData) => previousData,
     ...rest,
   });
 }


### PR DESCRIPTION
## Summary
- Removes default previous-data placeholders from authenticated queries so scheme/filter switches do not render stale records.
- Shows retry states for failed financials and WhatsApp dashboard loads instead of zero/old/loading views.
- Adds a retryable collection reminder draft error state and wires Levy Roll Remind into the existing reminder modal.

Fixes #276.
Fixes #235.
Fixes #239.
Fixes #238.
Fixes #263.

## Test Plan
- `npm test -- hooks/useAuthenticatedQuery.test.tsx app/app/'[schemeId]'/financials/page.test.tsx components/CollectionExecutionModal.test.tsx app/app/'[schemeId]'/whatsapp/page.test.tsx app/app/'[schemeId]'/levy/page.test.tsx`
- `npm run lint`
- `npm run typecheck`
- `npm test`

No merge performed.