### PR TITLE
fix: enforce scheme unit_count invariant on create and update (#260)

### DIFF
--- a/backend/internal/scheme/service.go
+++ b/backend/internal/scheme/service.go
@@ -325,6 +325,16 @@ func (s *Service) Update(ctx context.Context, identity auth.Identity, schemeID s
 		return nil, ErrForbidden
 	}
 
+	if input.UnitCount != scheme.UnitCount {
+		existingUnits, countErr := s.db.Q.ListUnitsByScheme(ctx, scheme.ID)
+		if countErr != nil {
+			return nil, countErr
+		}
+		if input.UnitCount < int32(len(existingUnits)) {
+			return nil, ErrInvalidInput
+		}
+	}
+
 	updated, err := s.db.Q.UpdateScheme(ctx, dbgen.UpdateSchemeParams{
 		ID:        scheme.ID,
 		Name:      input.Name,
@@ -427,6 +437,14 @@ func (s *Service) CreateUnit(ctx context.Context, identity auth.Identity, scheme
 	}
 	if int32(existingTotal)+input.SectionValueBps > 10000 {
 		return nil, errors.New("section value total would exceed 10000 basis points")
+	}
+
+	existingUnits, err := s.db.Q.ListUnitsByScheme(ctx, scheme.ID)
+	if err != nil {
+		return nil, err
+	}
+	if int32(len(existingUnits)) >= scheme.UnitCount {
+		return nil, errors.New("cannot create more units than the scheme unit count")
 	}
 
 	unit, err := s.db.Q.CreateUnit(ctx, dbgen.CreateUnitParams{


### PR DESCRIPTION
Closes #260

Scheme unit_count could diverge from actual unit rows because unit creation wasn't bounded by it and scheme updates could lower unit_count below existing unit records. Added checks to prevent creating more units than unit_count and lowering unit_count below the number of existing units.