### PR TITLE
fix: deduplicate scheme IDs before counting to avoid false forbidden (#201)

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -69,12 +69,16 @@ jobs:
 
       - name: Install tools
         run: |
-          go install github.com/sqlc-dev/sqlc/cmd/sqlc@v1.30.0
+          go install github.com/sqlc-dev/sqlc/cmd/sqlc@v1.31.1
           go install github.com/pressly/goose/v3/cmd/goose@latest
           go install golang.org/x/vuln/cmd/govulncheck@latest
 
       - name: Generate sqlc
         run: cd db && sqlc generate
+
+      - name: sqlc drift check
+        run: |
+          git diff --exit-code -- db/gen/ || (echo "ERROR: sqlc generate produced changes. Run 'make generate' and commit the result." && exit 1)
 
       - name: Run migrations
         run: goose -dir db/migrations postgres "postgres://stratahq:stratahq@localhost:5432/stratahq_test?sslmode=disable" up

--- a/backend/README.md
+++ b/backend/README.md
@@ -25,7 +25,7 @@ Go backend for [StrataHQ](https://stratahq.com) — property management software
 
 - [Go 1.26.4+](https://go.dev/dl/)
 - [Docker](https://docs.docker.com/get-docker/) & Docker Compose
-- [sqlc](https://docs.sqlc.dev/en/latest/overview/install.html)
+- [sqlc](https://docs.sqlc.dev/en/latest/overview/install.html) v1.31.1 (`go install github.com/sqlc-dev/sqlc/cmd/sqlc@v1.31.1`)
 - [goose](https://github.com/pressly/goose#install)
 - [golangci-lint](https://golangci-lint.run/welcome/install/)
 

--- a/backend/internal/contractors/service.go
+++ b/backend/internal/contractors/service.go
@@ -344,6 +344,7 @@ func (s *Service) contractorParams(ctx context.Context, orgID uuid.UUID, input U
 	if err != nil {
 		return dbgen.CreateContractorParams{}, nil, ErrInvalidInput
 	}
+	schemeIDs = dedupUUIDs(schemeIDs)
 	if len(schemeIDs) > 0 {
 		count, countErr := s.db.Q.CountSchemesByOrgForContractorLinks(ctx, dbgen.CountSchemesByOrgForContractorLinksParams{
 			OrgID: orgID, SchemeIds: schemeIDs,
@@ -375,6 +376,18 @@ func validTrade(value string) bool {
 	default:
 		return false
 	}
+}
+
+func dedupUUIDs(ids []uuid.UUID) []uuid.UUID {
+	seen := make(map[uuid.UUID]struct{}, len(ids))
+	result := make([]uuid.UUID, 0, len(ids))
+	for _, id := range ids {
+		if _, ok := seen[id]; !ok {
+			seen[id] = struct{}{}
+			result = append(result, id)
+		}
+	}
+	return result
 }
 
 func parseUUIDs(values []string) ([]uuid.UUID, error) {

--- a/backend/internal/integrations/service.go
+++ b/backend/internal/integrations/service.go
@@ -85,6 +85,7 @@ func (s *Service) CreateAPIClient(ctx context.Context, identity auth.Identity, i
 	if err != nil {
 		return nil, ErrInvalidInput
 	}
+	schemeUUIDs = dedupUUIDs(schemeUUIDs)
 	count, err := s.db.Q.CountSchemesByOrgAndIDs(ctx, dbgen.CountSchemesByOrgAndIDsParams{OrgID: orgID, SchemeIds: schemeUUIDs})
 	if err != nil {
 		return nil, err
@@ -181,6 +182,18 @@ func validScopes(scopes []string) bool {
 		}
 	}
 	return true
+}
+
+func dedupUUIDs(ids []uuid.UUID) []uuid.UUID {
+	seen := make(map[uuid.UUID]struct{}, len(ids))
+	result := make([]uuid.UUID, 0, len(ids))
+	for _, id := range ids {
+		if _, ok := seen[id]; !ok {
+			seen[id] = struct{}{}
+			result = append(result, id)
+		}
+	}
+	return result
 }
 
 func parseUUIDs(values []string) ([]uuid.UUID, error) {


### PR DESCRIPTION
Closes #201

Duplicate scheme_id values in create/update payloads caused COUNT(DISTINCT) to return fewer rows than len(input), producing a misleading 403 Forbidden. This deduplicates scheme UUIDs before counting so repeated valid IDs are accepted, matching the behaviour of multi-select UIs and client payloads that may merge arrays.