### PR TITLE
Fix financial period selection and Copilot budget context

### DIFF
--- a/backend/internal/ai/service.go
+++ b/backend/internal/ai/service.go
@@ -487,20 +487,22 @@ func mapNotices(notices []dbgen.Notice, limit int) []map[string]any {
 func mapFinancials(lines []dbgen.BudgetLine, hasReserve bool, reserve dbgen.ReserveFund) map[string]any {
 	periods := make([]string, 0, len(lines))
 	seen := map[string]struct{}{}
-	var totalBudgeted int64
-	var totalActual int64
 	for _, line := range lines {
-		totalBudgeted += line.BudgetedCents
-		totalActual += line.ActualCents
 		if _, ok := seen[line.PeriodLabel]; !ok {
 			seen[line.PeriodLabel] = struct{}{}
 			periods = append(periods, line.PeriodLabel)
 		}
 	}
-	sort.Sort(sort.Reverse(sort.StringSlice(periods)))
+	sortPeriodLabelsDesc(periods)
+	selected := ""
+	if len(periods) > 0 {
+		selected = periods[0]
+	}
+	selectedLines, totalBudgeted, totalActual := budgetLinesForPeriod(lines, selected, 8)
 	payload := map[string]any{
 		"budget_periods":       periods,
-		"budget_lines":         mapBudgetLines(lines, 8),
+		"selected_period":      selected,
+		"budget_lines":         selectedLines,
 		"total_budgeted_cents": totalBudgeted,
 		"total_actual_cents":   totalActual,
 	}
@@ -512,6 +514,21 @@ func mapFinancials(lines []dbgen.BudgetLine, hasReserve bool, reserve dbgen.Rese
 		}
 	}
 	return payload
+}
+
+func budgetLinesForPeriod(lines []dbgen.BudgetLine, period string, limit int) ([]map[string]any, int64, int64) {
+	filtered := make([]dbgen.BudgetLine, 0, len(lines))
+	var totalBudgeted int64
+	var totalActual int64
+	for _, line := range lines {
+		if line.PeriodLabel != period {
+			continue
+		}
+		filtered = append(filtered, line)
+		totalBudgeted += line.BudgetedCents
+		totalActual += line.ActualCents
+	}
+	return mapBudgetLines(filtered, limit), totalBudgeted, totalActual
 }
 
 func mapBudgetLines(lines []dbgen.BudgetLine, limit int) []map[string]any {
@@ -529,6 +546,35 @@ func mapBudgetLines(lines []dbgen.BudgetLine, limit int) []map[string]any {
 		})
 	}
 	return items
+}
+
+func sortPeriodLabelsDesc(periods []string) {
+	sort.Slice(periods, func(i, j int) bool {
+		aDate, aOK := parsePeriodLabel(periods[i])
+		bDate, bOK := parsePeriodLabel(periods[j])
+		switch {
+		case aOK && bOK:
+			return aDate.After(bDate)
+		case aOK:
+			return true
+		case bOK:
+			return false
+		default:
+			return periods[i] > periods[j]
+		}
+	})
+}
+
+func parsePeriodLabel(label string) (time.Time, bool) {
+	label = strings.TrimSpace(label)
+	layouts := []string{"January 2006", "Jan 2006", "2006-01", "2006"}
+	for _, layout := range layouts {
+		parsed, err := time.Parse(layout, label)
+		if err == nil {
+			return parsed, true
+		}
+	}
+	return time.Time{}, false
 }
 
 func mapResolutions(resolutions []dbgen.AgmResolution, limit int) []map[string]any {

--- a/backend/internal/ai/service_test.go
+++ b/backend/internal/ai/service_test.go
@@ -120,3 +120,27 @@ func TestMapMaintenanceRedactsContractorName(t *testing.T) {
 		t.Fatalf("mapMaintenance() leaked contractor_name: %+v", items[0])
 	}
 }
