### PR TITLE
fix: validate scheme_id UUID in contractor list filters (#230)

### DIFF
--- a/backend/internal/contractors/service.go
+++ b/backend/internal/contractors/service.go
@@ -169,6 +169,11 @@ func (s *Service) List(ctx context.Context, identity auth.Identity, filters Cont
 	if err != nil {
 		return nil, ErrInvalidInput
 	}
+	if filters.SchemeID != "" {
+		if _, parseErr := uuid.Parse(filters.SchemeID); parseErr != nil {
+			return nil, ErrInvalidInput
+		}
+	}
 	if !auth.IsAdminRole(identity.Role) {
 		if filters.SchemeID == "" {
 			return nil, ErrForbidden


### PR DESCRIPTION
Closes #230

Invalid scheme_id query parameters (e.g. 'not-a-uuid') were silently treated as no filter, returning all org contractors instead of rejecting the request. Added a UUID parse check that returns ErrInvalidInput / 400 for malformed scheme_id values.