### PR TITLE
Guard AGM scheduling and levy period creation

### DIFF
--- a/backend/internal/agm/service.go
+++ b/backend/internal/agm/service.go
@@ -152,14 +152,11 @@ func (s *Service) ScheduleMeeting(ctx context.Context, identity auth.Identity, s
 	if !auth.IsAdminRole(access.role) {
 		return nil, ErrForbidden
 	}
-	if input.MeetingDate.IsZero() || input.QuorumRequired <= 0 {
-		return nil, ErrInvalidInput
-	}
 	totalEligible, err := s.totalEligibleVoters(ctx, access.scheme.ID)
 	if err != nil {
 		return nil, err
 	}
-	if totalEligible <= 0 || input.QuorumRequired > totalEligible {
+	if err := validateScheduleMeetingInput(input, totalEligible); err != nil {
 		return nil, ErrInvalidInput
 	}
 
@@ -180,9 +177,6 @@ func (s *Service) ScheduleMeeting(ctx context.Context, identity auth.Identity, s
 	}
 
 	for _, resolution := range input.Resolutions {
-		if strings.TrimSpace(resolution.Title) == "" || strings.TrimSpace(resolution.Description) == "" {
-			return nil, ErrInvalidInput
-		}
 		if _, createErr := q.CreateAgmResolution(ctx, dbgen.CreateAgmResolutionParams{
 			MeetingID:     meeting.ID,
 			Title:         strings.TrimSpace(resolution.Title),
@@ -509,7 +503,35 @@ func (s *Service) totalEligibleVoters(ctx context.Context, schemeID uuid.UUID) (
 	if err != nil {
 		return 0, err
 	}
-	return int32(len(members)), nil
+	return eligibleVoterCount(members), nil
+}
+
+func eligibleVoterCount(members []dbgen.ListSchemeMembersBySchemeRow) int32 {
+	var total int32
+	for _, member := range members {
+		if member.Role == string(auth.RoleTrustee) || member.Role == string(auth.RoleResident) {
+			total++
+		}
+	}
+	return total
+}
+
+func validateScheduleMeetingInput(input ScheduleMeetingInput, totalEligible int32) error {
+	if input.MeetingDate.IsZero() || input.QuorumRequired <= 0 {
+		return ErrInvalidInput
+	}
+	if totalEligible <= 0 || input.QuorumRequired > totalEligible {
+		return ErrInvalidInput
+	}
+	if len(input.Resolutions) == 0 {
+		return ErrInvalidInput
+	}
+	for _, resolution := range input.Resolutions {
+		if strings.TrimSpace(resolution.Title) == "" || strings.TrimSpace(resolution.Description) == "" {
+			return ErrInvalidInput
+		}
+	}
+	return nil
 }
 
 func (s *Service) resolveAccess(ctx context.Context, identity auth.Identity, schemeID string) (*accessInfo, error) {

--- a/backend/internal/agm/service.go
+++ b/backend/internal/agm/service.go
@@ -156,7 +156,7 @@ func (s *Service) ScheduleMeeting(ctx context.Context, identity auth.Identity, s
 	if err != nil {
 		return nil, err
 	}
-	if err := validateScheduleMeetingInput(input, totalEligible); err != nil {
+	if validationErr := validateScheduleMeetingInput(input, totalEligible); validationErr != nil {
 		return nil, ErrInvalidInput
 	}
 

--- a/backend/internal/agm/service_test.go
+++ b/backend/internal/agm/service_test.go
@@ -2,10 +2,12 @@ package agm
 
 import (
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 
 	dbgen "github.com/stratahq/backend/db/gen"
+	"github.com/stratahq/backend/internal/auth"
 )
 
 func TestCalculateVoteTotalsCountsDelegatedVotes(t *testing.T) {
@@ -71,5 +73,57 @@ func TestAgmVoteAuditEvent(t *testing.T) {
 	}
 	if event.ResourceType != "agm_resolution" {
 		t.Fatalf("resource type = %q, want agm_resolution", event.ResourceType)
+	}
+}
+
+func TestEligibleVoterCountExcludesAdmins(t *testing.T) {
+	members := []dbgen.ListSchemeMembersBySchemeRow{
+		{Role: string(auth.RoleAdmin)},
+		{Role: string(auth.RoleTrustee)},
+		{Role: string(auth.RoleResident)},
+	}
+
+	if got := eligibleVoterCount(members); got != 2 {
+		t.Fatalf("eligibleVoterCount() = %d, want 2", got)
+	}
+}
+
+func TestValidateScheduleMeetingInputRequiresResolution(t *testing.T) {
+	err := validateScheduleMeetingInput(ScheduleMeetingInput{
+		MeetingDate:    time.Now().Add(24 * time.Hour),
+		QuorumRequired: 1,
+		Resolutions:    []ScheduleResolutionInput{},
+	}, 1)
+
+	if err != ErrInvalidInput {
+		t.Fatalf("validateScheduleMeetingInput() error = %v, want ErrInvalidInput", err)
+	}
+}
+
+func TestValidateScheduleMeetingInputRejectsBlankResolution(t *testing.T) {
+	err := validateScheduleMeetingInput(ScheduleMeetingInput{
+		MeetingDate:    time.Now().Add(24 * time.Hour),
+		QuorumRequired: 1,
+		Resolutions: []ScheduleResolutionInput{
+			{Title: "  ", Description: "Approve budget"},
+		},
+	}, 1)
+
+	if err != ErrInvalidInput {
+		t.Fatalf("validateScheduleMeetingInput() error = %v, want ErrInvalidInput", err)
+	}
+}
+
+func TestValidateScheduleMeetingInputAcceptsVotingMembersOnlyQuorum(t *testing.T) {
+	err := validateScheduleMeetingInput(ScheduleMeetingInput{
+		MeetingDate:    time.Now().Add(24 * time.Hour),
+		QuorumRequired: 2,
+		Resolutions: []ScheduleResolutionInput{
+			{Title: "Approve budget", Description: "Approve the annual budget"},
+		},
+	}, 2)
+
+	if err != nil {
+		t.Fatalf("validateScheduleMeetingInput() error = %v, want nil", err)
 	}
 }

--- a/backend/internal/levy/service.go
+++ b/backend/internal/levy/service.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -274,6 +275,18 @@ func (s *Service) CreatePeriod(ctx context.Context, identity auth.Identity, sche
 		return nil, ErrInvalidInput
 	}
 
+	units, err := s.db.Q.ListUnitsByScheme(ctx, scheme.ID)
+	if err != nil {
+		return nil, err
+	}
+	periods, err := s.db.Q.ListLevyPeriodsByScheme(ctx, scheme.ID)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateCreatePeriodInput(input, len(units), periods); err != nil {
+		return nil, err
+	}
+
 	tx, err := s.db.Begin(ctx)
 	if err != nil {
 		return nil, err
@@ -293,10 +306,6 @@ func (s *Service) CreatePeriod(ctx context.Context, identity auth.Identity, sche
 		return nil, err
 	}
 
-	units, err := q.ListUnitsByScheme(ctx, scheme.ID)
-	if err != nil {
-		return nil, err
-	}
 	for _, unit := range units {
 		if _, err := q.CreateLevyAccount(ctx, dbgen.CreateLevyAccountParams{
 			UnitID:      unit.ID,
@@ -329,6 +338,23 @@ func (s *Service) CreatePeriod(ctx context.Context, identity auth.Identity, sche
 	}
 
 	return &created, nil
+}
+
+func validateCreatePeriodInput(input CreatePeriodInput, unitCount int, existing []dbgen.LevyPeriod) error {
+	if strings.TrimSpace(input.Label) == "" || input.AmountCents <= 0 || input.DueDate.IsZero() {
+		return ErrInvalidInput
+	}
+	if unitCount <= 0 {
+		return ErrInvalidInput
+	}
+
+	label := strings.TrimSpace(input.Label)
+	for _, period := range existing {
+		if strings.EqualFold(strings.TrimSpace(period.Label), label) {
+			return ErrInvalidInput
+		}
+	}
+	return nil
 }
 
 func (s *Service) Reconcile(ctx context.Context, identity auth.Identity, schemeID string, payments []ReconcilePaymentInput) (*ReconcileResult, error) {

--- a/backend/internal/levy/service.go
+++ b/backend/internal/levy/service.go
@@ -283,8 +283,8 @@ func (s *Service) CreatePeriod(ctx context.Context, identity auth.Identity, sche
 	if err != nil {
 		return nil, err
 	}
-	if err := validateCreatePeriodInput(input, len(units), periods); err != nil {
-		return nil, err
+	if validationErr := validateCreatePeriodInput(input, len(units), periods); validationErr != nil {
+		return nil, validationErr
 	}
 
 	tx, err := s.db.Begin(ctx)

--- a/backend/internal/levy/service_test.go
+++ b/backend/internal/levy/service_test.go
@@ -1,6 +1,14 @@
 package levy
 
-import "testing"
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	dbgen "github.com/stratahq/backend/db/gen"
+)
 
 func TestLevyPeriodCreatedAuditEvent(t *testing.T) {
 	event := levyPeriodCreatedAuditEvent(levyPeriodAuditInput{
@@ -47,5 +55,45 @@ func TestLevyReconciledAuditEvent(t *testing.T) {
 	}
 	if metadata["skipped_count"] != 1 {
 		t.Fatalf("skipped count = %v, want 1", metadata["skipped_count"])
+	}
+}
+
+func TestValidateCreatePeriodGuardsEmptyUnitRegister(t *testing.T) {
+	err := validateCreatePeriodInput(CreatePeriodInput{
+		Label:       "May 2026",
+		AmountCents: 250000,
+		DueDate:     time.Now(),
+	}, 0, nil)
+
+	if err != ErrInvalidInput {
+		t.Fatalf("validateCreatePeriodInput() error = %v, want ErrInvalidInput", err)
+	}
+}
+
+func TestValidateCreatePeriodGuardsDuplicatePeriodLabel(t *testing.T) {
+	err := validateCreatePeriodInput(CreatePeriodInput{
+		Label:       "May 2026",
+		AmountCents: 250000,
+		DueDate:     time.Now(),
+	}, 1, []dbgen.LevyPeriod{
+		{ID: uuid.New(), Label: "May 2026", DueDate: pgtype.Date{Time: time.Now(), Valid: true}},
+	})
+
+	if err != ErrInvalidInput {
+		t.Fatalf("validateCreatePeriodInput() error = %v, want ErrInvalidInput", err)
+	}
+}
+
+func TestValidateCreatePeriodAllowsDistinctPeriodWithUnits(t *testing.T) {
+	err := validateCreatePeriodInput(CreatePeriodInput{
+		Label:       "June 2026",
+		AmountCents: 250000,
+		DueDate:     time.Now(),
+	}, 1, []dbgen.LevyPeriod{
+		{ID: uuid.New(), Label: "May 2026", DueDate: pgtype.Date{Time: time.Now(), Valid: true}},
+	})
+
+	if err != nil {
+		t.Fatalf("validateCreatePeriodInput() error = %v, want nil", err)
 	}
 }


### PR DESCRIPTION
## Summary
- Counts only trustee/resident memberships as AGM eligible voters, excluding non-voting admins.
- Rejects AGM meetings with no resolutions or blank resolution fields before creating the meeting.
- Rejects levy period creation when a scheme has no units or already has a matching period label.

Fixes #271.
Fixes #243.
Fixes #261.
Fixes #256.

## Test Plan
- `go test ./internal/agm ./internal/levy`
- `go test -count=1 ./internal/agm ./internal/levy`
- `go test ./internal/...`

No merge performed.