### PR TITLE
fix: enforce valid status transition for maintenance assignment (#215)

### DIFF
--- a/backend/internal/maintenance/service.go
+++ b/backend/internal/maintenance/service.go
@@ -227,6 +227,9 @@ func (s *Service) Assign(ctx context.Context, identity auth.Identity, schemeID, 
 	if request.SchemeID != access.scheme.ID {
 		return nil, ErrForbidden
 	}
+	if request.Status != dbgen.MaintenanceStatusOpen && request.Status != dbgen.MaintenanceStatusPendingApproval {
+		return nil, ErrInvalidInput
+	}
 
 	beforeInfo, err := s.enrichRequest(ctx, request)
 	if err != nil {


### PR DESCRIPTION
Closes #215

The Assign function allowed assigning contractors to maintenance requests regardless of current status, enabling reopened resolved jobs and skipping the approval workflow. Added a status guard requiring open or pending_approval status before assignment. The Resolve function already had proper guards.