### PR TITLE
fix: bump brace-expansion and drop ignored README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,8 +290,6 @@ and proxies allowed `/api/v1/*` calls through `app/api/proxy/[...path]`.
 - [docs/production-reliability-runbook.md](docs/production-reliability-runbook.md)
   - production reliability and load-test guidance
 - [docs/roadmap/](docs/roadmap/) - roadmap specs and implementation plans
-- [APP_TESTING.md](APP_TESTING.md), [DEMO_TESTING.md](DEMO_TESTING.md), and
-  [SECURITY_AUDIT.md](SECURITY_AUDIT.md) - additional testing and audit notes
 
 ## Deployment Notes
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2536,9 +2536,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary
- `npm audit fix` resolves the moderate `brace-expansion` advisory (GHSA-jxxr-4gwj-5jf2) by bumping the transitive dependency from 5.0.5 to 5.0.6.
- Drops the README pointer to `APP_TESTING.md`, `DEMO_TESTING.md`, and `SECURITY_AUDIT.md`. Those files are listed in `.gitignore` and are not part of `origin/main`, so the link was dead for anyone reading the public README.

Fixes #155.
Fixes #184.

## Test Plan
- `npm audit` (0 vulnerabilities)
- `npm run lint`
- `npm run typecheck`
- `npm test` (41 files, 149 tests pass)

No merge performed.