### PR TITLE
fix: normalize WhatsApp prefix in Twilio client to avoid duplication (#232)

### DIFF
--- a/backend/internal/twilio/client.go
+++ b/backend/internal/twilio/client.go
@@ -26,9 +26,17 @@ func NewClient(accountSID, authToken, fromNumber string) *Client {
 	return &Client{
 		accountSID: accountSID,
 		authToken:  authToken,
-		fromNumber: fromNumber,
+		fromNumber: stripWhatsAppPrefix(fromNumber),
 		httpClient: &http.Client{Timeout: requestTimeout},
 	}
+}
+
+func stripWhatsAppPrefix(num string) string {
+	const prefix = "whatsapp:"
+	for strings.HasPrefix(num, prefix) {
+		num = strings.TrimPrefix(num, prefix)
+	}
+	return num
 }
 
 func (c *Client) SendWhatsAppMessage(to, body string) error {


### PR DESCRIPTION
Closes #232

The Twilio client unconditionally prepends 'whatsapp:' to the configured from number, but config values could already include the prefix, resulting in 'whatsapp:whatsapp:+2782'. This strips any existing 'whatsapp:' prefixes before constructing the API request.