+
+func TestMapFinancialsScopesTotalsToCurrentBudgetPeriod(t *testing.T) {
+	lines := []dbgen.BudgetLine{
+		{PeriodLabel: "October 2025", Category: "Maintenance", BudgetedCents: 1000, ActualCents: 250},
+		{PeriodLabel: "September 2026", Category: "Maintenance", BudgetedCents: 5000, ActualCents: 1000},
+		{PeriodLabel: "September 2026", Category: "Insurance", BudgetedCents: 7000, ActualCents: 3000},
+	}
+
+	payload := mapFinancials(lines, false, dbgen.ReserveFund{})
+
+	if payload["selected_period"] != "September 2026" {
+		t.Fatalf("selected_period = %v, want September 2026", payload["selected_period"])
+	}
+	if payload["total_budgeted_cents"] != int64(12000) || payload["total_actual_cents"] != int64(4000) {
+		t.Fatalf("totals = (%v, %v), want (12000, 4000)", payload["total_budgeted_cents"], payload["total_actual_cents"])
+	}
+	budgetLines, ok := payload["budget_lines"].([]map[string]any)
+	if !ok {
+		t.Fatalf("budget_lines type = %T", payload["budget_lines"])
+	}
+	if len(budgetLines) != 2 {
+		t.Fatalf("budget_lines len = %d, want 2: %#v", len(budgetLines), budgetLines)
+	}
+}

--- a/backend/internal/financials/service.go
+++ b/backend/internal/financials/service.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"math"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -147,34 +148,13 @@ func (s *Service) Dashboard(ctx context.Context, identity auth.Identity, schemeI
 	}
 
 	if len(allLines) > 0 {
-		periods := make([]string, 0, len(allLines))
-		seen := make(map[string]struct{}, len(allLines))
-		for _, line := range allLines {
-			if _, ok := seen[line.PeriodLabel]; ok {
-				continue
-			}
-			seen[line.PeriodLabel] = struct{}{}
-			periods = append(periods, line.PeriodLabel)
-		}
-		slices.Sort(periods)
-		slices.Reverse(periods)
+		periods := budgetPeriods(allLines)
 		resp.AvailablePeriods = periods
 
-		selected := periodLabel
-		if selected == "" && len(periods) > 0 {
-			selected = periods[0]
-		}
+		selected := selectBudgetPeriod(periods, periodLabel)
 		resp.SelectedPeriod = selected
 
-		for _, line := range allLines {
-			if line.PeriodLabel != selected {
-				continue
-			}
-			mapped := mapBudgetLine(line)
-			resp.BudgetLines = append(resp.BudgetLines, mapped)
-			resp.TotalBudgetedCents += mapped.BudgetedCents
-			resp.TotalActualCents += mapped.ActualCents
-		}
+		resp.BudgetLines, resp.TotalBudgetedCents, resp.TotalActualCents = budgetLinesForPeriod(allLines, selected)
 		resp.SurplusCents = resp.TotalBudgetedCents - resp.TotalActualCents
 	}
 
@@ -203,6 +183,84 @@ func (s *Service) Dashboard(ctx context.Context, identity auth.Identity, schemeI
 	}
 
 	return resp, nil
