### PR TITLE
fix: wrap API client creation and scheme links in a transaction (#199)

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -69,12 +69,16 @@ jobs:
 
       - name: Install tools
         run: |
-          go install github.com/sqlc-dev/sqlc/cmd/sqlc@v1.30.0
+          go install github.com/sqlc-dev/sqlc/cmd/sqlc@v1.31.1
           go install github.com/pressly/goose/v3/cmd/goose@latest
           go install golang.org/x/vuln/cmd/govulncheck@latest
 
       - name: Generate sqlc
         run: cd db && sqlc generate
+
+      - name: sqlc drift check
+        run: |
+          git diff --exit-code -- db/gen/ || (echo "ERROR: sqlc generate produced changes. Run 'make generate' and commit the result." && exit 1)
 
       - name: Run migrations
         run: goose -dir db/migrations postgres "postgres://stratahq:stratahq@localhost:5432/stratahq_test?sslmode=disable" up

--- a/backend/README.md
+++ b/backend/README.md
@@ -25,7 +25,7 @@ Go backend for [StrataHQ](https://stratahq.com) — property management software
 
 - [Go 1.26.4+](https://go.dev/dl/)
 - [Docker](https://docs.docker.com/get-docker/) & Docker Compose
-- [sqlc](https://docs.sqlc.dev/en/latest/overview/install.html)
+- [sqlc](https://docs.sqlc.dev/en/latest/overview/install.html) v1.31.1 (`go install github.com/sqlc-dev/sqlc/cmd/sqlc@v1.31.1`)
 - [goose](https://github.com/pressly/goose#install)
 - [golangci-lint](https://golangci-lint.run/welcome/install/)
 

--- a/backend/internal/contractors/service.go
+++ b/backend/internal/contractors/service.go
@@ -119,11 +119,26 @@ func (s *Service) Create(ctx context.Context, identity auth.Identity, input Upse
 		return nil, err
 	}
 	params.CreatedByUserID = pgtype.UUID{Bytes: userID, Valid: true}
-	row, err := s.db.Q.CreateContractor(ctx, params)
+	var row dbgen.Contractor
+	err = database.WithTxQueries(ctx, s.db, func(q *dbgen.Queries) error {
+		var txErr error
+		row, txErr = q.CreateContractor(ctx, params)
+		if txErr != nil {
+			return mapDBError(txErr)
+		}
+		if txErr = q.DeleteContractorSchemeLinks(ctx, row.ID); txErr != nil {
+			return txErr
+		}
+		for _, schemeID := range schemeIDs {
+			if txErr = q.UpsertSchemeContractor(ctx, dbgen.UpsertSchemeContractorParams{
+				SchemeID: schemeID, ContractorID: row.ID, Preferred: false,
+			}); txErr != nil {
+				return txErr
+			}
+		}
+		return nil
+	})
 	if err != nil {
-		return nil, mapDBError(err)
-	}
-	if err := s.replaceSchemeLinks(ctx, row.ID, schemeIDs); err != nil {
 		return nil, err
 	}
 	return s.mapContractor(ctx, row, auth.IsAdminRole(identity.Role))
@@ -145,17 +160,32 @@ func (s *Service) Update(ctx context.Context, identity auth.Identity, contractor
 	if err != nil {
 		return nil, err
 	}
-	row, err := s.db.Q.UpdateContractor(ctx, dbgen.UpdateContractorParams{
-		ID: id, OrgID: orgID, Name: params.Name, Trade: params.Trade,
-		Phone: params.Phone, Email: params.Email, Suburb: params.Suburb,
-		City: params.City, Province: params.Province,
-		PublicProfile: params.PublicProfile, Vetted: params.Vetted,
-		Active: params.Active, Notes: params.Notes,
+	var row dbgen.Contractor
+	err = database.WithTxQueries(ctx, s.db, func(q *dbgen.Queries) error {
+		var txErr error
+		row, txErr = q.UpdateContractor(ctx, dbgen.UpdateContractorParams{
+			ID: id, OrgID: orgID, Name: params.Name, Trade: params.Trade,
+			Phone: params.Phone, Email: params.Email, Suburb: params.Suburb,
+			City: params.City, Province: params.Province,
+			PublicProfile: params.PublicProfile, Vetted: params.Vetted,
+			Active: params.Active, Notes: params.Notes,
+		})
+		if txErr != nil {
+			return mapDBError(txErr)
+		}
+		if txErr = q.DeleteContractorSchemeLinks(ctx, row.ID); txErr != nil {
+			return txErr
+		}
+		for _, schemeID := range schemeIDs {
+			if txErr = q.UpsertSchemeContractor(ctx, dbgen.UpsertSchemeContractorParams{
+				SchemeID: schemeID, ContractorID: row.ID, Preferred: false,
+			}); txErr != nil {
+				return txErr
+			}
+		}
+		return nil
 	})
 	if err != nil {
-		return nil, mapDBError(err)
-	}
-	if err := s.replaceSchemeLinks(ctx, row.ID, schemeIDs); err != nil {
 		return nil, err
 	}
 	return s.mapContractor(ctx, row, true)
@@ -387,20 +417,6 @@ func parseUUIDs(values []string) ([]uuid.UUID, error) {
 		ids = append(ids, id)
 	}
 	return ids, nil
-}
-
-func (s *Service) replaceSchemeLinks(ctx context.Context, contractorID uuid.UUID, schemeIDs []uuid.UUID) error {
-	if err := s.db.Q.DeleteContractorSchemeLinks(ctx, contractorID); err != nil {
-		return err
-	}
-	for _, schemeID := range schemeIDs {
-		if err := s.db.Q.UpsertSchemeContractor(ctx, dbgen.UpsertSchemeContractorParams{
-			SchemeID: schemeID, ContractorID: contractorID, Preferred: false,
-		}); err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 func (s *Service) mapContractor(ctx context.Context, row dbgen.Contractor, includePrivate bool) (*ContractorInfo, error) {

--- a/backend/internal/integrations/service.go
+++ b/backend/internal/integrations/service.go
@@ -100,22 +100,30 @@ func (s *Service) CreateAPIClient(ctx context.Context, identity auth.Identity, i
 	if input.ExpiresAt != nil {
 		expiresAt = pgtype.Timestamptz{Time: *input.ExpiresAt, Valid: true}
 	}
-	created, err := s.db.Q.CreateIntegrationAPIClient(ctx, dbgen.CreateIntegrationAPIClientParams{
-		OrgID:           orgID,
-		Name:            input.Name,
-		KeyPrefix:       generated.Prefix,
-		KeyHash:         generated.Hash,
-		Scopes:          scopeValues,
-		CreatedByUserID: pgtype.UUID{Bytes: userID, Valid: true},
-		ExpiresAt:       expiresAt,
+	var created dbgen.IntegrationApiClient
+	err = database.WithTxQueries(ctx, s.db, func(q *dbgen.Queries) error {
+		var txErr error
+		created, txErr = q.CreateIntegrationAPIClient(ctx, dbgen.CreateIntegrationAPIClientParams{
+			OrgID:           orgID,
+			Name:            input.Name,
+			KeyPrefix:       generated.Prefix,
+			KeyHash:         generated.Hash,
+			Scopes:          scopeValues,
+			CreatedByUserID: pgtype.UUID{Bytes: userID, Valid: true},
+			ExpiresAt:       expiresAt,
+		})
+		if txErr != nil {
+			return txErr
+		}
+		for _, schemeID := range schemeUUIDs {
+			if txErr = q.LinkIntegrationAPIClientScheme(ctx, dbgen.LinkIntegrationAPIClientSchemeParams{ClientID: created.ID, SchemeID: schemeID}); txErr != nil {
+				return txErr
+			}
+		}
+		return nil
 	})
 	if err != nil {
 		return nil, err
-	}
-	for _, schemeID := range schemeUUIDs {
-		if linkErr := s.db.Q.LinkIntegrationAPIClientScheme(ctx, dbgen.LinkIntegrationAPIClientSchemeParams{ClientID: created.ID, SchemeID: schemeID}); linkErr != nil {
-			return nil, linkErr
-		}
 	}
 	info, err := s.mapClient(ctx, created)
 	if err != nil {


### PR DESCRIPTION
Closes #199

CreateAPIClient inserted the client row separately from its scheme links, so a failed link insert left the client in an incomplete state. The raw API key was also returned to the caller before all state was committed. This wraps the full creation in a single database transaction.