### PR TITLE
fix: bump Go to 1.26.4 to resolve govulncheck failures

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.25"
+          go-version: "1.26"
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
@@ -65,7 +65,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.25"
+          go-version: "1.26"
 
       - name: Install tools
         run: |
@@ -117,7 +117,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.25"
+          go-version: "1.26"
 
       - name: Build server binary
         run: go build -ldflags="-s -w" -o bin/server ./cmd/server/

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ stratahq-app/
 | --- | --- |
 | Frontend | Next.js 16, React 19, TypeScript, Tailwind CSS |
 | Frontend data | Server actions, server components, React Query |
-| Backend | Go 1.25.0+, Chi, pgx/v5, sqlc, goose |
+| Backend | Go 1.26.4+, Chi, pgx/v5, sqlc, goose |
 | Data stores | PostgreSQL 17, Redis 7 |
 | Auth | Backend-issued JWT access and refresh tokens |
 | Payments | Stripe |
@@ -180,7 +180,7 @@ Integration tests require local PostgreSQL and Redis services. Start them with
 
 - Node.js 22 or newer
 - npm
-- Go 1.25.0 or newer
+- Go 1.26.4 or newer
 - Docker and Docker Compose
 - sqlc
 - goose

--- a/backend/.github/workflows/ci.yml
+++ b/backend/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version: "1.26"
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
@@ -61,7 +61,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version: "1.26"
 
       - name: Install tools
         run: |
@@ -91,7 +91,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version: "1.26"
 
       - name: Build binary
         run: go build -ldflags="-s -w" -o bin/server ./cmd/server/

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build
-FROM golang:1.25-alpine AS builder
+FROM golang:1.26-alpine AS builder
 
 ARG GOOSE_VERSION=v3.27.1
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -6,7 +6,7 @@ Go backend for [StrataHQ](https://stratahq.com) — property management software
 
 | Tool | Purpose |
 |------|---------|
-| [Go 1.25.9+](https://go.dev/) | Language |
+| [Go 1.26.4+](https://go.dev/) | Language |
 | [Chi](https://github.com/go-chi/chi) | HTTP router |
 | [PostgreSQL 17](https://www.postgresql.org/) | Primary database |
 | [pgx/v5](https://github.com/jackc/pgx) | Postgres driver |
@@ -23,7 +23,7 @@ Go backend for [StrataHQ](https://stratahq.com) — property management software
 
 ### Prerequisites
 
-- [Go 1.25.9+](https://go.dev/dl/)
+- [Go 1.26.4+](https://go.dev/dl/)
 - [Docker](https://docs.docker.com/get-docker/) & Docker Compose
 - [sqlc](https://docs.sqlc.dev/en/latest/overview/install.html)
 - [goose](https://github.com/pressly/goose#install)

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,6 +1,6 @@
 module github.com/stratahq/backend
 
-go 1.25.9
+go 1.26.4
 
 require (
 	github.com/alicebob/miniredis/v2 v2.37.0
@@ -11,6 +11,7 @@ require (
 	github.com/joho/godotenv v1.5.1
 	github.com/openai/openai-go v1.12.0
 	github.com/prometheus/client_golang v1.23.2
+	github.com/prometheus/client_model v0.6.2
 	github.com/redis/go-redis/v9 v9.18.0
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/crypto v0.36.0
@@ -27,7 +28,6 @@ require (
 	github.com/kr/text v0.2.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
 	github.com/tidwall/gjson v1.14.4 // indirect


### PR DESCRIPTION
## Problem

Backend CI fails on `main` because `govulncheck` exits with code 3 — two Go stdlib vulnerabilities:

- **GO-2026-5039** — `net/textproto`: unescaped inputs in errors
- **GO-2026-5037** — `crypto/x509`: inefficient hostname parsing

Both fixed in **Go 1.26.4** (released June 2, 2026).

## Fix

Bump Go from 1.25 → 1.26 across:

- `go.mod` → `go 1.26.4`
- `.github/workflows/backend-ci.yml` → `go-version: 1.26`
- `backend/.github/workflows/ci.yml` → `go-version: 1.26` (was 1.24)
- `backend/Dockerfile` → `golang:1.26-alpine`

## Verification

- [x] `govulncheck ./...` → 0 vulnerabilities
- [x] `go test ./internal/...` → all pass
- [x] `go build` → server + worker build cleanly
- [x] `go vet ./...` → clean