### PR TITLE
fix: return early-access approval email errors instead of discarding them (#175)

### DIFF
--- a/backend/internal/earlyaccess/service.go
+++ b/backend/internal/earlyaccess/service.go
@@ -306,8 +306,7 @@ func (s *Service) sendApproval(ctx context.Context, req dbgen.EarlyAccessRequest
 		return err
 	}
 
-	_ = s.notifier.SendEarlyAccessApproval(ctx, req.Email, req.FullName, setPasswordURL)
-	return nil
+	return s.notifier.SendEarlyAccessApproval(ctx, req.Email, req.FullName, setPasswordURL)
 }
 
 func toResponse(r dbgen.EarlyAccessRequest) *RequestResponse {


### PR DESCRIPTION
Closes #175

The sendApproval function discarded the notification provider error with `_ =`, so admins saw success but the user never received the set-password link when the email provider was down. This returns the error so the handler surfaces it as a 500 and the admin can retry.