### PR TITLE
fix: Copilot AGM context to select nearest future meeting as upcoming (#226)

### DIFF
--- a/backend/internal/ai/service.go
+++ b/backend/internal/ai/service.go
@@ -312,7 +312,7 @@ func (s *Service) buildAgmSummary(ctx context.Context, meetings []dbgen.AgmMeeti
 		return map[string]any{}, nil
 	}
 	sort.Slice(meetings, func(i, j int) bool {
-		return meetings[i].MeetingDate.Time.After(meetings[j].MeetingDate.Time)
+		return meetings[i].MeetingDate.Time.Before(meetings[j].MeetingDate.Time)
 	})
 
 	var latest map[string]any
@@ -330,7 +330,7 @@ func (s *Service) buildAgmSummary(ctx context.Context, meetings []dbgen.AgmMeeti
 			"quorum_present":  meeting.QuorumPresent,
 			"resolutions":     mapResolutions(resolutions, 6),
 		}
-		if (meeting.MeetingDate.Time.Before(now) || meeting.Status == dbgen.AgmStatusClosed) && latest == nil {
+		if meeting.MeetingDate.Time.Before(now) || meeting.Status == dbgen.AgmStatusClosed {
 			latest = item
 			continue
 		}


### PR DESCRIPTION
Closes #226

The Copilot AGM prompt builder sorted meetings newest-first, which caused upcoming to pick the furthest future meeting instead of the nearest. Changed sort order to ascending so the first future meeting encountered is the nearest one, and latest is the most recent past meeting (the last one seen in ascending order).