### PR TITLE
fix: return store error from collection reminder handlers after send (#224)

### DIFF
--- a/backend/internal/jobs/collection_reminders.go
+++ b/backend/internal/jobs/collection_reminders.go
@@ -57,6 +57,7 @@ func (h *CollectionReminderEmailHandler) Handle(ctx context.Context, raw json.Ra
 		EmailError:  pgtype.Text{},
 	}); err != nil {
 		h.logger.Error("failed to mark collection event email delivery as sent", "collectionEventId", payload.CollectionEventID, "error", err)
+		return err
 	}
 	return nil
 }
@@ -95,6 +96,7 @@ func (h *CollectionReminderWhatsAppHandler) Handle(ctx context.Context, raw json
 		WhatsappError:  pgtype.Text{},
 	}); err != nil {
 		h.logger.Error("failed to mark collection event whatsapp delivery as sent", "collectionEventId", payload.CollectionEventID, "error", err)
+		return err
 	}
 	return nil
 }

--- a/backend/internal/jobs/collection_reminders_test.go
+++ b/backend/internal/jobs/collection_reminders_test.go
@@ -40,21 +40,29 @@ func (f *fakeWhatsAppSender) SendWhatsAppMessage(to, body string) error {
 }
 
 type fakeCollectionDeliveryStore struct {
-	emailStatus    pgtype.Text
-	emailError     pgtype.Text
-	whatsappStatus pgtype.Text
-	whatsappError  pgtype.Text
+	emailStatus      pgtype.Text
+	emailError       pgtype.Text
+	whatsappStatus   pgtype.Text
+	whatsappError    pgtype.Text
+	emailMarkErr     error
+	whatsappMarkErr  error
 }
 
 func (f *fakeCollectionDeliveryStore) MarkCollectionEventEmailDelivery(ctx context.Context, arg dbgen.MarkCollectionEventEmailDeliveryParams) (dbgen.CollectionEvent, error) {
 	f.emailStatus = arg.EmailStatus
 	f.emailError = arg.EmailError
+	if f.emailMarkErr != nil {
+		return dbgen.CollectionEvent{}, f.emailMarkErr
+	}
 	return dbgen.CollectionEvent{ID: arg.ID}, nil
 }
 
 func (f *fakeCollectionDeliveryStore) MarkCollectionEventWhatsAppDelivery(ctx context.Context, arg dbgen.MarkCollectionEventWhatsAppDeliveryParams) (dbgen.CollectionEvent, error) {
 	f.whatsappStatus = arg.WhatsappStatus
 	f.whatsappError = arg.WhatsappError
+	if f.whatsappMarkErr != nil {
+		return dbgen.CollectionEvent{}, f.whatsappMarkErr
+	}
 	return dbgen.CollectionEvent{ID: arg.ID}, nil
 }
 
@@ -121,6 +129,43 @@ func TestCollectionReminderWhatsAppHandlerMarksSent(t *testing.T) {
 	require.Equal(t, "Please pay", sender.body)
 	require.Equal(t, pgtype.Text{String: "sent", Valid: true}, store.whatsappStatus)
 	require.False(t, store.whatsappError.Valid)
+}
+
+func TestCollectionReminderEmailHandlerReturnsStoreErrorAfterSend(t *testing.T) {
+	eventID := uuid.MustParse("33333333-3333-3333-3333-333333333333")
+	store := &fakeCollectionDeliveryStore{emailMarkErr: errors.New("db unavailable")}
+	sender := &fakeEmailSender{}
+	handler := NewCollectionReminderEmailHandler(store, sender)
+	payload, err := json.Marshal(CollectionReminderEmailPayload{
+		CollectionEventID: eventID,
+		To:                "owner@example.com",
+		Subject:           "Reminder",
+		HTMLBody:          "<p>Pay</p>",
+	})
+	require.NoError(t, err)
+
+	err = handler.Handle(context.Background(), payload)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "db unavailable")
+}
+
+func TestCollectionReminderWhatsAppHandlerReturnsStoreErrorAfterSend(t *testing.T) {
+	eventID := uuid.MustParse("44444444-4444-4444-4444-444444444444")
+	store := &fakeCollectionDeliveryStore{whatsappMarkErr: errors.New("db unavailable")}
+	sender := &fakeWhatsAppSender{}
+	handler := NewCollectionReminderWhatsAppHandler(store, sender)
+	payload, err := json.Marshal(CollectionReminderWhatsAppPayload{
+		CollectionEventID: eventID,
+		To:                "+27820000000",
+		Body:              "Please pay",
+	})
+	require.NoError(t, err)
+
+	err = handler.Handle(context.Background(), payload)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "db unavailable")
 }
 
 func TestCollectionReminderWhatsAppHandlerRejectsBadPayload(t *testing.T) {


### PR DESCRIPTION
Closes #224

Collection reminder email/WhatsApp handlers swallowed database errors when marking delivery status as sent after a successful provider send. This caused the job to be marked succeeded while the collection event stayed stale. Now returns the mark-as-sent error so the job can be retried, and adds tests for the store-failure-after-send path.