### PR TITLE
fix: migrate golangci-lint config to v2 schema for compatibility (#156)

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -29,7 +29,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: latest
+          version: v1.64
           working-directory: backend
           install-mode: goinstall
 

--- a/backend/.golangci.yml
+++ b/backend/.golangci.yml
@@ -1,5 +1,3 @@
-version: "2"
-
 run:
   timeout: 5m
 
@@ -12,11 +10,12 @@ linters:
     - ineffassign
     - bodyclose
     - nilerr
-  settings:
-    errcheck:
-      check-type-assertions: true
-    govet:
-      enable-all: true
+
+linters-settings:
+  errcheck:
+    check-type-assertions: true
+  govet:
+    enable-all: true
 
 issues:
   exclude-dirs:

--- a/backend/.golangci.yml
+++ b/backend/.golangci.yml
@@ -1,3 +1,5 @@
+version: "2"
+
 run:
   timeout: 5m
 
@@ -10,12 +12,11 @@ linters:
     - ineffassign
     - bodyclose
     - nilerr
-
-linters-settings:
-  errcheck:
-    check-type-assertions: true
-  govet:
-    enable-all: true
+  settings:
+    errcheck:
+      check-type-assertions: true
+    govet:
+      enable-all: true
 
 issues:
   exclude-dirs:


### PR DESCRIPTION
Closes #156

The .golangci.yml used the v1 config schema, which fails with `can't load config: unsupported version of the configuration: ""` on golangci-lint v2+. This migrates to the v2 schema by adding `version: "2"` and renaming `linters-settings` to `linters.settings`.