### PR TITLE
fix: add timeouts to outbound provider and server fetches

### DIFF
--- a/backend/internal/notification/email.go
+++ b/backend/internal/notification/email.go
@@ -7,7 +7,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"time"
 )
+
+const emailRequestTimeout = 15 * time.Second
 
 // Sender is the interface all notification implementations must satisfy.
 type Sender interface {
@@ -25,7 +28,7 @@ type EmailClient struct {
 
 func NewEmailClient(apiKey, fromAddr string) *EmailClient {
 	return &EmailClient{
-		httpClient: &http.Client{},
+		httpClient: &http.Client{Timeout: emailRequestTimeout},
 		apiKey:     apiKey,
 		fromAddr:   fromAddr,
 	}

--- a/backend/internal/notification/email_test.go
+++ b/backend/internal/notification/email_test.go
@@ -1,0 +1,14 @@
+package notification
+
+import (
+	"testing"
+)
+
+func TestNewEmailClientHasTimeout(t *testing.T) {
+	t.Parallel()
+
+	c := NewEmailClient("test-api-key", "from@example.com")
+	if c.httpClient.Timeout != emailRequestTimeout {
+		t.Fatalf("expected http client timeout %s, got %s", emailRequestTimeout, c.httpClient.Timeout)
+	}
+}

--- a/backend/internal/twilio/client.go
+++ b/backend/internal/twilio/client.go
@@ -1,6 +1,7 @@
 package twilio
 
 import (
+	"context"
 	"crypto/hmac"
 	"crypto/sha1"
 	"encoding/base64"
@@ -9,7 +10,10 @@ import (
 	"net/url"
 	"sort"
 	"strings"
+	"time"
 )
+
+const requestTimeout = 15 * time.Second
 
 type Client struct {
 	httpClient *http.Client
@@ -23,11 +27,17 @@ func NewClient(accountSID, authToken, fromNumber string) *Client {
 		accountSID: accountSID,
 		authToken:  authToken,
 		fromNumber: fromNumber,
-		httpClient: &http.Client{},
+		httpClient: &http.Client{Timeout: requestTimeout},
 	}
 }
 
 func (c *Client) SendWhatsAppMessage(to, body string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
+	defer cancel()
+	return c.sendWhatsAppMessage(ctx, to, body)
+}
+
+func (c *Client) sendWhatsAppMessage(ctx context.Context, to, body string) error {
 	endpoint := fmt.Sprintf(
 		"https://api.twilio.com/2010-04-01/Accounts/%s/Messages.json",
 		c.accountSID,
@@ -38,7 +48,7 @@ func (c *Client) SendWhatsAppMessage(to, body string) error {
 	data.Set("To", "whatsapp:"+to)
 	data.Set("Body", body)
 
-	req, err := http.NewRequest(http.MethodPost, endpoint, strings.NewReader(data.Encode()))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader(data.Encode()))
 	if err != nil {
 		return fmt.Errorf("create request: %w", err)
 	}

--- a/backend/internal/twilio/client_test.go
+++ b/backend/internal/twilio/client_test.go
@@ -1,0 +1,14 @@
+package twilio
+
+import (
+	"testing"
+)
+
+func TestNewClientHasTimeout(t *testing.T) {
+	t.Parallel()
+
+	c := NewClient("AC123", "secret", "+15550000000")
+	if c.httpClient.Timeout != requestTimeout {
+		t.Fatalf("expected http client timeout %s, got %s", requestTimeout, c.httpClient.Timeout)
+	}
+}

--- a/lib/auth-actions.test.ts
+++ b/lib/auth-actions.test.ts
@@ -243,4 +243,51 @@ describe("auth actions", () => {
     await action;
     expect(resolved).toBe(true);
   });
+
+  it("logout sends a timeout signal and clears cookies on the backend call", async () => {
+    cookieGet.mockImplementation((name: string) => {
+      if (name === "sh_refresh") return { value: "refresh-token" };
+      return undefined;
+    });
+    const fetchMock = vi.fn(async (_url: string, init: RequestInit) => {
+      expect(init.signal).toBeInstanceOf(AbortSignal);
+      return new Response(null, { status: 200 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { logoutAction } = await import("./auth-actions");
+    await logoutAction();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(clearAuthCookies).toHaveBeenCalledTimes(1);
+  });
+
+  it("logout still clears cookies when the backend logout call fails", async () => {
+    cookieGet.mockImplementation((name: string) => {
+      if (name === "sh_refresh") return { value: "refresh-token" };
+      return undefined;
+    });
+    const fetchMock = vi.fn(async () => {
+      throw new Error("network");
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { logoutAction } = await import("./auth-actions");
+    await logoutAction();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(clearAuthCookies).toHaveBeenCalledTimes(1);
+  });
+
+  it("logout clears cookies when no refresh token is present", async () => {
+    cookieGet.mockImplementation(() => undefined);
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { logoutAction } = await import("./auth-actions");
+    await logoutAction();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(clearAuthCookies).toHaveBeenCalledTimes(1);
+  });
 });

--- a/lib/auth-actions.ts
+++ b/lib/auth-actions.ts
@@ -119,15 +119,17 @@ export async function logoutAction(): Promise<void> {
   const cookieStore = await cookies();
   const refreshToken = cookieStore.get("sh_refresh")?.value;
 
-  if (refreshToken) {
-    await fetch(`${BACKEND()}/api/v1/auth/logout`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ refresh_token: refreshToken }),
-    }).catch(() => {});
+  try {
+    if (refreshToken) {
+      await fetchWithTimeout(`${BACKEND()}/api/v1/auth/logout`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ refresh_token: refreshToken }),
+      }).catch(() => {});
+    }
+  } finally {
+    await clearAuthCookies();
   }
-
-  await clearAuthCookies();
 }
 
 // ─── Clear auth ───────────────────────────────────────────────────────────────

--- a/lib/server-api.test.ts
+++ b/lib/server-api.test.ts
@@ -68,4 +68,33 @@ describe("fetchBackendJson", () => {
     expect(refreshAuthSession).toHaveBeenCalledTimes(1);
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
+
+  it("passes an abort signal to each backend GET", async () => {
+    const fetchMock = vi.fn(async (_url: string, init: RequestInit) => {
+      expect(init.signal).toBeInstanceOf(AbortSignal);
+      return new Response(
+        JSON.stringify({ data: { id: "scheme-1" } }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { fetchBackendJson } = await import("./server-api");
+    const data = await fetchBackendJson<{ id: string }>("/api/v1/schemes/abc");
+
+    expect(data).toEqual({ id: "scheme-1" });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("translates a fetch failure into a retryable temporary error", async () => {
+    const fetchMock = vi.fn(async () => {
+      throw new Error("network down");
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { fetchBackendJson } = await import("./server-api");
+    await expect(fetchBackendJson("/api/v1/schemes")).rejects.toThrow(
+      "Temporary service issue. Please retry.",
+    );
+  });
 });

--- a/lib/server-api.ts
+++ b/lib/server-api.ts
@@ -5,21 +5,35 @@ import { clearAuthCookies, refreshAuthSession } from "@/lib/server-auth";
 
 const BACKEND = () => process.env.BACKEND_URL ?? "http://localhost:8080";
 
+const SERVER_FETCH_TIMEOUT_MS = 10_000;
+
 async function forwardGet(path: string, accessToken?: string): Promise<Response> {
-  return fetch(`${BACKEND()}${path}`, {
-    method: "GET",
-    headers: {
-      ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),
-    },
-    cache: "no-store",
-  });
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), SERVER_FETCH_TIMEOUT_MS);
+  try {
+    return await fetch(`${BACKEND()}${path}`, {
+      method: "GET",
+      headers: {
+        ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),
+      },
+      cache: "no-store",
+      signal: controller.signal,
+    });
+  } finally {
+    clearTimeout(timeout);
+  }
 }
 
 export async function fetchBackendJson<T>(path: string): Promise<T> {
   const cookieStore = await cookies();
   const accessToken = cookieStore.get("sh_access")?.value;
 
-  let response = await forwardGet(path, accessToken);
+  let response: Response;
+  try {
+    response = await forwardGet(path, accessToken);
+  } catch {
+    throw new Error("Temporary service issue. Please retry.");
+  }
   if (response.status === 401) {
     const refreshed = await refreshAuthSession();
     if (refreshed.kind === "invalid") {
@@ -32,7 +46,11 @@ export async function fetchBackendJson<T>(path: string): Promise<T> {
     }
 
     const updatedToken = cookieStore.get("sh_access")?.value;
-    response = await forwardGet(path, updatedToken);
+    try {
+      response = await forwardGet(path, updatedToken);
+    } catch {
+      throw new Error("Temporary service issue. Please retry.");
+    }
   }
 
   if (!response.ok) {


### PR DESCRIPTION
## Summary
- Twilio: `NewClient` now sets a 15s `http.Client` timeout, and `SendWhatsAppMessage` builds its request with a `context.WithTimeout` deadline so a stalled WhatsApp send cannot tie up a webhook reply, broadcast loop, or worker job.
- Resend (`notification.EmailClient`): `NewEmailClient` now sets a 15s `http.Client` timeout matching the existing Stripe client pattern.
- `lib/server-api.ts`: each backend GET is wrapped in an `AbortController` with a 10s deadline and any fetch failure is translated into the existing "Temporary service issue" error so server-rendered pages fall into a bounded error state instead of hanging.
- `lib/auth-actions.ts`: `logoutAction` now uses `fetchWithTimeout` and clears cookies in a `finally` block so a hung backend logout cannot block local sign-out and the client redirect.

Fixes #160.
Fixes #162.
Fixes #164.

## Test Plan
- `go test ./internal/notification ./internal/twilio`
- `go test ./...`
- `golangci-lint run ./...`
- `npm test -- lib/auth-actions.test.ts lib/server-api.test.ts`
- `npm test`
- `npm run lint`
- `npm run typecheck`

No merge performed.