### PR TITLE
fix: exclude pending_approval requests from dashboard SLA-breach count (#229)

### DIFF
--- a/backend/internal/maintenance/service.go
+++ b/backend/internal/maintenance/service.go
@@ -545,7 +545,7 @@ func timestamptzPointer(value pgtype.Timestamptz) *time.Time {
 }
 
 func isSlaBreached(createdAt time.Time, slaHours int32, status dbgen.MaintenanceStatus, now time.Time) bool {
-	if status == dbgen.MaintenanceStatusResolved {
+	if status == dbgen.MaintenanceStatusResolved || status == dbgen.MaintenanceStatusPendingApproval {
 		return false
 	}
 	return createdAt.Add(time.Duration(slaHours) * time.Hour).Before(now)


### PR DESCRIPTION
Closes #229

Pending-approval maintenance requests were counted as SLA-breached in the dashboard but excluded from the health-score query. This aligns  with the health-score SQL by also excluding  status, ensuring consistent SLA breach signals across both views.