### PR TITLE
fix: harden bank-statement parser and apply pipeline

### DIFF
--- a/backend/internal/levy/bank_statement_import.go
+++ b/backend/internal/levy/bank_statement_import.go
@@ -120,6 +120,88 @@ func normalizeBankStatementReference(value string) string {
 	return strings.TrimSpace(cleaned)
 }
 
+func validateManualBankMatches(manualMatches []BankStatementManualMatchInput) error {
+	if len(manualMatches) == 0 {
+		return ErrInvalidInput
+	}
+	seen := make(map[string]struct{}, len(manualMatches))
+	for _, match := range manualMatches {
+		if match.RowID == "" || match.AccountID == "" {
+			return ErrInvalidInput
+		}
+		if _, dup := seen[match.RowID]; dup {
+			return ErrInvalidInput
+		}
+		seen[match.RowID] = struct{}{}
+	}
+	return nil
+}
+
+func parseCurrencyToCents(amount string) (int64, error) {
+	cleaned := strings.TrimSpace(amount)
+	if cleaned == "" {
+		return 0, fmt.Errorf("empty amount")
+	}
+	negative := false
+	if strings.HasPrefix(cleaned, "-") {
+		negative = true
+		cleaned = cleaned[1:]
+	} else if strings.HasPrefix(cleaned, "+") {
+		cleaned = cleaned[1:]
+	}
+
+	var sign int64 = 1
+	if negative {
+		sign = -1
+	}
+
+	randPart, centsPart, hasCents := strings.Cut(cleaned, ".")
+	if randPart == "" && centsPart == "" {
+		return 0, fmt.Errorf("invalid amount %q", amount)
+	}
+	if strings.ContainsRune(randPart, '.') || strings.ContainsRune(centsPart, '.') {
+		return 0, fmt.Errorf("invalid amount %q", amount)
+	}
+	if randPart == "" {
+		randPart = "0"
+	}
+	if hasCents && centsPart == "" {
+		return 0, fmt.Errorf("invalid amount %q: missing cents digits", amount)
+	}
+
+	for _, r := range randPart {
+		if r < '0' || r > '9' {
+			return 0, fmt.Errorf("invalid amount %q: non-numeric characters", amount)
+		}
+	}
+	if hasCents {
+		if len(centsPart) > 2 {
+			return 0, fmt.Errorf("invalid amount %q: more than two decimal places", amount)
+		}
+		for _, r := range centsPart {
+			if r < '0' || r > '9' {
+				return 0, fmt.Errorf("invalid amount %q: non-numeric decimal", amount)
+			}
+		}
+	} else {
+		centsPart = "00"
+	}
+	if hasCents && len(centsPart) == 1 {
+		centsPart = centsPart + "0"
+	}
+
+	randVal, err := strconv.ParseInt(randPart, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid amount %q: %w", amount, err)
+	}
+	centsVal, err := strconv.ParseInt(centsPart, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid amount %q: %w", amount, err)
+	}
+
+	return sign * (randVal*100 + centsVal), nil
+}
+
 func parseFNBStatementCSV(data []byte) ([]ParsedBankStatementRow, error) {
 	reader := csv.NewReader(bytes.NewReader(data))
 	records, err := reader.ReadAll()
@@ -170,14 +252,13 @@ func parseFNBStatementCSV(data []byte) ([]ParsedBankStatementRow, error) {
 
 		amountStr := strings.TrimSpace(record[amountIdx])
 		cleanAmount := strings.NewReplacer(",", "", "R", "").Replace(amountStr)
-		floatVal, err := strconv.ParseFloat(cleanAmount, 64)
+		cents, err := parseCurrencyToCents(cleanAmount)
 		if err != nil {
 			return nil, fmt.Errorf("row %d: cannot parse amount %q", row.RowNumber, amountStr)
 		}
-		if floatVal <= 0 {
+		if cents <= 0 {
 			continue
 		}
-		cents := int64(floatVal * 100)
 		row.AmountCents = cents
 
 		if hasRef && refIdx < len(record) {
@@ -467,6 +548,13 @@ func (s *Service) ApplyBankStatementImport(ctx context.Context, identity auth.Id
 		}
 		return nil, err
 	}
+	if import_.Status != dbgen.BankStatementImportStatusReviewRequired {
+		return nil, ErrInvalidInput
+	}
+
+	if vErr := validateManualBankMatches(manualMatches); vErr != nil {
+		return nil, vErr
+	}
 
 	tx, err := s.db.Begin(ctx)
 	if err != nil {
@@ -483,11 +571,18 @@ func (s *Service) ApplyBankStatementImport(ctx context.Context, identity auth.Id
 		return nil, err
 	}
 
+	if len(dbRows) == 0 {
+		return nil, ErrInvalidInput
+	}
+
 	rowMap := make(map[string]dbgen.BankStatementRow)
 	for _, r := range dbRows {
 		rowMap[r.ID.String()] = r
 	}
 
+	matchedDelta := int32(0)
+	ambiguousDelta := int32(0)
+	unmatchedDelta := int32(0)
 	appliedCount := int32(0)
 	for _, match := range manualMatches {
 		row, ok := rowMap[match.RowID]
@@ -496,6 +591,15 @@ func (s *Service) ApplyBankStatementImport(ctx context.Context, identity auth.Id
 		}
 		if row.Status == dbgen.BankStatementRowStatusApplied || row.Status == dbgen.BankStatementRowStatusSkipped {
 			continue
+		}
+
+		switch row.Status {
+		case dbgen.BankStatementRowStatusMatched:
+			matchedDelta++
+		case dbgen.BankStatementRowStatusAmbiguous:
+			ambiguousDelta++
+		case dbgen.BankStatementRowStatusUnmatched:
+			unmatchedDelta++
 		}
 
 		accountID, parseErr := uuid.Parse(match.AccountID)
@@ -559,10 +663,24 @@ func (s *Service) ApplyBankStatementImport(ctx context.Context, identity auth.Id
 			return nil, err
 		}
 
+		row.Status = dbgen.BankStatementRowStatusApplied
+		rowMap[match.RowID] = row
 		appliedCount++
 	}
 
 	newApplied := import_.AppliedRows + appliedCount
+	newMatched := import_.MatchedRows - matchedDelta
+	newAmbiguous := import_.AmbiguousRows - ambiguousDelta
+	newUnmatched := import_.UnmatchedRows - unmatchedDelta
+	if newMatched < 0 {
+		newMatched = 0
+	}
+	if newAmbiguous < 0 {
+		newAmbiguous = 0
+	}
+	if newUnmatched < 0 {
+		newUnmatched = 0
+	}
 	finalStatus := dbgen.BankStatementImportStatusReviewRequired
 	if newApplied >= import_.TotalRows && import_.TotalRows > 0 {
 		finalStatus = dbgen.BankStatementImportStatusApplied
@@ -578,9 +696,9 @@ func (s *Service) ApplyBankStatementImport(ctx context.Context, identity auth.Id
 		ID:            importUUID,
 		Status:        finalStatus,
 		TotalRows:     import_.TotalRows,
-		MatchedRows:   import_.MatchedRows,
-		AmbiguousRows: import_.AmbiguousRows,
-		UnmatchedRows: import_.UnmatchedRows,
+		MatchedRows:   newMatched,
+		AmbiguousRows: newAmbiguous,
+		UnmatchedRows: newUnmatched,
 		AppliedRows:   newApplied,
 		ParsedAt:      import_.ParsedAt,
 		AppliedAt:     appliedAt,
@@ -600,9 +718,9 @@ func (s *Service) ApplyBankStatementImport(ctx context.Context, identity auth.Id
 		BankName:      import_.BankName,
 		Status:        string(finalStatus),
 		TotalRows:     int64(import_.TotalRows),
-		MatchedRows:   int64(import_.MatchedRows),
-		AmbiguousRows: int64(import_.AmbiguousRows),
-		UnmatchedRows: int64(import_.UnmatchedRows),
+		MatchedRows:   int64(newMatched),
+		AmbiguousRows: int64(newAmbiguous),
+		UnmatchedRows: int64(newUnmatched),
 		AppliedRows:   int64(newApplied),
 	}, nil
 }

--- a/backend/internal/levy/bank_statement_import_test.go
+++ b/backend/internal/levy/bank_statement_import_test.go
@@ -37,6 +37,78 @@ func TestParseFNBStatementCSV(t *testing.T) {
 	}
 }
 
+func TestParseCurrencyToCentsHandlesFloatingPointEdgeCases(t *testing.T) {
+	cases := []struct {
+		in   string
+		want int64
+	}{
+		{"128.14", 12814},
+		{"128.17", 12817},
+		{"128.20", 12820},
+		{"128.23", 12823},
+		{"128.39", 12839},
+		{"0.29", 29},
+		{"0.05", 5},
+		{"2450.00", 245000},
+		{"1", 100},
+		{"-128.20", -12820},
+		{"+128.20", 12820},
+		{"0.5", 50},
+		{"0", 0},
+		{"0.00", 0},
+	}
+	for _, c := range cases {
+		got, err := parseCurrencyToCents(c.in)
+		if err != nil {
+			t.Errorf("parseCurrencyToCents(%q) error: %v", c.in, err)
+			continue
+		}
+		if got != c.want {
+			t.Errorf("parseCurrencyToCents(%q) = %d, want %d", c.in, got, c.want)
+		}
+	}
+}
+
+func TestParseCurrencyToCentsRejectsInvalid(t *testing.T) {
+	cases := []string{
+		"",
+		"   ",
+		"abc",
+		"1.234",
+		"1.2.3",
+		".",
+		"1,2,3.45",
+		"1.0e2",
+		"-",
+	}
+	for _, in := range cases {
+		if _, err := parseCurrencyToCents(in); err == nil {
+			t.Errorf("parseCurrencyToCents(%q) expected error, got nil", in)
+		}
+	}
+}
+
+func TestParseFNBStatementCSVRoundsTwoDecimalCents(t *testing.T) {
+	csvData := []byte(`Date,Description,Reference,Amount
+2026-04-01,EFT UNIT 12A,12A,128.20
+2026-04-02,EFT UNIT 12B,12B,0.29
+2026-04-03,EFT UNIT 12C,12C,128.17
+`)
+	rows, err := parseFNBStatementCSV(csvData)
+	if err != nil {
+		t.Fatalf("parse csv: %v", err)
+	}
+	want := []int64{12820, 29, 12817}
+	if len(rows) != len(want) {
+		t.Fatalf("rows = %d, want %d", len(rows), len(want))
+	}
+	for i, w := range want {
+		if rows[i].AmountCents != w {
+			t.Errorf("row %d amount = %d, want %d", i, rows[i].AmountCents, w)
+		}
+	}
+}
+
 func TestParseFNBStatementCSVSkipsNonPositiveRows(t *testing.T) {
 	csvData := []byte(`Date,Description,Reference,Amount
 2026-04-01,EFT UNIT 12A,12A,2450.00
@@ -53,6 +125,60 @@ func TestParseFNBStatementCSVSkipsNonPositiveRows(t *testing.T) {
 	}
 	if rows[0].RowNumber != 2 || rows[1].RowNumber != 5 {
 		t.Fatalf("row numbers = %d,%d, want 2,5", rows[0].RowNumber, rows[1].RowNumber)
+	}
+}
+
+func TestValidateManualBankMatches(t *testing.T) {
+	rowID := func(s string) string { return s }
+	accountID := func(s string) string { return s }
+
+	tests := []struct {
+		name    string
+		matches []BankStatementManualMatchInput
+		wantErr bool
+	}{
+		{
+			name:    "empty",
+			matches: nil,
+			wantErr: true,
+		},
+		{
+			name: "valid",
+			matches: []BankStatementManualMatchInput{
+				{RowID: rowID("r1"), AccountID: accountID("a1")},
+				{RowID: rowID("r2"), AccountID: accountID("a2")},
+			},
+		},
+		{
+			name: "duplicate row_id",
+			matches: []BankStatementManualMatchInput{
+				{RowID: rowID("r1"), AccountID: accountID("a1")},
+				{RowID: rowID("r1"), AccountID: accountID("a2")},
+			},
+			wantErr: true,
+		},
+		{
+			name: "blank row id",
+			matches: []BankStatementManualMatchInput{
+				{RowID: "", AccountID: accountID("a1")},
+			},
+			wantErr: true,
+		},
+		{
+			name: "blank account id",
+			matches: []BankStatementManualMatchInput{
+				{RowID: rowID("r1"), AccountID: ""},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateManualBankMatches(tt.matches)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("err = %v, wantErr = %v", err, tt.wantErr)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- #223 — Replaced float64 truncation in the FNB CSV parser with `parseCurrencyToCents`, which uses integer arithmetic so values like `128.20` and `0.29` round to the correct cent. Inputs with more than two decimal places or non-numeric characters are now rejected.
- #204 — `ApplyBankStatementImport` refuses to mutate an import whose status is not `review_required` and rejects an empty `manual_matches` array, so a queued/processing import cannot be moved to `review_required` without parsed rows.
- #205 — `ApplyBankStatementImport` recalculates matched/ambiguous/unmatched row counts based on the prior status of each row being applied and writes those updated counters in the final status update, so the import summary matches reality.
- #206 — Reject `manual_matches` with duplicate `row_id` values to prevent `applied_rows` from being double-counted for the same row.

## Test plan

- [x] `go test ./...` — all backend packages pass.
- [x] `go vet ./...` — clean.
- [x] `golangci-lint run ./...` — clean.
- [x] `npm test` — 149 frontend tests pass.
- [x] `npm run lint` — clean.
- [x] `npm run typecheck` — clean.
- [x] New unit tests: `TestParseCurrencyToCentsHandlesFloatingPointEdgeCases`, `TestParseCurrencyToCentsRejectsInvalid`, `TestParseFNBStatementCSVRoundsTwoDecimalCents`, `TestValidateManualBankMatches`.