### PR TITLE
fix: wrap contractor create/update in a transaction with scheme links (#200)

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -69,12 +69,16 @@ jobs:
 
       - name: Install tools
         run: |
-          go install github.com/sqlc-dev/sqlc/cmd/sqlc@v1.30.0
+          go install github.com/sqlc-dev/sqlc/cmd/sqlc@v1.31.1
           go install github.com/pressly/goose/v3/cmd/goose@latest
           go install golang.org/x/vuln/cmd/govulncheck@latest
 
       - name: Generate sqlc
         run: cd db && sqlc generate
+
+      - name: sqlc drift check
+        run: |
+          git diff --exit-code -- db/gen/ || (echo "ERROR: sqlc generate produced changes. Run 'make generate' and commit the result." && exit 1)
 
       - name: Run migrations
         run: goose -dir db/migrations postgres "postgres://stratahq:stratahq@localhost:5432/stratahq_test?sslmode=disable" up

--- a/backend/README.md
+++ b/backend/README.md
@@ -25,7 +25,7 @@ Go backend for [StrataHQ](https://stratahq.com) — property management software
 
 - [Go 1.26.4+](https://go.dev/dl/)
 - [Docker](https://docs.docker.com/get-docker/) & Docker Compose
-- [sqlc](https://docs.sqlc.dev/en/latest/overview/install.html)
+- [sqlc](https://docs.sqlc.dev/en/latest/overview/install.html) v1.31.1 (`go install github.com/sqlc-dev/sqlc/cmd/sqlc@v1.31.1`)
 - [goose](https://github.com/pressly/goose#install)
 - [golangci-lint](https://golangci-lint.run/welcome/install/)
 


### PR DESCRIPTION
Closes #200

Contractor Create and Update wrote the contractor row and scheme links as separate non-transactional operations. A failure in replaceSchemeLinks could leave the contractor with missing or partial scheme associations. This wraps the insert/update and all scheme-link mutations in a single database transaction.