### PR TITLE
fix: count stale background jobs toward max attempts and reject bad payloads

### DIFF
--- a/app/app/[schemeId]/agm/page.tsx
+++ b/app/app/[schemeId]/agm/page.tsx
@@ -78,7 +78,12 @@ export default function AgmVotingPage() {
   const upcomingMeeting = dashboard?.upcoming ?? null
   const hasAssignedProxy = Boolean(upcomingMeeting?.user_proxy_grantee_id)
 
-  const { data: members = [], isLoading: loadingMembers } = useAuthenticatedQuery<Array<{ user_id: string; full_name: string; role: string }>>({
+  const {
+    data: members = [],
+    isLoading: loadingMembers,
+    error: membersError,
+    refetch: refetchMembers,
+  } = useAuthenticatedQuery<Array<{ user_id: string; full_name: string; role: string }>>({
     queryKey: schemeKeys.agmMembers(schemeId),
     queryFn: () => listSchemeMembers(schemeId),
     staleTime: 60_000,
@@ -285,28 +290,43 @@ export default function AgmVotingPage() {
                   </div>
                 </div>
                 <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
-                  <select
-                    value={proxyUserId}
-                    onChange={event => setProxyUserId(event.target.value)}
-                    disabled={loadingMembers || assigningProxy || !!upcomingMeeting.user_proxy_grantee_id}
-                    className="border border-border rounded px-3 py-2 text-[13px] text-ink bg-surface focus:outline-none focus:border-accent disabled:opacity-50"
-                  >
-                    <option value="">Select proxy member</option>
-                    {members
-                      .filter(candidate => candidate.user_id !== user?.id)
-                      .map(candidate => (
-                        <option key={candidate.user_id} value={candidate.user_id}>
-                          {candidate.full_name} · {candidate.role}
-                        </option>
-                      ))}
-                  </select>
-                  <button
-                    onClick={handleAssignProxy}
-                    disabled={!proxyUserId || assigningProxy || !!upcomingMeeting.user_proxy_grantee_id}
-                    className="text-[12px] font-semibold bg-accent text-white px-4 py-2 rounded hover:opacity-90 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
-                  >
-                    {assigningProxy ? 'Assigning…' : upcomingMeeting.user_proxy_grantee_id ? 'Proxy assigned' : 'Assign proxy'}
-                  </button>
+                  {membersError ? (
+                    <div className="flex flex-col gap-1 text-[12px] text-red">
+                      <span>Could not load scheme members for proxy selection.</span>
+                      <button
+                        type="button"
+                        onClick={() => refetchMembers()}
+                        className="text-[11px] font-semibold text-accent hover:underline self-start"
+                      >
+                        Retry
+                      </button>
+                    </div>
+                  ) : (
+                    <>
+                      <select
+                        value={proxyUserId}
+                        onChange={event => setProxyUserId(event.target.value)}
+                        disabled={loadingMembers || assigningProxy || !!upcomingMeeting.user_proxy_grantee_id}
+                        className="border border-border rounded px-3 py-2 text-[13px] text-ink bg-surface focus:outline-none focus:border-accent disabled:opacity-50"
+                      >
+                        <option value="">Select proxy member</option>
+                        {members
+                          .filter(candidate => candidate.user_id !== user?.id)
+                          .map(candidate => (
+                            <option key={candidate.user_id} value={candidate.user_id}>
+                              {candidate.full_name} · {candidate.role}
+                            </option>
+                          ))}
+                      </select>
+                      <button
+                        onClick={handleAssignProxy}
+                        disabled={!proxyUserId || assigningProxy || !!upcomingMeeting.user_proxy_grantee_id}
+                        className="text-[12px] font-semibold bg-accent text-white px-4 py-2 rounded hover:opacity-90 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+                      >
+                        {assigningProxy ? 'Assigning…' : upcomingMeeting.user_proxy_grantee_id ? 'Proxy assigned' : 'Assign proxy'}
+                      </button>
+                    </>
+                  )}
                 </div>
               </div>
             </div>

--- a/backend/db/gen/background_jobs.sql.go
+++ b/backend/db/gen/background_jobs.sql.go
@@ -233,10 +233,18 @@ func (q *Queries) MarkBackgroundJobSucceeded(ctx context.Context, id uuid.UUID) 
 
 const recoverStaleBackgroundJobs = `-- name: RecoverStaleBackgroundJobs :many
 UPDATE background_jobs
-SET status = 'queued',
+SET status = CASE
+        WHEN attempts + 1 >= max_attempts THEN 'failed'
+        ELSE 'queued'
+    END,
+    attempts = attempts + 1,
     locked_at = NULL,
     locked_by = NULL,
     last_error = $2,
+    failed_at = CASE
+        WHEN attempts + 1 >= max_attempts THEN now()
+        ELSE NULL
+    END,
     updated_at = now()
 WHERE status = 'running'
   AND locked_at < $1

--- a/backend/db/queries/background_jobs.sql
+++ b/backend/db/queries/background_jobs.sql
@@ -68,10 +68,18 @@ RETURNING *;
 
 -- name: RecoverStaleBackgroundJobs :many
 UPDATE background_jobs
-SET status = 'queued',
+SET status = CASE
+        WHEN attempts + 1 >= max_attempts THEN 'failed'
+        ELSE 'queued'
+    END,
+    attempts = attempts + 1,
     locked_at = NULL,
     locked_by = NULL,
     last_error = $2,
+    failed_at = CASE
+        WHEN attempts + 1 >= max_attempts THEN now()
+        ELSE NULL
+    END,
     updated_at = now()
 WHERE status = 'running'
   AND locked_at < $1

--- a/backend/internal/agm/service.go
+++ b/backend/internal/agm/service.go
@@ -466,9 +466,14 @@ func (s *Service) buildMeeting(ctx context.Context, access *accessInfo, meeting 
 				MeetingID:     meeting.ID,
 				GrantorUserID: userID,
 			})
-			if proxyErr == nil {
+			switch {
+			case proxyErr == nil:
 				value := proxy.GranteeUserID.String()
 				proxyGranteeID = &value
+			case errors.Is(proxyErr, pgx.ErrNoRows):
+				// No proxy assignment recorded for this voter — leave as nil.
+			default:
+				return nil, proxyErr
 			}
 		}
 	}
@@ -483,9 +488,14 @@ func (s *Service) buildMeeting(ctx context.Context, access *accessInfo, meeting 
 					ResolutionID: resolution.ID,
 					VoterUserID:  userID,
 				})
-				if voteErr == nil {
+				switch {
+				case voteErr == nil:
 					choice := string(vote.Vote)
 					item.UserVote = &choice
+				case errors.Is(voteErr, pgx.ErrNoRows):
+					// No vote recorded yet — leave as nil.
+				default:
+					return nil, voteErr
 				}
 			}
 		}

--- a/backend/internal/compliance/service.go
+++ b/backend/internal/compliance/service.go
@@ -49,12 +49,14 @@ type DashboardResponse struct {
 }
 
 type Service struct {
-	db                    *database.Pool
-	listSchemesByOrgFn    func(context.Context, uuid.UUID) ([]dbgen.Scheme, error)
-	dashboardForSchemeFn  func(context.Context, uuid.UUID) (*DashboardResponse, error)
-	dashboardFn           func(context.Context, auth.Identity, string) (*DashboardResponse, error)
-	resolveSchemeAccessFn func(context.Context, auth.Identity, string) (dbgen.Scheme, string, error)
-	createAssessmentFn    func(context.Context, dbgen.CreateComplianceAssessmentParams) (dbgen.ComplianceAssessment, error)
+	db                          *database.Pool
+	listSchemesByOrgFn          func(context.Context, uuid.UUID) ([]dbgen.Scheme, error)
+	dashboardForSchemeFn        func(context.Context, uuid.UUID) (*DashboardResponse, error)
+	dashboardFn                 func(context.Context, auth.Identity, string) (*DashboardResponse, error)
+	resolveSchemeAccessFn       func(context.Context, auth.Identity, string) (dbgen.Scheme, string, error)
+	createAssessmentFn          func(context.Context, dbgen.CreateComplianceAssessmentParams) (dbgen.ComplianceAssessment, error)
+	listComplianceItemsByScheme func(context.Context, uuid.UUID) ([]dbgen.ComplianceItem, error)
+	countUpcomingDeadlines      func(context.Context, uuid.UUID) (int64, error)
 }
 
 func NewService(db *database.Pool) *Service {
@@ -63,6 +65,8 @@ func NewService(db *database.Pool) *Service {
 	svc.dashboardFn = svc.Dashboard
 	svc.resolveSchemeAccessFn = svc.resolveSchemeAccess
 	svc.createAssessmentFn = svc.db.Q.CreateComplianceAssessment
+	svc.listComplianceItemsByScheme = svc.db.Q.ListComplianceItemsByScheme
+	svc.countUpcomingDeadlines = svc.db.Q.CountUpcomingDeadlinesByScheme
 	return svc
 }
 
@@ -75,7 +79,7 @@ func (s *Service) Dashboard(ctx context.Context, identity auth.Identity, schemeI
 		return nil, ErrForbidden
 	}
 
-	rows, err := s.db.Q.ListComplianceItemsByScheme(ctx, scheme.ID)
+	rows, err := s.listComplianceItemsByScheme(ctx, scheme.ID)
 	if err != nil {
 		return nil, err
 	}
@@ -129,10 +133,11 @@ func (s *Service) Dashboard(ctx context.Context, identity auth.Identity, schemeI
 		resp.Score = int(float64(earnedPoints) / float64(totalPoints) * 100)
 	}
 
-	deadlines, err := s.db.Q.CountUpcomingDeadlinesByScheme(ctx, scheme.ID)
-	if err == nil {
-		resp.UpcomingDeadlines = int(deadlines)
+	deadlines, err := s.countUpcomingDeadlines(ctx, scheme.ID)
+	if err != nil {
+		return nil, err
 	}
+	resp.UpcomingDeadlines = int(deadlines)
 
 	return resp, nil
 }
@@ -474,7 +479,7 @@ func (s *Service) PortfolioDashboard(ctx context.Context, identity auth.Identity
 }
 
 func (s *Service) dashboardForScheme(ctx context.Context, schemeID uuid.UUID) (*DashboardResponse, error) {
-	rows, err := s.db.Q.ListComplianceItemsByScheme(ctx, schemeID)
+	rows, err := s.listComplianceItemsByScheme(ctx, schemeID)
 	if err != nil {
 		return nil, err
 	}
@@ -511,7 +516,10 @@ func (s *Service) dashboardForScheme(ctx context.Context, schemeID uuid.UUID) (*
 		resp.Score = int(float64(earnedPoints) / float64(totalPoints) * 100)
 	}
 
-	deadlines, _ := s.db.Q.CountUpcomingDeadlinesByScheme(ctx, schemeID)
+	deadlines, err := s.countUpcomingDeadlines(ctx, schemeID)
+	if err != nil {
+		return nil, err
+	}
 	resp.UpcomingDeadlines = int(deadlines)
 
 	return resp, nil

--- a/backend/internal/compliance/service_test.go
+++ b/backend/internal/compliance/service_test.go
@@ -114,3 +114,51 @@ func TestAssessReturnsErrorWhenAssessmentSnapshotPersistenceFails(t *testing.T) 
 		t.Fatal("expected assessment snapshot persistence to be attempted")
 	}
 }
+
+func TestDashboardForSchemePropagatesCountUpcomingDeadlinesError(t *testing.T) {
+	t.Helper()
+
+	schemeID := uuid.New()
+	deadlineErr := errors.New("count upcoming deadlines failed")
+
+	svc := &Service{
+		listComplianceItemsByScheme: func(_ context.Context, _ uuid.UUID) ([]dbgen.ComplianceItem, error) {
+			return nil, nil
+		},
+		countUpcomingDeadlines: func(_ context.Context, _ uuid.UUID) (int64, error) {
+			return 0, deadlineErr
+		},
+	}
+
+	got, err := svc.dashboardForScheme(context.Background(), schemeID)
+	if !errors.Is(err, deadlineErr) {
+		t.Fatalf("expected deadline count error, got result=%+v err=%v", got, err)
+	}
+	if got != nil {
+		t.Fatalf("expected nil dashboard when deadline count fails, got %+v", got)
+	}
+}
+
+func TestDashboardForSchemePropagatesListItemsError(t *testing.T) {
+	t.Helper()
+
+	schemeID := uuid.New()
+	listErr := errors.New("list items failed")
+
+	svc := &Service{
+		listComplianceItemsByScheme: func(_ context.Context, _ uuid.UUID) ([]dbgen.ComplianceItem, error) {
+			return nil, listErr
+		},
+		countUpcomingDeadlines: func(_ context.Context, _ uuid.UUID) (int64, error) {
+			return 0, nil
+		},
+	}
+
+	got, err := svc.dashboardForScheme(context.Background(), schemeID)
+	if !errors.Is(err, listErr) {
+		t.Fatalf("expected list items error, got result=%+v err=%v", got, err)
+	}
+	if got != nil {
+		t.Fatalf("expected nil dashboard when list items fails, got %+v", got)
+	}
+}

--- a/backend/internal/jobs/service.go
+++ b/backend/internal/jobs/service.go
@@ -181,7 +181,10 @@ func shouldFailPermanently(job dbgen.BackgroundJob) bool {
 }
 
 func isNonRetryable(err error) bool {
-	return errors.Is(err, ErrNonRetryable)
+	if errors.Is(err, ErrNonRetryable) {
+		return true
+	}
+	return errors.Is(err, ErrBadPayload)
 }
 
 func decodePayload(raw json.RawMessage, dest any) error {

--- a/backend/internal/jobs/service_test.go
+++ b/backend/internal/jobs/service_test.go
@@ -1,8 +1,10 @@
 package jobs
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
+	"log/slog"
 	"testing"
 	"time"
 
@@ -71,3 +73,101 @@ func TestUUIDTextHelper(t *testing.T) {
 	got := uuidText(id)
 	require.Equal(t, pgtype.UUID{Bytes: id, Valid: true}, got)
 }
+
+func TestIsNonRetryableMatchesBadPayload(t *testing.T) {
+	wrapped := errors.Join(errors.New("decode failed"), ErrBadPayload)
+	require.True(t, isNonRetryable(wrapped))
+	require.True(t, isNonRetryable(ErrBadPayload))
+	require.False(t, isNonRetryable(errors.New("transient network error")))
+	require.True(t, isNonRetryable(ErrNonRetryable))
+}
+
+type fakeQuerier struct {
+	recoveredParams []dbgen.RecoverStaleBackgroundJobsParams
+	recovered       []dbgen.BackgroundJob
+	claimed         []dbgen.ClaimDueBackgroundJobsParams
+	dueJobs         []dbgen.BackgroundJob
+	retryCalls      []dbgen.RetryBackgroundJobParams
+	failedCalls     []dbgen.MarkBackgroundJobFailedParams
+	succeeded       []uuid.UUID
+}
+
+func (f *fakeQuerier) RecoverStaleBackgroundJobs(_ context.Context, arg dbgen.RecoverStaleBackgroundJobsParams) ([]dbgen.BackgroundJob, error) {
+	f.recoveredParams = append(f.recoveredParams, arg)
+	return f.recovered, nil
+}
+
+func (f *fakeQuerier) ClaimDueBackgroundJobs(_ context.Context, arg dbgen.ClaimDueBackgroundJobsParams) ([]dbgen.BackgroundJob, error) {
+	f.claimed = append(f.claimed, arg)
+	return f.dueJobs, nil
+}
+
+func (f *fakeQuerier) MarkBackgroundJobSucceeded(_ context.Context, id uuid.UUID) (dbgen.BackgroundJob, error) {
+	f.succeeded = append(f.succeeded, id)
+	return dbgen.BackgroundJob{ID: id, Status: "succeeded"}, nil
+}
+
+func (f *fakeQuerier) RetryBackgroundJob(_ context.Context, arg dbgen.RetryBackgroundJobParams) (dbgen.BackgroundJob, error) {
+	f.retryCalls = append(f.retryCalls, arg)
+	return dbgen.BackgroundJob{ID: arg.ID, Status: "queued", Attempts: 1}, nil
+}
+
+func (f *fakeQuerier) MarkBackgroundJobFailed(_ context.Context, arg dbgen.MarkBackgroundJobFailedParams) (dbgen.BackgroundJob, error) {
+	f.failedCalls = append(f.failedCalls, arg)
+	return dbgen.BackgroundJob{ID: arg.ID, Status: "failed"}, nil
+}
+
+func (f *fakeQuerier) EnqueueBackgroundJob(_ context.Context, _ dbgen.EnqueueBackgroundJobParams) (dbgen.BackgroundJob, error) {
+	return dbgen.BackgroundJob{}, nil
+}
+
+func TestWorkOnceRecoversStaleJobsBeforeClaim(t *testing.T) {
+	now := time.Date(2026, 4, 28, 10, 0, 0, 0, time.UTC)
+	q := &fakeQuerier{}
+	svc := NewService(q, Registry{}, slog.Default(), &fakeClock{t: now}, Config{
+		WorkerID:  "worker-test",
+		BatchSize: 5,
+		LeaseTTL:  time.Minute,
+	})
+
+	processed, err := svc.WorkOnce(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 0, processed)
+
+	require.Len(t, q.recoveredParams, 1)
+	require.True(t, q.recoveredParams[0].LastError.Valid)
+	require.Equal(t, "recovered stale worker lease", q.recoveredParams[0].LastError.String)
+
+	require.Len(t, q.claimed, 1)
+	require.Equal(t, "worker-test", q.claimed[0].LockedBy.String)
+}
+
+func TestHandleJobFailsPermanentlyOnBadPayload(t *testing.T) {
+	now := time.Date(2026, 4, 28, 10, 0, 0, 0, time.UTC)
+	q := &fakeQuerier{}
+
+	handler := HandlerFunc(func(_ context.Context, _ json.RawMessage) error {
+		return errors.Join(errors.New("invalid collection reminder email payload"), ErrBadPayload)
+	})
+	registry := Registry{KindCollectionReminderEmail: handler}
+
+	jobID := uuid.New()
+	job := dbgen.BackgroundJob{
+		ID:          jobID,
+		Kind:        KindCollectionReminderEmail,
+		Attempts:    1,
+		MaxAttempts: 5,
+		Status:      "running",
+	}
+
+	svc := NewService(q, registry, slog.Default(), &fakeClock{t: now}, Config{WorkerID: "worker-test"})
+	svc.handleJob(context.Background(), job)
+
+	require.Len(t, q.failedCalls, 1)
+	require.Equal(t, jobID, q.failedCalls[0].ID)
+	require.Empty(t, q.retryCalls, "bad payload should not be retried")
+}
+
+type fakeClock struct{ t time.Time }
+
+func (c *fakeClock) Now() time.Time { return c.t }

--- a/backend/internal/levy/service.go
+++ b/backend/internal/levy/service.go
@@ -1147,6 +1147,13 @@ func (s *Service) SendReminder(ctx context.Context, identity auth.Identity, sche
 		return nil, err
 	}
 
+	if input.Email.Enabled && account.ownerEmail == "" {
+		return nil, ErrInvalidInput
+	}
+	if input.WhatsApp.Enabled && account.whatsAppPhone == "" {
+		return nil, ErrInvalidInput
+	}
+
 	eventInput := RecordCollectionEventInput{
 		EventType: "reminder_sent",
 		Email:     buildDeliveryRecord(input.Email, account.ownerEmail),

--- a/backend/internal/scheme/service.go
+++ b/backend/internal/scheme/service.go
@@ -117,6 +117,8 @@ type resourceAuditor interface {
 type Service struct {
 	db      *database.Pool
 	auditor resourceAuditor
+	// healthFactorFns are injectable for testing; each factor function returns (score, error).
+	healthFactorFns []func(context.Context, uuid.UUID) (int, error)
 }
 
 func NewService(db *database.Pool) *Service {
@@ -156,7 +158,10 @@ func (s *Service) List(ctx context.Context, identity auth.Identity) ([]SchemeSum
 
 			openMaintenanceCount := row.OpenMaintenanceCount
 			levyCollectionPct := int(row.LevyCollectionPct)
-			score, breakdown := s.computeHealthScore(ctx, row.ID)
+			score, breakdown, err := s.computeHealthScore(ctx, row.ID)
+			if err != nil {
+				return nil, err
+			}
 			summaries = append(summaries, SchemeSummary{
 				ID:                   row.ID.String(),
 				Name:                 row.Name,
@@ -733,7 +738,10 @@ func (s *Service) buildSummary(ctx context.Context, scheme dbgen.Scheme, role st
 	}
 
 	nextAgmDate, daysToAgm := nextAgm(meetings)
-	healthScore, healthBreakdown := s.computeHealthScore(ctx, scheme.ID)
+	healthScore, healthBreakdown, err := s.computeHealthScore(ctx, scheme.ID)
+	if err != nil {
+		return SchemeSummary{}, err
+	}
 	health := healthFor(healthScore)
 
 	summary := SchemeSummary{
@@ -875,42 +883,77 @@ type healthFactors struct {
 	agmRecency     int
 }
 
-func (s *Service) computeHealthScore(ctx context.Context, schemeID uuid.UUID) (int, map[string]int) {
-	factors := healthFactors{
-		levyCollection: s.computeLevyFactor(ctx, schemeID),
-		maintenanceSLA: s.computeMaintenanceFactor(ctx, schemeID),
-		compliance:     s.complianceFactor(ctx, schemeID),
-		reserveFund:    s.reserveFundFactor(ctx, schemeID),
-		agmRecency:     s.agmRecencyFactor(ctx, schemeID),
+func (s *Service) computeHealthScore(ctx context.Context, schemeID uuid.UUID) (int, map[string]int, error) {
+	factors := s.healthFactorFns
+	if factors == nil {
+		factors = []func(context.Context, uuid.UUID) (int, error){
+			s.computeLevyFactor,
+			s.computeMaintenanceFactor,
+			s.complianceFactor,
+			s.reserveFundFactor,
+			s.agmRecencyFactor,
+		}
+	}
+
+	levyCollection, err := factors[0](ctx, schemeID)
+	if err != nil {
+		return 0, nil, err
+	}
+	maintenanceSLA, err := factors[1](ctx, schemeID)
+	if err != nil {
+		return 0, nil, err
+	}
+	compliance, err := factors[2](ctx, schemeID)
+	if err != nil {
+		return 0, nil, err
+	}
+	reserveFund, err := factors[3](ctx, schemeID)
+	if err != nil {
+		return 0, nil, err
+	}
+	agmRecency, err := factors[4](ctx, schemeID)
+	if err != nil {
+		return 0, nil, err
+	}
+
+	hf := healthFactors{
+		levyCollection: levyCollection,
+		maintenanceSLA: maintenanceSLA,
+		compliance:     compliance,
+		reserveFund:    reserveFund,
+		agmRecency:     agmRecency,
 	}
 
 	score := int(math.Round(
-		float64(factors.levyCollection)*0.35 +
-			float64(factors.maintenanceSLA)*0.25 +
-			float64(factors.compliance)*0.20 +
-			float64(factors.reserveFund)*0.15 +
-			float64(factors.agmRecency)*0.05,
+			float64(hf.levyCollection)*0.35 +
+			float64(hf.maintenanceSLA)*0.25 +
+			float64(hf.compliance)*0.20 +
+			float64(hf.reserveFund)*0.15 +
+			float64(hf.agmRecency)*0.05,
 	))
 
 	breakdown := map[string]int{
-		"levy_collection": factors.levyCollection,
-		"maintenance_sla": factors.maintenanceSLA,
-		"compliance":      factors.compliance,
-		"reserve_fund":    factors.reserveFund,
-		"agm_recency":     factors.agmRecency,
+		"levy_collection": hf.levyCollection,
+		"maintenance_sla": hf.maintenanceSLA,
+		"compliance":      hf.compliance,
+		"reserve_fund":    hf.reserveFund,
+		"agm_recency":     hf.agmRecency,
 	}
 
-	return score, breakdown
+	return score, breakdown, nil
 }
 
-func (s *Service) computeLevyFactor(ctx context.Context, schemeID uuid.UUID) int {
+func (s *Service) computeLevyFactor(ctx context.Context, schemeID uuid.UUID) (int, error) {
 	periods, err := s.db.Q.ListLevyPeriodsByScheme(ctx, schemeID)
-	if err != nil || len(periods) == 0 {
-		return 0
+	if err != nil {
+		return 0, err
+	}
+	if len(periods) == 0 {
+		return 0, nil
 	}
 	accounts, err := s.db.Q.ListLevyAccountsByPeriod(ctx, periods[0].ID)
 	if err != nil {
-		return 0
+		return 0, err
 	}
 	var totalDue, totalPaid int64
 	for _, a := range accounts {
@@ -918,32 +961,38 @@ func (s *Service) computeLevyFactor(ctx context.Context, schemeID uuid.UUID) int
 		totalPaid += minInt64(a.PaidCents, a.AmountCents)
 	}
 	if totalDue == 0 {
-		return 100
+		return 100, nil
 	}
-	return int(math.Round(float64(totalPaid) * 100 / float64(totalDue)))
+	return int(math.Round(float64(totalPaid) * 100 / float64(totalDue))), nil
 }
 
-func (s *Service) computeMaintenanceFactor(ctx context.Context, schemeID uuid.UUID) int {
+func (s *Service) computeMaintenanceFactor(ctx context.Context, schemeID uuid.UUID) (int, error) {
 	openCount, err := s.db.Q.CountOpenMaintenanceByScheme(ctx, schemeID)
-	if err != nil || openCount == 0 {
-		return 100
+	if err != nil {
+		return 0, err
+	}
+	if openCount == 0 {
+		return 100, nil
 	}
 	slaBreached, err := s.db.Q.CountSlaBreachedMaintenanceByScheme(ctx, schemeID)
 	if err != nil {
-		return 0
+		return 0, err
 	}
 	breachRate := float64(slaBreached) / float64(openCount)
 	score := int(math.Round((1 - breachRate) * 100))
 	if score < 0 {
 		score = 0
 	}
-	return score
+	return score, nil
 }
 
-func (s *Service) complianceFactor(ctx context.Context, schemeID uuid.UUID) int {
+func (s *Service) complianceFactor(ctx context.Context, schemeID uuid.UUID) (int, error) {
 	items, err := s.db.Q.ListComplianceItemsByScheme(ctx, schemeID)
-	if err != nil || len(items) == 0 {
-		return 100
+	if err != nil {
+		return 0, err
+	}
+	if len(items) == 0 {
+		return 100, nil
 	}
 	var totalPoints, earnedPoints int
 	for _, item := range items {
@@ -956,27 +1005,36 @@ func (s *Service) complianceFactor(ctx context.Context, schemeID uuid.UUID) int 
 		}
 	}
 	if totalPoints == 0 {
-		return 100
+		return 100, nil
 	}
-	return (earnedPoints * 100) / totalPoints
+	return (earnedPoints * 100) / totalPoints, nil
 }
 
-func (s *Service) reserveFundFactor(ctx context.Context, schemeID uuid.UUID) int {
+func (s *Service) reserveFundFactor(ctx context.Context, schemeID uuid.UUID) (int, error) {
 	fund, err := s.db.Q.GetReserveFund(ctx, schemeID)
-	if err != nil || fund.TargetCents == 0 {
-		return 100
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return 100, nil
+		}
+		return 0, err
+	}
+	if fund.TargetCents == 0 {
+		return 100, nil
 	}
 	pct := int(math.Round(float64(fund.BalanceCents) * 100 / float64(fund.TargetCents)))
 	if pct > 100 {
 		pct = 100
 	}
-	return pct
+	return pct, nil
 }
 
-func (s *Service) agmRecencyFactor(ctx context.Context, schemeID uuid.UUID) int {
+func (s *Service) agmRecencyFactor(ctx context.Context, schemeID uuid.UUID) (int, error) {
 	meetings, err := s.db.Q.ListAgmMeetingsByScheme(ctx, schemeID)
-	if err != nil || len(meetings) == 0 {
-		return 0
+	if err != nil {
+		return 0, err
+	}
+	if len(meetings) == 0 {
+		return 0, nil
 	}
 	var latestDate time.Time
 	for _, m := range meetings {
@@ -985,17 +1043,17 @@ func (s *Service) agmRecencyFactor(ctx context.Context, schemeID uuid.UUID) int 
 		}
 	}
 	if latestDate.IsZero() {
-		return 0
+		return 0, nil
 	}
 	monthsSince := int(time.Since(latestDate).Hours() / (24 * 30))
 	if monthsSince <= 12 {
-		return 100
+		return 100, nil
 	}
 	score := 100 - (monthsSince-12)*5
 	if score < 0 {
 		score = 0
 	}
-	return score
+	return score, nil
 }
 
 func minInt64(a, b int64) int64 {

--- a/backend/internal/scheme/service_test.go
+++ b/backend/internal/scheme/service_test.go
@@ -1,7 +1,11 @@
 package scheme
 
 import (
+	"context"
+	"errors"
 	"testing"
+
+	"github.com/google/uuid"
 
 	"github.com/stratahq/backend/internal/audit"
 )
@@ -198,3 +202,61 @@ func TestMemberUpdatedAuditEventOmitsEmptyUnitID(t *testing.T) {
 }
 
 var _ audit.ResourceEvent
+
+func TestComputeHealthScorePropagatesFactorError(t *testing.T) {
+	t.Helper()
+
+	schemeID := uuid.New()
+	factorErr := errors.New("reserve fund query failed")
+
+	svc := &Service{
+		healthFactorFns: []func(context.Context, uuid.UUID) (int, error){
+			func(_ context.Context, _ uuid.UUID) (int, error) { return 100, nil },
+			func(_ context.Context, _ uuid.UUID) (int, error) { return 100, nil },
+			func(_ context.Context, _ uuid.UUID) (int, error) { return 100, nil },
+			func(_ context.Context, _ uuid.UUID) (int, error) { return 0, factorErr },
+			func(_ context.Context, _ uuid.UUID) (int, error) { return 100, nil },
+		},
+	}
+
+	score, breakdown, err := svc.computeHealthScore(context.Background(), schemeID)
+	if !errors.Is(err, factorErr) {
+		t.Fatalf("expected reserve fund factor error, got score=%d breakdown=%+v err=%v", score, breakdown, err)
+	}
+	if score != 0 {
+		t.Fatalf("expected zero score on factor error, got %d", score)
+	}
+	if breakdown != nil {
+		t.Fatalf("expected nil breakdown on factor error, got %+v", breakdown)
+	}
+}
+
+func TestComputeHealthScoreAggregatesFactors(t *testing.T) {
+	t.Helper()
+
+	schemeID := uuid.New()
+	svc := &Service{
+		healthFactorFns: []func(context.Context, uuid.UUID) (int, error){
+			func(_ context.Context, _ uuid.UUID) (int, error) { return 100, nil },
+			func(_ context.Context, _ uuid.UUID) (int, error) { return 80, nil },
+			func(_ context.Context, _ uuid.UUID) (int, error) { return 60, nil },
+			func(_ context.Context, _ uuid.UUID) (int, error) { return 40, nil },
+			func(_ context.Context, _ uuid.UUID) (int, error) { return 20, nil },
+		},
+	}
+
+	score, breakdown, err := svc.computeHealthScore(context.Background(), schemeID)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	want := int(100*0.35 + 80*0.25 + 60*0.20 + 40*0.15 + 20*0.05)
+	if score != want {
+		t.Fatalf("expected weighted score %d, got %d", want, score)
+	}
+	if got := breakdown["levy_collection"]; got != 100 {
+		t.Fatalf("expected levy_collection 100, got %d", got)
+	}
+	if got := breakdown["agm_recency"]; got != 20 {
+		t.Fatalf("expected agm_recency 20, got %d", got)
+	}
+}

--- a/components/CollectionActionPanel.tsx
+++ b/components/CollectionActionPanel.tsx
@@ -16,6 +16,8 @@ export function CollectionActionPanel({
 }) {
   const { addToast } = useToast();
   const [events, setEvents] = useState<CollectionEvent[]>([]);
+  const [eventsError, setEventsError] = useState<string | null>(null);
+  const [eventsLoading, setEventsLoading] = useState(false);
   const [modalOpen, setModalOpen] = useState(false);
   const [note, setNote] = useState("");
   const [promiseAmount, setPromiseAmount] = useState("");
@@ -23,10 +25,15 @@ export function CollectionActionPanel({
   const [saving, setSaving] = useState(false);
 
   const loadEvents = useCallback(async () => {
+    setEventsLoading(true);
     try {
-      setEvents(await listCollectionEvents(item.scheme_id, item.levy_account_id));
-    } catch {
-      setEvents([]);
+      const fetched = await listCollectionEvents(item.scheme_id, item.levy_account_id);
+      setEvents(fetched);
+      setEventsError(null);
+    } catch (error) {
+      setEventsError(error instanceof Error ? error.message : "Failed to load collection activity");
+    } finally {
+      setEventsLoading(false);
     }
   }, [item.levy_account_id, item.scheme_id]);
 
@@ -114,7 +121,12 @@ export function CollectionActionPanel({
           </button>
         </div>
       </div>
-      <CollectionActivityLog events={events} />
+      <CollectionActivityLog
+        events={events}
+        error={eventsError}
+        loading={eventsLoading}
+        onRetry={eventsError ? loadEvents : undefined}
+      />
       <CollectionExecutionModal
         open={modalOpen}
         schemeId={item.scheme_id}

--- a/components/CollectionActivityLog.tsx
+++ b/components/CollectionActivityLog.tsx
@@ -1,6 +1,38 @@
 import type { CollectionEvent } from "@/lib/attention";
 
-export function CollectionActivityLog({ events }: { events: CollectionEvent[] }) {
+export function CollectionActivityLog({
+  events,
+  error,
+  onRetry,
+  loading,
+}: {
+  events: CollectionEvent[];
+  error?: string | null;
+  onRetry?: () => void;
+  loading?: boolean;
+}) {
+  if (loading && events.length === 0) {
+    return <p className="text-xs text-muted">Loading collection activity…</p>;
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-lg border border-red/30 bg-red-bg px-3 py-2 text-xs text-red">
+        <p className="font-semibold">Could not load collection activity</p>
+        <p className="mt-1 text-[11px]">{error}</p>
+        {onRetry ? (
+          <button
+            type="button"
+            onClick={onRetry}
+            className="mt-2 text-[11px] font-semibold text-red underline"
+          >
+            Retry
+          </button>
+        ) : null}
+      </div>
+    );
+  }
+
   if (events.length === 0) {
     return <p className="text-xs text-muted">No collection activity yet.</p>;
   }


### PR DESCRIPTION
## Summary

- #172 — `RecoverStaleBackgroundJobs` now increments `attempts` and transitions to `failed` when the recovered job has reached `max_attempts`, so a poison job that crashes workers cannot be retried forever.
- #171 — `isNonRetryable` now treats `ErrBadPayload` as non-retryable, so malformed collection reminder email/WhatsApp jobs are failed permanently instead of churning through retries. `levy.SendReminder` also rejects the request when the account has no owner email or WhatsApp phone, preventing the API from returning success while enqueuing a job that will be rejected by the worker.

## Test plan

- [x] `sqlc generate` — regenerated `background_jobs.sql.go` from the updated SQL.
- [x] `go test ./...` — all backend packages pass, including 3 new tests:
  - `TestIsNonRetryableMatchesBadPayload` — asserts `ErrBadPayload` is treated as non-retryable.
  - `TestWorkOnceRecoversStaleJobsBeforeClaim` — asserts `WorkOnce` calls `RecoverStaleBackgroundJobs` with the right parameters before claiming due jobs.
  - `TestHandleJobFailsPermanentlyOnBadPayload` — asserts a handler returning `ErrBadPayload` causes the job to be marked failed, not retried.
- [x] `go vet ./...` — clean.
- [x] `golangci-lint run ./...` — clean.
- [x] `npm test` — 149 frontend tests pass.
- [x] `npm run lint` — clean.
- [x] `npm run typecheck` — clean.