+}
+
+func budgetPeriods(lines []dbgen.BudgetLine) []string {
+	periods := make([]string, 0, len(lines))
+	seen := make(map[string]struct{}, len(lines))
+	for _, line := range lines {
+		label := strings.TrimSpace(line.PeriodLabel)
+		if label == "" {
+			continue
+		}
+		if _, ok := seen[label]; ok {
+			continue
+		}
+		seen[label] = struct{}{}
+		periods = append(periods, label)
+	}
+	sortPeriodLabelsDesc(periods)
+	return periods
+}
+
+func selectBudgetPeriod(periods []string, requested string) string {
+	if len(periods) == 0 {
+		return ""
+	}
+	requested = strings.TrimSpace(requested)
+	if requested != "" {
+		for _, period := range periods {
+			if period == requested {
+				return requested
+			}
+		}
+	}
+	return periods[0]
+}
+
+func budgetLinesForPeriod(lines []dbgen.BudgetLine, period string) ([]BudgetLineInfo, int64, int64) {
+	items := []BudgetLineInfo{}
+	var totalBudgeted int64
+	var totalActual int64
+	for _, line := range lines {
+		if line.PeriodLabel != period {
+			continue
+		}
+		mapped := mapBudgetLine(line)
+		items = append(items, mapped)
+		totalBudgeted += mapped.BudgetedCents
+		totalActual += mapped.ActualCents
+	}
+	return items, totalBudgeted, totalActual
+}
+
+func sortPeriodLabelsDesc(periods []string) {
+	slices.SortFunc(periods, func(a, b string) int {
+		aDate, aOK := parsePeriodLabel(a)
+		bDate, bOK := parsePeriodLabel(b)
+		switch {
+		case aOK && bOK:
+			return bDate.Compare(aDate)
+		case aOK:
+			return -1
+		case bOK:
+			return 1
+		default:
+			return strings.Compare(b, a)
+		}
+	})
+}
+
+func parsePeriodLabel(label string) (time.Time, bool) {
+	label = strings.TrimSpace(label)
+	layouts := []string{"January 2006", "Jan 2006", "2006-01", "2006"}
+	for _, layout := range layouts {
+		parsed, err := time.Parse(layout, label)
+		if err == nil {
+			return parsed, true
+		}
+	}
+	return time.Time{}, false
 }
 
 func (s *Service) UpsertBudgetLine(ctx context.Context, identity auth.Identity, schemeID string, input UpsertBudgetLineInput) (*BudgetLineInfo, error) {

--- a/backend/internal/financials/service_test.go
+++ b/backend/internal/financials/service_test.go
@@ -1,0 +1,54 @@
+package financials
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	dbgen "github.com/stratahq/backend/db/gen"
+)
+
+func TestBudgetPeriodsSortByParsedPeriodDate(t *testing.T) {
+	periods := budgetPeriods([]dbgen.BudgetLine{
+		{PeriodLabel: "October 2025"},
+		{PeriodLabel: "September 2026"},
+		{PeriodLabel: "January 2026"},
+		{PeriodLabel: "October 2025"},
+	})
+
+	want := []string{"September 2026", "January 2026", "October 2025"}
+	if len(periods) != len(want) {
+		t.Fatalf("period count = %d, want %d: %#v", len(periods), len(want), periods)
+	}
+	for i := range want {
+		if periods[i] != want[i] {
+			t.Fatalf("periods[%d] = %q, want %q (all=%#v)", i, periods[i], want[i], periods)
+		}
+	}
+}
+
+func TestSelectBudgetPeriodFallsBackWhenRequestedPeriodDoesNotExist(t *testing.T) {
+	periods := []string{"September 2026", "January 2026"}
+
+	if got := selectBudgetPeriod(periods, "Not a period"); got != "September 2026" {
+		t.Fatalf("selected period = %q, want September 2026", got)
+	}
+}
+
+func TestBudgetTotalsOnlyUseSelectedPeriod(t *testing.T) {
+	schemeID := uuid.New()
+	lines := []dbgen.BudgetLine{
+		{ID: uuid.New(), SchemeID: schemeID, Category: "Maintenance", PeriodLabel: "September 2026", BudgetedCents: 1000, ActualCents: 250, CreatedAt: time.Now(), UpdatedAt: time.Now()},
+		{ID: uuid.New(), SchemeID: schemeID, Category: "Insurance", PeriodLabel: "January 2026", BudgetedCents: 9000, ActualCents: 8000, CreatedAt: time.Now(), UpdatedAt: time.Now()},
+	}
+
+	items, totalBudgeted, totalActual := budgetLinesForPeriod(lines, "September 2026")
+
+	if len(items) != 1 {
+		t.Fatalf("items = %d, want 1", len(items))
+	}
+	if totalBudgeted != 1000 || totalActual != 250 {
+		t.Fatalf("totals = (%d, %d), want (1000, 250)", totalBudgeted, totalActual)
+	}
+}


### PR DESCRIPTION
## Summary
- Sorts financial dashboard budget periods by parsed period date instead of raw lexicographic order.
- Falls back to the latest available period when an unknown period filter is requested instead of returning zero-value totals.
- Scopes Copilot financial budget lines and totals to the selected/current budget period instead of aggregating across every period.

Fixes #267.
Fixes #242.
Fixes #255.

## Test Plan
- `go test ./internal/financials ./internal/ai`
- `go test ./internal/...`

No merge performed.