### PR TITLE
fix: disable inert Delete account button with coming-soon affordance (#237)

### DIFF
--- a/app/agent/settings/page.tsx
+++ b/app/agent/settings/page.tsx
@@ -278,8 +278,11 @@ export default function AgentSettingsPage() {
           </div>
           <div className="pt-2 border-t border-border">
             <p className="text-[12px] text-muted mb-2">Danger zone</p>
-            <button className="text-[12px] font-medium text-red hover:underline">
-              Delete account
+            <button
+              disabled
+              className="text-[12px] font-medium text-muted opacity-50 cursor-not-allowed"
+            >
+              Delete account (coming soon)
             </button>
           </div>
         </div>


### PR DESCRIPTION
Closes #237

The Delete account button in Agent Settings had no click handler, leaving users confused when nothing happened on click. This disables the button and adds a (coming soon) label so the state is clear.