### PR TITLE
fix: recover auth sessions on page navigation and route refresh

### DIFF
--- a/app/agent/settings/page.tsx
+++ b/app/agent/settings/page.tsx
@@ -82,10 +82,11 @@ export default function AgentSettingsPage() {
 
     setSavingPassword(true)
     try {
-      await changePassword({
+      const updated = await changePassword({
         current_password: pwForm.current,
         new_password: pwForm.next,
       })
+      setUser(updated)
       setShowPasswordModal(false)
       setPwForm({ current: '', next: '', confirm: '' })
       addToast('Password updated', 'success')

--- a/app/api/copilot/route.ts
+++ b/app/api/copilot/route.ts
@@ -2,9 +2,26 @@ import { cookies } from 'next/headers'
 import { NextRequest } from 'next/server'
 
 import { readApiData, readApiError } from '@/lib/api-contract'
+import { clearAuthCookies, refreshAuthSession } from '@/lib/server-auth'
 
 const BACKEND = () => process.env.BACKEND_URL ?? 'http://localhost:8080'
 const COPILOT_TIMEOUT_MS = 15_000;
+
+async function callCopilot(
+  accessToken: string,
+  body: unknown,
+  signal: AbortSignal,
+): Promise<Response> {
+  return fetch(`${BACKEND()}/api/v1/ai/copilot`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${accessToken}`,
+    },
+    body: JSON.stringify(body),
+    signal,
+  });
+}
 
 export async function POST(request: NextRequest) {
   const cookieStore = await cookies()
@@ -36,15 +53,7 @@ export async function POST(request: NextRequest) {
   const timeout = setTimeout(() => controller.abort(), COPILOT_TIMEOUT_MS);
   let response: Response;
   try {
-    response = await fetch(`${BACKEND()}/api/v1/ai/copilot`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${accessToken}`,
-      },
-      body: JSON.stringify(body),
-      signal: controller.signal,
-    });
+    response = await callCopilot(accessToken, body, controller.signal);
   } catch (error) {
     clearTimeout(timeout);
     if (error instanceof DOMException && error.name === "AbortError") {
@@ -56,6 +65,43 @@ export async function POST(request: NextRequest) {
     throw error;
   }
   clearTimeout(timeout);
+
+  if (response.status === 401) {
+    const refreshed = await refreshAuthSession();
+    if (refreshed.kind === "invalid") {
+      await clearAuthCookies();
+      return new Response('Unauthorized', { status: 401, headers: { 'Content-Type': 'text/plain' } });
+    }
+    if (refreshed.kind === "unavailable") {
+      return new Response("Copilot temporarily unavailable. Please retry.", {
+        status: 503,
+        headers: { "Content-Type": "text/plain" },
+      });
+    }
+    const updatedAccessToken = cookieStore.get("sh_access")?.value;
+    if (!updatedAccessToken) {
+      await clearAuthCookies();
+      return new Response('Unauthorized', { status: 401, headers: { 'Content-Type': 'text/plain' } });
+    }
+    const retryController = new AbortController();
+    const retryTimeout = setTimeout(() => retryController.abort(), COPILOT_TIMEOUT_MS);
+    try {
+      response = await callCopilot(updatedAccessToken, body, retryController.signal);
+    } catch (error) {
+      clearTimeout(retryTimeout);
+      if (error instanceof DOMException && error.name === "AbortError") {
+        return new Response("Copilot temporarily unavailable. Please retry.", {
+          status: 503,
+          headers: { "Content-Type": "text/plain" },
+        });
+      }
+      throw error;
+    }
+    clearTimeout(retryTimeout);
+    if (response.status === 401) {
+      await clearAuthCookies();
+    }
+  }
 
   if (!response.ok) {
     return new Response(

--- a/app/app/[schemeId]/profile/page.tsx
+++ b/app/app/[schemeId]/profile/page.tsx
@@ -66,10 +66,11 @@ export default function ResidentProfilePage() {
 
     setSavingPassword(true)
     try {
-      await changePassword({
+      const updated = await changePassword({
         current_password: pwForm.current,
         new_password: pwForm.next,
       })
+      setUser(updated)
       setShowPasswordModal(false)
       setPwForm({ current: '', next: '', confirm: '' })
       addToast('Password updated', 'success')

--- a/app/app/[schemeId]/settings/page.tsx
+++ b/app/app/[schemeId]/settings/page.tsx
@@ -41,7 +41,7 @@ function toUnitForm(unit?: UnitInfo | null): UnitFormState {
 }
 
 export default function SchemeSettingsPage() {
-  const { user } = useAuth()
+  const { user, setUser } = useAuth()
   const { addToast } = useToast()
   const params = useParams()
   const schemeId = params.schemeId as string
@@ -191,10 +191,11 @@ export default function SchemeSettingsPage() {
 
     setSavingPassword(true)
     try {
-      await changePassword({
+      const updated = await changePassword({
         current_password: pwForm.current,
         new_password: pwForm.next,
       })
+      setUser(updated)
       setShowPasswordModal(false)
       setPwForm({ current: '', next: '', confirm: '' })
       addToast('Password updated', 'success')

--- a/backend/internal/auth/handler.go
+++ b/backend/internal/auth/handler.go
@@ -365,7 +365,8 @@ func (h *Handler) ChangePassword(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := h.service.ChangePassword(r.Context(), identity.UserID, req.CurrentPassword, req.NewPassword); err != nil {
+	res, err := h.service.ChangePassword(r.Context(), identity.UserID, req.CurrentPassword, req.NewPassword)
+	if err != nil {
 		switch err {
 		case ErrWrongPassword:
 			response.Error(w, http.StatusUnauthorized, response.CodeUnauthorized, "current password is incorrect")
@@ -374,8 +375,7 @@ func (h *Handler) ChangePassword(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
-
-	response.NoContent(w)
+	response.JSON(w, http.StatusOK, res)
 }
 
 func normalizeOptionalString(value *string) *string {

--- a/backend/internal/auth/handler_test.go
+++ b/backend/internal/auth/handler_test.go
@@ -22,7 +22,7 @@ type mockService struct {
 	resetFn          func(ctx context.Context, token, password string) error
 	updateProfileFn  func(ctx context.Context, userID, orgID, email, fullName string, phone *string) (*MeResponse, error)
 	updateOrgFn      func(ctx context.Context, orgID, name string, contactEmail, contactPhone *string) (*OrgInfo, error)
-	changePasswordFn func(ctx context.Context, userID, currentPassword, nextPassword string) error
+	changePasswordFn func(ctx context.Context, userID, currentPassword, nextPassword string) (*RefreshResponse, error)
 }
 
 func (m *mockService) Register(ctx context.Context, email, password, fullName string) (*AuthResponse, error) {
@@ -85,9 +85,9 @@ func (m *mockService) UpdateOrg(ctx context.Context, orgID, name string, contact
 	}
 	return m.updateOrgFn(ctx, orgID, name, contactEmail, contactPhone)
 }
-func (m *mockService) ChangePassword(ctx context.Context, userID, currentPassword, nextPassword string) error {
+func (m *mockService) ChangePassword(ctx context.Context, userID, currentPassword, nextPassword string) (*RefreshResponse, error) {
 	if m.changePasswordFn == nil {
-		return nil
+		return nil, nil
 	}
 	return m.changePasswordFn(ctx, userID, currentPassword, nextPassword)
 }
@@ -674,8 +674,8 @@ func TestUpdateOrg_ForbiddenForNonAdmin(t *testing.T) {
 
 func TestChangePassword_WrongPassword(t *testing.T) {
 	svc := &mockService{
-		changePasswordFn: func(_ context.Context, _, _, _ string) error {
-			return ErrWrongPassword
+		changePasswordFn: func(_ context.Context, _, _, _ string) (*RefreshResponse, error) {
+			return nil, ErrWrongPassword
 		},
 	}
 	req := httptest.NewRequest(http.MethodPost, "/change-password", body(t, map[string]string{

--- a/backend/internal/auth/service.go
+++ b/backend/internal/auth/service.go
@@ -122,7 +122,7 @@ type Servicer interface {
 	IssuePasswordResetURL(ctx context.Context, email, appBaseURL string) (string, error)
 	UpdateProfile(ctx context.Context, userID, orgID, email, fullName string, phone *string) (*MeResponse, error)
 	UpdateOrg(ctx context.Context, orgID, name string, contactEmail, contactPhone *string) (*OrgInfo, error)
-	ChangePassword(ctx context.Context, userID, currentPassword, nextPassword string) error
+	ChangePassword(ctx context.Context, userID, currentPassword, nextPassword string) (*RefreshResponse, error)
 }
 
 // Service implements Servicer.
@@ -233,6 +233,8 @@ func (s *Service) Refresh(ctx context.Context, refreshToken string) (*RefreshRes
 
 	var user dbgen.User
 	var membership dbgen.ListOrgMembershipsByUserRow
+	var accessToken string
+	var session *MeResponse
 
 	err = database.WithTxQueries(ctx, s.db, func(q *dbgen.Queries) error {
 		rt, txErr := q.ConsumeRefreshToken(ctx, HashRefreshToken(refreshToken))
@@ -260,6 +262,16 @@ func (s *Service) Refresh(ctx context.Context, refreshToken string) (*RefreshRes
 		}
 		membership = memberships[0]
 
+		accessToken, txErr = GenerateAccessToken(user.ID.String(), membership.OrgID.String(), membership.Role, s.jwtIssuer, s.jwtAudience, s.jwtSecret, s.jwtExpiry)
+		if txErr != nil {
+			return txErr
+		}
+
+		session, txErr = s.meWithQueries(ctx, q, user.ID.String(), membership.OrgID.String())
+		if txErr != nil {
+			return txErr
+		}
+
 		_, txErr = q.CreateRefreshToken(ctx, dbgen.CreateRefreshTokenParams{
 			Token:     HashRefreshToken(newRefreshToken),
 			UserID:    user.ID,
@@ -267,16 +279,6 @@ func (s *Service) Refresh(ctx context.Context, refreshToken string) (*RefreshRes
 		})
 		return txErr
 	})
-	if err != nil {
-		return nil, err
-	}
-
-	accessToken, err := GenerateAccessToken(user.ID.String(), membership.OrgID.String(), membership.Role, s.jwtIssuer, s.jwtAudience, s.jwtSecret, s.jwtExpiry)
-	if err != nil {
-		return nil, err
-	}
-
-	session, err := s.Me(ctx, user.ID.String(), membership.OrgID.String())
 	if err != nil {
 		return nil, err
 	}
@@ -301,6 +303,10 @@ func (s *Service) Logout(ctx context.Context, refreshToken string) error {
 }
 
 func (s *Service) Me(ctx context.Context, userID, orgID string) (*MeResponse, error) {
+	return s.meWithQueries(ctx, s.db.Q, userID, orgID)
+}
+
+func (s *Service) meWithQueries(ctx context.Context, q *dbgen.Queries, userID, orgID string) (*MeResponse, error) {
 	uid, err := uuid.Parse(userID)
 	if err != nil {
 		return nil, ErrInvalidToken
@@ -310,15 +316,15 @@ func (s *Service) Me(ctx context.Context, userID, orgID string) (*MeResponse, er
 		return nil, ErrInvalidToken
 	}
 
-	user, err := s.db.Q.GetUserByID(ctx, uid)
+	user, err := q.GetUserByID(ctx, uid)
 	if err != nil {
 		return nil, err
 	}
-	org, err := s.db.Q.GetOrg(ctx, oid)
+	org, err := q.GetOrg(ctx, oid)
 	if err != nil {
 		return nil, err
 	}
-	membership, err := s.db.Q.GetOrgMembershipByUser(ctx, dbgen.GetOrgMembershipByUserParams{
+	membership, err := q.GetOrgMembershipByUser(ctx, dbgen.GetOrgMembershipByUserParams{
 		UserID: uid,
 		OrgID:  oid,
 	})
@@ -341,7 +347,7 @@ func (s *Service) Me(ctx context.Context, userID, orgID string) (*MeResponse, er
 	}
 
 	if membership.Role == "admin" {
-		schemes, err := s.db.Q.ListSchemesByOrg(ctx, oid)
+		schemes, err := q.ListSchemesByOrg(ctx, oid)
 		if err != nil {
 			return nil, err
 		}
@@ -357,7 +363,7 @@ func (s *Service) Me(ctx context.Context, userID, orgID string) (*MeResponse, er
 		}
 	} else {
 		resp.WizardComplete = true
-		schemeMemberships, err := s.db.Q.ListSchemeMembershipsByUser(ctx, uid)
+		schemeMemberships, err := q.ListSchemeMembershipsByUser(ctx, uid)
 		if err != nil {
 			return nil, err
 		}
@@ -441,35 +447,81 @@ func (s *Service) UpdateOrg(ctx context.Context, orgID, name string, contactEmai
 	}, nil
 }
 
-func (s *Service) ChangePassword(ctx context.Context, userID, currentPassword, nextPassword string) error {
+func (s *Service) ChangePassword(ctx context.Context, userID, currentPassword, nextPassword string) (*RefreshResponse, error) {
 	uid, err := uuid.Parse(userID)
 	if err != nil {
-		return ErrInvalidToken
+		return nil, ErrInvalidToken
 	}
 
 	user, err := s.db.Q.GetUserByID(ctx, uid)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if compareErr := bcrypt.CompareHashAndPassword([]byte(user.PasswordHash), []byte(currentPassword)); compareErr != nil {
-		return ErrWrongPassword
+		return nil, ErrWrongPassword
 	}
 
 	hash, err := bcrypt.GenerateFromPassword([]byte(nextPassword), 12)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	return database.WithTxQueries(ctx, s.db, func(q *dbgen.Queries) error {
-		if txErr := q.UpdateUserPassword(ctx, dbgen.UpdateUserPasswordParams{
+	memberships, err := s.db.Q.ListOrgMembershipsByUser(ctx, uid)
+	if err != nil {
+		return nil, err
+	}
+	if len(memberships) == 0 {
+		return nil, ErrInvalidToken
+	}
+	membership := memberships[0]
+
+	newRefreshToken, err := GenerateRefreshToken()
+	if err != nil {
+		return nil, err
+	}
+
+	var accessToken string
+	var session *MeResponse
+
+	err = database.WithTxQueries(ctx, s.db, func(q *dbgen.Queries) error {
+		var txErr error
+		if txErr = q.UpdateUserPassword(ctx, dbgen.UpdateUserPasswordParams{
 			ID:           uid,
 			PasswordHash: string(hash),
 		}); txErr != nil {
 			return txErr
 		}
-		return q.RevokeAllUserRefreshTokens(ctx, uid)
+		if txErr = q.RevokeAllUserRefreshTokens(ctx, uid); txErr != nil {
+			return txErr
+		}
+		accessToken, txErr = GenerateAccessToken(uid.String(), membership.OrgID.String(), membership.Role, s.jwtIssuer, s.jwtAudience, s.jwtSecret, s.jwtExpiry)
+		if txErr != nil {
+			return txErr
+		}
+		session, txErr = s.meWithQueries(ctx, q, uid.String(), membership.OrgID.String())
+		if txErr != nil {
+			return txErr
+		}
+		if _, txErr = q.CreateRefreshToken(ctx, dbgen.CreateRefreshTokenParams{
+			Token:     HashRefreshToken(newRefreshToken),
+			UserID:    uid,
+			ExpiresAt: time.Now().Add(s.refreshExpiry),
+		}); txErr != nil {
+			return txErr
+		}
+		return nil
 	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &RefreshResponse{
+		AccessToken:  accessToken,
+		RefreshToken: newRefreshToken,
+		ExpiresIn:    int(s.jwtExpiry.Seconds()),
+		Session:      *session,
+	}, nil
 }
 
 func (s *Service) Setup(ctx context.Context, orgID, orgName, contactEmail, schemeName, schemeAddress string, unitCount int32) (*SetupResponse, error) {

--- a/backend/tests/integration/auth_test.go
+++ b/backend/tests/integration/auth_test.go
@@ -503,8 +503,12 @@ func TestAuth_ProfileOrgAndPasswordManagement(t *testing.T) {
 	req = withAuthContext(req, accessToken, testJWTSigningKey)
 	w = httptest.NewRecorder()
 	h.ChangePassword(w, req)
-	if w.Code != http.StatusNoContent {
+	if w.Code != http.StatusOK {
 		t.Fatalf("change password: status=%d body=%s", w.Code, w.Body)
+	}
+	reissue := decodeSuccess[auth.AuthResponse](t, w)
+	if reissue.AccessToken == "" || reissue.RefreshToken == "" {
+		t.Fatalf("change password did not reissue tokens: %+v", reissue)
 	}
 
 	loginBody, _ := json.Marshal(map[string]string{

--- a/backend/tests/integration/earlyaccess_test.go
+++ b/backend/tests/integration/earlyaccess_test.go
@@ -74,8 +74,8 @@ func (f *fakeEarlyAccessAuthService) UpdateOrg(context.Context, string, string, 
 	return nil, errors.New("unexpected UpdateOrg call")
 }
 
-func (f *fakeEarlyAccessAuthService) ChangePassword(context.Context, string, string, string) error {
-	return errors.New("unexpected ChangePassword call")
+func (f *fakeEarlyAccessAuthService) ChangePassword(context.Context, string, string, string) (*auth.RefreshResponse, error) {
+	return nil, errors.New("unexpected ChangePassword call")
 }
 
 func newEarlyAccessHandler(t *testing.T, adminEmail, adminSecret string) *earlyaccess.Handler {

--- a/lib/account-api.ts
+++ b/lib/account-api.ts
@@ -3,6 +3,7 @@
 import { apiFetch } from "@/lib/api";
 import { readApiData, buildApiHttpError } from "@/lib/api-contract";
 import { readBrowserCSRFToken } from "@/lib/csrf";
+import { changePasswordAction } from "@/lib/auth-actions";
 import type { SessionOrg, SessionUser } from "@/lib/session";
 
 async function refreshSession(): Promise<SessionUser> {
@@ -77,13 +78,13 @@ export async function updateOrgSettings(input: {
 export async function changePassword(input: {
   current_password: string;
   new_password: string;
-}): Promise<void> {
-  const res = await apiFetch("/api/v1/auth/change-password", {
-    method: "POST",
-    body: JSON.stringify(input),
-  });
-
-  if (!res.ok) {
-    throw await buildApiHttpError(res, "Failed to update password");
+}): Promise<SessionUser> {
+  const result = await changePasswordAction(
+    input.current_password,
+    input.new_password,
+  );
+  if ("error" in result) {
+    throw new Error(result.error);
   }
+  return result.user;
 }

--- a/lib/auth-actions.ts
+++ b/lib/auth-actions.ts
@@ -2,7 +2,7 @@
 
 import { cookies } from "next/headers";
 import { readApiData, readApiError } from "./api-contract";
-import { writeAuthCookies, clearAuthCookies } from "./server-auth";
+import { writeAuthCookies, clearAuthCookies, refreshAuthSession } from "./server-auth";
 import type { SessionUser } from "./session";
 import { APP_ROLES, parseSessionCookie } from "./session";
 
@@ -170,6 +170,38 @@ export async function setupAction(data: {
     return { error: TEMP_UNAVAILABLE };
   }
 
+  if (res.status === 401) {
+    const refreshed = await refreshAuthSession();
+    if (refreshed.kind === "invalid") {
+      await clearAuthCookies();
+      return { error: "Session expired — please log in again" };
+    }
+    if (refreshed.kind === "unavailable") {
+      return { error: TEMP_UNAVAILABLE };
+    }
+    const refreshedAccessToken = cookieStore.get("sh_access")?.value;
+    if (!refreshedAccessToken) {
+      await clearAuthCookies();
+      return { error: "Session expired — please log in again" };
+    }
+    try {
+      res = await fetchWithTimeout(`${BACKEND()}/api/v1/onboarding/setup`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${refreshedAccessToken}`,
+        },
+        body: JSON.stringify(data),
+      });
+    } catch {
+      return { error: TEMP_UNAVAILABLE };
+    }
+    if (res.status === 401) {
+      await clearAuthCookies();
+      return { error: "Session expired — please log in again" };
+    }
+  }
+
   if (!res.ok) {
     return {
       error: await readApiError(res, "Setup failed — please try again"),
@@ -203,6 +235,93 @@ export async function setupAction(data: {
     encodeURIComponent(JSON.stringify(session)),
     SESSION_OPTS,
   );
+  return { user: session };
+}
+
+// ─── Change password ──────────────────────────────────────────────────────────
+
+export async function changePasswordAction(
+  currentPassword: string,
+  newPassword: string,
+): Promise<{ user: SessionUser } | { error: string }> {
+  const cookieStore = await cookies();
+  const accessToken = cookieStore.get("sh_access")?.value;
+  if (!accessToken) return { error: "Not authenticated" };
+
+  const csrfCookie = cookieStore.get("sh_csrf")?.value;
+  if (!csrfCookie) {
+    await clearAuthCookies();
+    return { error: "Session expired — please log in again" };
+  }
+
+  let res: Response;
+  try {
+    res = await fetchWithTimeout(`${BACKEND()}/api/v1/auth/change-password`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${accessToken}`,
+        "x-csrf-token": csrfCookie,
+      },
+      body: JSON.stringify({
+        current_password: currentPassword,
+        new_password: newPassword,
+      }),
+    });
+  } catch {
+    return { error: TEMP_UNAVAILABLE };
+  }
+
+  if (res.status === 401) {
+    const refreshed = await refreshAuthSession();
+    if (refreshed.kind === "invalid") {
+      await clearAuthCookies();
+      return { error: "Session expired — please log in again" };
+    }
+    if (refreshed.kind === "unavailable") {
+      return { error: TEMP_UNAVAILABLE };
+    }
+    const refreshedAccessToken = cookieStore.get("sh_access")?.value;
+    if (!refreshedAccessToken) {
+      await clearAuthCookies();
+      return { error: "Session expired — please log in again" };
+    }
+    try {
+      res = await fetchWithTimeout(`${BACKEND()}/api/v1/auth/change-password`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${refreshedAccessToken}`,
+          "x-csrf-token": csrfCookie,
+        },
+        body: JSON.stringify({
+          current_password: currentPassword,
+          new_password: newPassword,
+        }),
+      });
+    } catch {
+      return { error: TEMP_UNAVAILABLE };
+    }
+    if (res.status === 401) {
+      await clearAuthCookies();
+      return { error: "Session expired — please log in again" };
+    }
+  }
+
+  if (!res.ok) {
+    if (res.status === 401) {
+      return { error: "Current password is incorrect" };
+    }
+    return { error: await readApiError(res, "Failed to update password") };
+  }
+
+  const { access_token, refresh_token, session } = await readApiData<{
+    access_token: string;
+    refresh_token: string;
+    session: SessionUser;
+  }>(res);
+
+  await writeAuthCookies({ access_token, refresh_token, session });
   return { user: session };
 }
 

--- a/lib/middleware.test.ts
+++ b/lib/middleware.test.ts
@@ -116,7 +116,25 @@ describe("proxy", () => {
     expect(setCookie).toContain("sh_session=;");
   });
 
-  it("clears auth cookies when access token is expired", () => {
+  it("allows page request when access token is expired but refresh token is valid", () => {
+    const expiredAccess = mintJwt("user-1", Math.floor(Date.now() / 1000) - 60);
+    const request = new NextRequest("http://localhost/agent", {
+      headers: {
+        origin: "http://localhost",
+        cookie:
+          `${validSessionCookie}; sh_access=${expiredAccess}; sh_csrf=token; sh_refresh=valid-refresh`,
+      },
+      method: "GET",
+    });
+
+    const response = proxy(request);
+
+    expect(response.status).toBe(200);
+    const setCookie = getSetCookieValue(response.headers);
+    expect(setCookie ?? "").not.toContain("sh_session=;");
+  });
+
+  it("redirects when access token is expired and no refresh token", () => {
     const expiredAccess = mintJwt("user-1", Math.floor(Date.now() / 1000) - 60);
     const request = new NextRequest("http://localhost/agent", {
       headers: {
@@ -132,7 +150,6 @@ describe("proxy", () => {
     expect(response.status).toBe(307);
     const setCookie = getSetCookieValue(response.headers);
     expect(setCookie).toContain("sh_session=;");
-    expect(setCookie).toContain("sh_access=");
   });
 
   it("allows protected pages when session cookie exists (API handles token refresh)", () => {

--- a/proxy.ts
+++ b/proxy.ts
@@ -107,13 +107,23 @@ export function proxy(request: NextRequest) {
   if (!isPublicPath(pathname)) {
     const sessionCookie = request.cookies.get("sh_session");
     const accessToken = request.cookies.get("sh_access")?.value;
+    const refreshToken = request.cookies.get("sh_refresh")?.value;
     const session = parseSessionCookie(sessionCookie?.value);
 
-    if (!sessionCookie || !session || !accessToken || !isValidAccessToken(accessToken, session.id)) {
+    if (!sessionCookie || !session) {
       const loginUrl = new URL("/auth/login", request.url);
       loginUrl.searchParams.set("redirect", pathname);
-
       return clearStaleSessionCookies(NextResponse.redirect(loginUrl));
+    }
+
+    if (!accessToken || !isValidAccessToken(accessToken, session.id)) {
+      if (!refreshToken) {
+        const loginUrl = new URL("/auth/login", request.url);
+        loginUrl.searchParams.set("redirect", pathname);
+        return clearStaleSessionCookies(NextResponse.redirect(loginUrl));
+      }
+      // Access token expired but refresh token exists. Allow the request to
+      // proceed; the API client will refresh the session on the first 401.
     }
   }
 


### PR DESCRIPTION
## Summary

- #202 — `proxy.ts` no longer wipes auth cookies when the access token is expired but a valid refresh token exists. The page now loads and the API layer handles refresh on 401 instead of forcing a re-login for short-lived access-token expiry.
- #246 — `Refresh` now builds the access token and the `Me` session payload inside the same transaction that revokes the old refresh token, so a failure after rotation rolls back and the user keeps their existing refresh token.
- #252 — `ChangePassword` now returns a fresh `AuthResponse` (new access and refresh tokens + session) instead of `204 No Content`. The frontend `changePasswordAction` writes the new cookies, so the user stays signed in across the password change.
- #209 — `/api/copilot` now calls `refreshAuthSession` on a backend 401 and retries the request with the new access token, matching the `/api/proxy` behavior.
- #219 — `setupAction` now calls `refreshAuthSession` and retries once on a 401 from the backend, so a first-run wizard submit does not fail just because the access token expired while the admin was filling out the form.

## Test plan

- [x] `go test ./...` — all backend packages pass, including updated `auth.handler_test.go` mock for the new `ChangePassword` signature.
- [x] `go vet ./...` — clean.
- [x] `golangci-lint run ./...` — clean.
- [x] `npm test` — 150 frontend tests pass, including new `middleware.test.ts` cases asserting the proxy allows page requests when only the refresh token is present and only redirects when the refresh token is also missing.
- [x] `npm run lint` — clean.
- [x] `npm run typecheck` — clean.