### PR TITLE
fix: disable inert levy statement download button with coming-soon affordance (#264)

### DIFF
--- a/app/app/[schemeId]/levy/page.tsx
+++ b/app/app/[schemeId]/levy/page.tsx
@@ -207,8 +207,11 @@ export default function LevyPaymentsPage() {
           </div>
         )}
 
-        <button onClick={() => addToast('Statement downloads will ship with the documents slice.', 'info')} className="text-[12px] text-accent font-medium border border-accent rounded px-4 py-2 hover:bg-accent-dim transition-colors">
-          Download statement (PDF)
+        <button
+          disabled
+          className="text-[12px] text-muted font-medium border border-border rounded px-4 py-2 opacity-50 cursor-not-allowed"
+        >
+          Download statement (PDF) — coming soon
         </button>
       </div>
     )


### PR DESCRIPTION
Closes #264

The Download statement (PDF) button on the resident levy page only showed a toast and had no actual download implementation. This disables the button with a clear coming-soon label.