### PR TITLE
Harden invitation lifecycle transitions

### DIFF
--- a/backend/internal/invitation/handler.go
+++ b/backend/internal/invitation/handler.go
@@ -154,6 +154,8 @@ func (h *Handler) Revoke(w http.ResponseWriter, r *http.Request) {
 			response.Error(w, http.StatusNotFound, response.CodeNotFound, "invitation not found")
 		case ErrForbidden:
 			response.Error(w, http.StatusForbidden, response.CodeForbidden, "invitation belongs to a different org")
+		case ErrInvalidToken:
+			response.Error(w, http.StatusConflict, response.CodeConflict, "only pending invitations can be revoked")
 		default:
 			response.Error(w, http.StatusInternalServerError, response.CodeInternalError, "failed to revoke invitation")
 		}

--- a/backend/internal/invitation/handler_test.go
+++ b/backend/internal/invitation/handler_test.go
@@ -14,6 +14,7 @@ import (
 type stubServicer struct {
 	createFn func(ctx context.Context, orgID string, p CreateParams, appBaseURL string) (*InvitationResponse, error)
 	resendFn func(context.Context, string, string, string) (*InvitationResponse, error)
+	revokeFn func(context.Context, string, string) error
 }
 
 func (s *stubServicer) Create(ctx context.Context, orgID string, p CreateParams, appBaseURL string) (*InvitationResponse, error) {
@@ -31,8 +32,11 @@ func (s *stubServicer) Resend(ctx context.Context, orgID string, invitationID st
 	return s.resendFn(ctx, orgID, invitationID, appBaseURL)
 }
 
-func (s *stubServicer) Revoke(context.Context, string, string) error {
-	panic("unexpected Revoke call")
+func (s *stubServicer) Revoke(ctx context.Context, orgID string, invitationID string) error {
+	if s.revokeFn == nil {
+		panic("unexpected Revoke call")
+	}
+	return s.revokeFn(ctx, orgID, invitationID)
 }
 
 func (s *stubServicer) Verify(context.Context, string) (*VerifyResponse, error) {
@@ -92,6 +96,35 @@ func TestHandlerResendReturnsConflictForNonPendingInvitation(t *testing.T) {
 	}
 	if payload.Error.Message != "only pending invitations can be resent" {
 		t.Fatalf("message = %q, want %q", payload.Error.Message, "only pending invitations can be resent")
+	}
+}
+
+func TestHandlerRevokeReturnsConflictForNonPendingInvitation(t *testing.T) {
+	h := NewHandler(&stubServicer{
+		revokeFn: func(context.Context, string, string) error {
+			return ErrInvalidToken
+		},
+	}, "http://localhost:3000")
+
+	req := httptest.NewRequest(http.MethodDelete, "/invitations/11111111-1111-1111-1111-111111111111", nil)
+	req = req.WithContext(auth.ContextWithIdentity(req.Context(), "00000000-0000-0000-0000-000000000003", "00000000-0000-0000-0000-000000000004", string(auth.RoleAdmin)))
+	w := httptest.NewRecorder()
+
+	h.Revoke(w, req)
+	if w.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusConflict)
+	}
+
+	var payload struct {
+		Error struct {
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&payload); err != nil {
+		t.Fatalf("response decode: %v", err)
+	}
+	if payload.Error.Message != "only pending invitations can be revoked" {
+		t.Fatalf("message = %q, want %q", payload.Error.Message, "only pending invitations can be revoked")
 	}
 }
 

--- a/backend/internal/invitation/service.go
+++ b/backend/internal/invitation/service.go
@@ -324,6 +324,9 @@ func (s *Service) Revoke(ctx context.Context, orgID, invitationID string) error 
 	if existing.OrgID != oid {
 		return ErrForbidden
 	}
+	if existing.Status != "pending" {
+		return ErrInvalidToken
+	}
 
 	if err := s.q.UpdateInvitationStatus(ctx, dbgen.UpdateInvitationStatusParams{
 		Status: "revoked",
@@ -421,10 +424,7 @@ func (s *Service) Accept(ctx context.Context, token, password string) (*auth.Aut
 		if txErr != nil {
 			return txErr
 		}
-		return q.UpdateInvitationStatus(ctx, dbgen.UpdateInvitationStatusParams{
-			Status: "accepted",
-			ID:     inv.ID,
-		})
+		return nil
 	})
 	if err != nil {
 		return nil, err
@@ -440,6 +440,12 @@ func (s *Service) Accept(ctx context.Context, token, password string) (*auth.Aut
 	}
 	err = s.storeRefreshToken(ctx, user.ID, refreshToken)
 	if err != nil {
+		return nil, err
+	}
+	if err := s.q.UpdateInvitationStatus(ctx, dbgen.UpdateInvitationStatusParams{
+		Status: "accepted",
+		ID:     inv.ID,
+	}); err != nil {
 		return nil, err
 	}
 

--- a/backend/internal/invitation/service_test.go
+++ b/backend/internal/invitation/service_test.go
@@ -580,6 +580,32 @@ func TestServiceResendDoesNotRotateTokenOnSendFailure(t *testing.T) {
 	}
 }
 
+func TestServiceRevokeRejectsAcceptedInvitation(t *testing.T) {
+	orgID := uuid.New()
+	invitationID := uuid.New()
+	store := &fakeInvitationStore{
+		invitationByID: &dbgen.Invitation{
+			ID:        invitationID,
+			OrgID:     orgID,
+			SchemeID:  uuid.New(),
+			Email:     "user@example.com",
+			FullName:  "Test User",
+			Role:      "trustee",
+			Status:    "accepted",
+			ExpiresAt: time.Now().Add(time.Hour),
+		},
+	}
+	svc := newTestService(store)
+
+	err := svc.Revoke(context.Background(), orgID.String(), invitationID.String())
+	if !errors.Is(err, ErrInvalidToken) {
+		t.Fatalf("Revoke() error = %v, want %v", err, ErrInvalidToken)
+	}
+	if store.updatedInviteStatus != nil {
+		t.Fatalf("Revoke() updated invitation status = %+v, want nil", store.updatedInviteStatus)
+	}
+}
+
 func TestServiceAcceptStoresHashedRefreshToken(t *testing.T) {
 	orgID := uuid.New()
 	schemeID := uuid.New()
@@ -624,6 +650,41 @@ func TestServiceAcceptStoresHashedRefreshToken(t *testing.T) {
 	}
 	if store.updatedInviteStatus == nil || store.updatedInviteStatus.Status != "accepted" {
 		t.Fatalf("invitation status update = %+v, want accepted", store.updatedInviteStatus)
+	}
+}
+
+func TestServiceAcceptDoesNotMarkInvitationAcceptedWhenRefreshTokenPersistenceFails(t *testing.T) {
+	orgID := uuid.New()
+	schemeID := uuid.New()
+	store := &fakeInvitationStore{
+		invitationByToken: &dbgen.Invitation{
+			ID:        uuid.New(),
+			OrgID:     orgID,
+			SchemeID:  schemeID,
+			UnitID:    pgtype.UUID{},
+			Email:     "trustee@example.com",
+			FullName:  "Trustee User",
+			Role:      "trustee",
+			Token:     "invite-token",
+			Status:    "pending",
+			ExpiresAt: time.Now().Add(time.Hour),
+		},
+		getUserByEmailErr:     pgx.ErrNoRows,
+		createRefreshTokenErr: errors.New("refresh token store unavailable"),
+		createdUser: &dbgen.User{
+			ID:       uuid.New(),
+			Email:    "trustee@example.com",
+			FullName: "Trustee User",
+		},
+	}
+	svc := newTestService(store)
+
+	_, err := svc.Accept(context.Background(), "invite-token", "StrongPassword!123")
+	if err == nil {
+		t.Fatal("Accept() error = nil, want refresh token persistence failure")
+	}
+	if store.updatedInviteStatus != nil {
+		t.Fatalf("Accept() updated invitation status = %+v, want nil", store.updatedInviteStatus)
 	}
 }
 


### PR DESCRIPTION
## Summary
- prevent revoke from rewriting accepted or otherwise finalized invitations
- map non-pending revoke attempts to a 409 conflict instead of a 500
- delay marking invitations accepted until refresh token persistence succeeds

## Issues
- Fixes #228
- Fixes #248

## Verification
- go test ./internal/invitation
- go test ./internal/...
- golangci-lint run ./...