### PR TITLE
fix: prevent dismissing non-candidate WhatsApp maintenance intakes (#250)

### DIFF
--- a/backend/internal/whatsapp/service.go
+++ b/backend/internal/whatsapp/service.go
@@ -702,6 +702,9 @@ func (s *Service) DismissMaintenanceIntake(ctx context.Context, identity auth.Id
 	if intake.SchemeID != access.scheme.ID {
 		return nil, ErrForbidden
 	}
+	if intake.Status != "candidate" {
+		return nil, ErrInvalidInput
+	}
 	dismissed, err := s.db.Q.DismissWhatsAppMaintenanceIntake(ctx, id)
 	if err != nil {
 		return nil, err

--- a/backend/tests/integration/whatsapp_test.go
+++ b/backend/tests/integration/whatsapp_test.go
@@ -540,13 +540,8 @@ func TestWhatsAppMaintenanceInboxManualCreateAndDismiss(t *testing.T) {
 	dismissReq = dismissReq.WithContext(auth.ContextWithIdentity(dismissReq.Context(), trusteeUserID, orgID, string(auth.RoleTrustee)))
 	dismissW := httptest.NewRecorder()
 	h.DismissMaintenanceIntake(dismissW, dismissReq)
-	if dismissW.Code != http.StatusOK {
-		t.Fatalf("trustee dismiss maintenance intake: status=%d body=%s", dismissW.Code, dismissW.Body)
-	}
-
-	dismissed := decodeSuccess[whatsapp.MaintenanceIntakeInfo](t, dismissW)
-	if dismissed.Status != "dismissed" {
-		t.Fatalf("expected dismissed status, got %q", dismissed.Status)
+	if dismissW.Code != http.StatusBadRequest {
+		t.Fatalf("trustee dismiss ticket_created intake should fail: status=%d body=%s", dismissW.Code, dismissW.Body)
 	}
 
 	createReq = httptest.NewRequest(http.MethodPost, "/whatsapp/"+schemeID+"/messages/"+msgID+"/maintenance-request", bytes.NewReader(createBody))
@@ -554,8 +549,8 @@ func TestWhatsAppMaintenanceInboxManualCreateAndDismiss(t *testing.T) {
 	createReq = createReq.WithContext(auth.ContextWithIdentity(createReq.Context(), trusteeUserID, orgID, string(auth.RoleTrustee)))
 	createW = httptest.NewRecorder()
 	h.CreateMaintenanceFromMessage(createW, createReq)
-	if createW.Code != http.StatusBadRequest {
-		t.Fatalf("trustee create maintenance after dismissal should be rejected: status=%d body=%s", createW.Code, createW.Body)
+	if createW.Code != http.StatusOK {
+		t.Fatalf("trustee re-create maintenance from same message should return existing intake: status=%d body=%s", createW.Code, createW.Body)
 	}
 
 	dismissReq = httptest.NewRequest(http.MethodPatch, "/whatsapp/"+schemeID+"/maintenance-intakes/"+created.ID, nil)

--- a/backend/tests/integration/whatsapp_test.go
+++ b/backend/tests/integration/whatsapp_test.go
@@ -549,7 +549,7 @@ func TestWhatsAppMaintenanceInboxManualCreateAndDismiss(t *testing.T) {
 	createReq = createReq.WithContext(auth.ContextWithIdentity(createReq.Context(), trusteeUserID, orgID, string(auth.RoleTrustee)))
 	createW = httptest.NewRecorder()
 	h.CreateMaintenanceFromMessage(createW, createReq)
-	if createW.Code != http.StatusOK {
+	if createW.Code != http.StatusCreated {
 		t.Fatalf("trustee re-create maintenance from same message should return existing intake: status=%d body=%s", createW.Code, createW.Body)
 	}
 


### PR DESCRIPTION
Closes #250

The WhatsApp intake dismiss endpoint unconditionally dismissed any intake regardless of its status. This allowed dismissing already ticket-created intakes, hiding the ticket relationship while leaving the maintenance request active. Added a status guard so only candidate intakes can be dismissed.