### PR TITLE
fix: provision early-access accounts before marking requests approved (#208)

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -69,12 +69,16 @@ jobs:
 
       - name: Install tools
         run: |
-          go install github.com/sqlc-dev/sqlc/cmd/sqlc@v1.30.0
+          go install github.com/sqlc-dev/sqlc/cmd/sqlc@v1.31.1
           go install github.com/pressly/goose/v3/cmd/goose@latest
           go install golang.org/x/vuln/cmd/govulncheck@latest
 
       - name: Generate sqlc
         run: cd db && sqlc generate
+
+      - name: sqlc drift check
+        run: |
+          git diff --exit-code -- db/gen/ || (echo "ERROR: sqlc generate produced changes. Run 'make generate' and commit the result." && exit 1)
 
       - name: Run migrations
         run: goose -dir db/migrations postgres "postgres://stratahq:stratahq@localhost:5432/stratahq_test?sslmode=disable" up

--- a/backend/README.md
+++ b/backend/README.md
@@ -25,7 +25,7 @@ Go backend for [StrataHQ](https://stratahq.com) — property management software
 
 - [Go 1.26.4+](https://go.dev/dl/)
 - [Docker](https://docs.docker.com/get-docker/) & Docker Compose
-- [sqlc](https://docs.sqlc.dev/en/latest/overview/install.html)
+- [sqlc](https://docs.sqlc.dev/en/latest/overview/install.html) v1.31.1 (`go install github.com/sqlc-dev/sqlc/cmd/sqlc@v1.31.1`)
 - [goose](https://github.com/pressly/goose#install)
 - [golangci-lint](https://golangci-lint.run/welcome/install/)
 

--- a/backend/internal/earlyaccess/service.go
+++ b/backend/internal/earlyaccess/service.go
@@ -183,7 +183,8 @@ func (s *Service) Approve(ctx context.Context, id string) (*RequestResponse, err
 		return nil, ErrAlreadyReviewed
 	}
 
-	if err := s.sendApproval(ctx, request); err != nil {
+	err = s.sendApproval(ctx, request)
+	if err != nil {
 		return nil, err
 	}
 
@@ -273,7 +274,8 @@ func (s *Service) approveWithoutContextAuth(ctx context.Context, id string) (*Re
 		return nil, ErrAlreadyReviewed
 	}
 
-	if err := s.sendApproval(ctx, request); err != nil {
+	err = s.sendApproval(ctx, request)
+	if err != nil {
 		return nil, err
 	}
 

--- a/backend/internal/earlyaccess/service.go
+++ b/backend/internal/earlyaccess/service.go
@@ -168,12 +168,27 @@ func (s *Service) Approve(ctx context.Context, id string) (*RequestResponse, err
 		return nil, err
 	}
 
-	updated, err := s.transitionPendingReview(ctx, id, dbgen.EarlyAccessStatusApproved)
+	uid, err := uuid.Parse(id)
 	if err != nil {
+		return nil, ErrNotFound
+	}
+	request, err := s.db.GetEarlyAccessRequest(ctx, uid)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	if request.Status != dbgen.EarlyAccessStatusPending {
+		return nil, ErrAlreadyReviewed
+	}
+
+	if err := s.sendApproval(ctx, request); err != nil {
 		return nil, err
 	}
 
-	if err := s.sendApproval(ctx, updated); err != nil {
+	updated, err := s.transitionPendingReview(ctx, id, dbgen.EarlyAccessStatusApproved)
+	if err != nil {
 		return nil, err
 	}
 
@@ -243,12 +258,27 @@ func (s *Service) authorizeProtectedAdmin(ctx context.Context) error {
 }
 
 func (s *Service) approveWithoutContextAuth(ctx context.Context, id string) (*RequestResponse, error) {
-	updated, err := s.transitionPendingReview(ctx, id, dbgen.EarlyAccessStatusApproved)
+	uid, err := uuid.Parse(id)
 	if err != nil {
+		return nil, ErrNotFound
+	}
+	request, err := s.db.GetEarlyAccessRequest(ctx, uid)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	if request.Status != dbgen.EarlyAccessStatusPending {
+		return nil, ErrAlreadyReviewed
+	}
+
+	if err := s.sendApproval(ctx, request); err != nil {
 		return nil, err
 	}
 
-	if err := s.sendApproval(ctx, updated); err != nil {
+	updated, err := s.transitionPendingReview(ctx, id, dbgen.EarlyAccessStatusApproved)
+	if err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Closes #208

Approval callbacks set the request status to approved before calling sendApproval, so a provider failure during registration or email delivery left an approved request with no provisioned account. This reorders the flow to register the user and send the email first, only updating status after successful provisioning.