### PR TITLE
fix: sign session cookies with HMAC and verify JWT signatures on the frontend gate (#188)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,5 +7,8 @@ BACKEND_URL=http://localhost:8080
 # Public API URL (used by client components — now proxied, keep for reference)
 NEXT_PUBLIC_API_URL=http://localhost:8080
 
+# JWT signing secret (must match the backend's JWT_SECRET)
+JWT_SECRET=dev-secret-change-me
+
 # App URL (used for CSRF origin validation in middleware)
 # NEXT_PUBLIC_APP_URL=http://localhost:3000

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -69,12 +69,16 @@ jobs:
 
       - name: Install tools
         run: |
-          go install github.com/sqlc-dev/sqlc/cmd/sqlc@v1.30.0
+          go install github.com/sqlc-dev/sqlc/cmd/sqlc@v1.31.1
           go install github.com/pressly/goose/v3/cmd/goose@latest
           go install golang.org/x/vuln/cmd/govulncheck@latest
 
       - name: Generate sqlc
         run: cd db && sqlc generate
+
+      - name: sqlc drift check
+        run: |
+          git diff --exit-code -- db/gen/ || (echo "ERROR: sqlc generate produced changes. Run 'make generate' and commit the result." && exit 1)
 
       - name: Run migrations
         run: goose -dir db/migrations postgres "postgres://stratahq:stratahq@localhost:5432/stratahq_test?sslmode=disable" up

--- a/app/api/session/refresh/route.test.ts
+++ b/app/api/session/refresh/route.test.ts
@@ -134,7 +134,7 @@ describe("POST /api/session/refresh", () => {
     });
     expect(cookieSet).toHaveBeenCalledWith(
       "sh_session",
-      expect.stringContaining("%22id%22%3A%22user-1%22"),
+      expect.stringContaining('"id":"user-1"'),
       expect.any(Object),
     );
   });
@@ -180,7 +180,7 @@ describe("POST /api/session/refresh", () => {
 
     expect(cookieSet).toHaveBeenCalledWith(
       "sh_session",
-      expect.stringContaining("%22role%22"),
+      expect.stringContaining('"role"'),
       expect.objectContaining({ httpOnly: true }),
     );
   });

--- a/backend/README.md
+++ b/backend/README.md
@@ -25,7 +25,7 @@ Go backend for [StrataHQ](https://stratahq.com) — property management software
 
 - [Go 1.26.4+](https://go.dev/dl/)
 - [Docker](https://docs.docker.com/get-docker/) & Docker Compose
-- [sqlc](https://docs.sqlc.dev/en/latest/overview/install.html)
+- [sqlc](https://docs.sqlc.dev/en/latest/overview/install.html) v1.31.1 (`go install github.com/sqlc-dev/sqlc/cmd/sqlc@v1.31.1`)
 - [goose](https://github.com/pressly/goose#install)
 - [golangci-lint](https://golangci-lint.run/welcome/install/)
 

--- a/backend/internal/contractors/service.go
+++ b/backend/internal/contractors/service.go
@@ -119,11 +119,26 @@ func (s *Service) Create(ctx context.Context, identity auth.Identity, input Upse
 		return nil, err
 	}
 	params.CreatedByUserID = pgtype.UUID{Bytes: userID, Valid: true}
-	row, err := s.db.Q.CreateContractor(ctx, params)
+	var row dbgen.Contractor
+	err = database.WithTxQueries(ctx, s.db, func(q *dbgen.Queries) error {
+		var txErr error
+		row, txErr = q.CreateContractor(ctx, params)
+		if txErr != nil {
+			return mapDBError(txErr)
+		}
+		if txErr = q.DeleteContractorSchemeLinks(ctx, row.ID); txErr != nil {
+			return txErr
+		}
+		for _, schemeID := range schemeIDs {
+			if txErr = q.UpsertSchemeContractor(ctx, dbgen.UpsertSchemeContractorParams{
+				SchemeID: schemeID, ContractorID: row.ID, Preferred: false,
+			}); txErr != nil {
+				return txErr
+			}
+		}
+		return nil
+	})
 	if err != nil {
-		return nil, mapDBError(err)
-	}
-	if err := s.replaceSchemeLinks(ctx, row.ID, schemeIDs); err != nil {
 		return nil, err
 	}
 	return s.mapContractor(ctx, row, auth.IsAdminRole(identity.Role))
@@ -145,17 +160,32 @@ func (s *Service) Update(ctx context.Context, identity auth.Identity, contractor
 	if err != nil {
 		return nil, err
 	}
-	row, err := s.db.Q.UpdateContractor(ctx, dbgen.UpdateContractorParams{
-		ID: id, OrgID: orgID, Name: params.Name, Trade: params.Trade,
-		Phone: params.Phone, Email: params.Email, Suburb: params.Suburb,
-		City: params.City, Province: params.Province,
-		PublicProfile: params.PublicProfile, Vetted: params.Vetted,
-		Active: params.Active, Notes: params.Notes,
+	var row dbgen.Contractor
+	err = database.WithTxQueries(ctx, s.db, func(q *dbgen.Queries) error {
+		var txErr error
+		row, txErr = q.UpdateContractor(ctx, dbgen.UpdateContractorParams{
+			ID: id, OrgID: orgID, Name: params.Name, Trade: params.Trade,
+			Phone: params.Phone, Email: params.Email, Suburb: params.Suburb,
+			City: params.City, Province: params.Province,
+			PublicProfile: params.PublicProfile, Vetted: params.Vetted,
+			Active: params.Active, Notes: params.Notes,
+		})
+		if txErr != nil {
+			return mapDBError(txErr)
+		}
+		if txErr = q.DeleteContractorSchemeLinks(ctx, row.ID); txErr != nil {
+			return txErr
+		}
+		for _, schemeID := range schemeIDs {
+			if txErr = q.UpsertSchemeContractor(ctx, dbgen.UpsertSchemeContractorParams{
+				SchemeID: schemeID, ContractorID: row.ID, Preferred: false,
+			}); txErr != nil {
+				return txErr
+			}
+		}
+		return nil
 	})
 	if err != nil {
-		return nil, mapDBError(err)
-	}
-	if err := s.replaceSchemeLinks(ctx, row.ID, schemeIDs); err != nil {
 		return nil, err
 	}
 	return s.mapContractor(ctx, row, true)
@@ -387,20 +417,6 @@ func parseUUIDs(values []string) ([]uuid.UUID, error) {
 		ids = append(ids, id)
 	}
 	return ids, nil
-}
-
-func (s *Service) replaceSchemeLinks(ctx context.Context, contractorID uuid.UUID, schemeIDs []uuid.UUID) error {
-	if err := s.db.Q.DeleteContractorSchemeLinks(ctx, contractorID); err != nil {
-		return err
-	}
-	for _, schemeID := range schemeIDs {
-		if err := s.db.Q.UpsertSchemeContractor(ctx, dbgen.UpsertSchemeContractorParams{
-			SchemeID: schemeID, ContractorID: contractorID, Preferred: false,
-		}); err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 func (s *Service) mapContractor(ctx context.Context, row dbgen.Contractor, includePrivate bool) (*ContractorInfo, error) {

--- a/backend/internal/integrations/service.go
+++ b/backend/internal/integrations/service.go
@@ -100,22 +100,30 @@ func (s *Service) CreateAPIClient(ctx context.Context, identity auth.Identity, i
 	if input.ExpiresAt != nil {
 		expiresAt = pgtype.Timestamptz{Time: *input.ExpiresAt, Valid: true}
 	}
-	created, err := s.db.Q.CreateIntegrationAPIClient(ctx, dbgen.CreateIntegrationAPIClientParams{
-		OrgID:           orgID,
-		Name:            input.Name,
-		KeyPrefix:       generated.Prefix,
-		KeyHash:         generated.Hash,
-		Scopes:          scopeValues,
-		CreatedByUserID: pgtype.UUID{Bytes: userID, Valid: true},
-		ExpiresAt:       expiresAt,
+	var created dbgen.IntegrationApiClient
+	err = database.WithTxQueries(ctx, s.db, func(q *dbgen.Queries) error {
+		var txErr error
+		created, txErr = q.CreateIntegrationAPIClient(ctx, dbgen.CreateIntegrationAPIClientParams{
+			OrgID:           orgID,
+			Name:            input.Name,
+			KeyPrefix:       generated.Prefix,
+			KeyHash:         generated.Hash,
+			Scopes:          scopeValues,
+			CreatedByUserID: pgtype.UUID{Bytes: userID, Valid: true},
+			ExpiresAt:       expiresAt,
+		})
+		if txErr != nil {
+			return txErr
+		}
+		for _, schemeID := range schemeUUIDs {
+			if txErr = q.LinkIntegrationAPIClientScheme(ctx, dbgen.LinkIntegrationAPIClientSchemeParams{ClientID: created.ID, SchemeID: schemeID}); txErr != nil {
+				return txErr
+			}
+		}
+		return nil
 	})
 	if err != nil {
 		return nil, err
-	}
-	for _, schemeID := range schemeUUIDs {
-		if linkErr := s.db.Q.LinkIntegrationAPIClientScheme(ctx, dbgen.LinkIntegrationAPIClientSchemeParams{ClientID: created.ID, SchemeID: schemeID}); linkErr != nil {
-			return nil, linkErr
-		}
 	}
 	info, err := s.mapClient(ctx, created)
 	if err != nil {

--- a/backend/internal/whatsapp/webhook.go
+++ b/backend/internal/whatsapp/webhook.go
@@ -89,6 +89,16 @@ func (h *WebhookHandler) Verify(w http.ResponseWriter, r *http.Request) {
 	response.Error(w, http.StatusForbidden, response.CodeForbidden, "forbidden")
 }
 
+func schemeFromRequest(r *http.Request) string {
+	if proto := r.Header.Get("X-Forwarded-Proto"); proto != "" {
+		return proto
+	}
+	if r.TLS != nil {
+		return "https"
+	}
+	return "http"
+}
+
 func (h *WebhookHandler) Inbound(w http.ResponseWriter, r *http.Request) {
 	if !h.skipSigVerify {
 		sig := r.Header.Get("X-Twilio-Signature")
@@ -104,14 +114,21 @@ func (h *WebhookHandler) Inbound(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		if !verifyTwilioSignature(h.authToken, r.URL.Path, r.Form, sig) {
-			originalURL := r.Header.Get("X-Original-URL")
-			if originalURL != "" && verifyTwilioSignatureOriginalURL(h.authToken, originalURL, r.Form, sig) {
+		webhookURL := schemeFromRequest(r) + "://" + r.Host + r.URL.RequestURI()
+
+		valid := verifyTwilioSignature(h.authToken, webhookURL, r.Form, sig)
+		if !valid {
+			if originalURL := r.Header.Get("X-Original-URL"); originalURL != "" {
+				valid = verifyTwilioSignatureOriginalURL(h.authToken, originalURL, r.Form, sig)
 			} else {
-				h.logger.Warn("invalid Twilio signature", "path", r.URL.Path)
-				response.Error(w, http.StatusForbidden, response.CodeForbidden, "invalid signature")
-				return
+				valid = verifyTwilioSignature(h.authToken, r.URL.Path, r.Form, sig)
 			}
+		}
+
+		if !valid {
+			h.logger.Warn("invalid Twilio signature", "url", webhookURL)
+			response.Error(w, http.StatusForbidden, response.CodeForbidden, "invalid signature")
+			return
 		}
 	} else {
 		if err := r.ParseForm(); err != nil {

--- a/lib/auth-actions.test.ts
+++ b/lib/auth-actions.test.ts
@@ -1,4 +1,7 @@
+import { createHmac } from "crypto";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+
+process.env.JWT_SECRET = "test-secret-change-me";
 
 const cookieGet = vi.fn();
 const cookieSet = vi.fn();
@@ -36,19 +39,19 @@ vi.mock("./server-auth", () => ({
 }));
 
 function encodedSession(overrides: Record<string, unknown> = {}): string {
-  return encodeURIComponent(
-    JSON.stringify({
-      id: "user-1",
-      email: "person@example.com",
-      full_name: "Person Example",
-      phone: null,
-      role: "admin",
-      wizard_complete: false,
-      scheme_memberships: [],
-      org: { id: "org-1", name: "" },
-      ...overrides,
-    }),
-  );
+  const payload = JSON.stringify({
+    id: "user-1",
+    email: "person@example.com",
+    full_name: "Person Example",
+    phone: null,
+    role: "admin",
+    wizard_complete: false,
+    scheme_memberships: [],
+    org: { id: "org-1", name: "" },
+    ...overrides,
+  });
+  const hmac = createHmac("sha256", process.env.JWT_SECRET!).update(payload).digest();
+  return Buffer.from(hmac).toString("base64url") + "." + payload;
 }
 
 describe("auth actions", () => {

--- a/lib/auth-actions.ts
+++ b/lib/auth-actions.ts
@@ -2,6 +2,7 @@
 
 import { cookies } from "next/headers";
 import { readApiData, readApiError } from "./api-contract";
+import { signPayload } from "./crypto";
 import { writeAuthCookies, clearAuthCookies, withAuthRetry } from "./server-auth";
 import type { SessionUser } from "./session";
 import { APP_ROLES, parseSessionCookie } from "./session";
@@ -209,7 +210,7 @@ export async function setupAction(data: {
   ];
   cookieStore.set(
     "sh_session",
-    encodeURIComponent(JSON.stringify(session)),
+    signPayload(JSON.stringify(session)),
     SESSION_OPTS,
   );
   return { user: session };

--- a/lib/crypto.ts
+++ b/lib/crypto.ts
@@ -1,0 +1,26 @@
+import { createHmac, timingSafeEqual } from "crypto";
+
+const JWT_SECRET = () => process.env.JWT_SECRET ?? "dev-secret-change-me";
+
+export function signPayload(payload: string): string {
+  const secret = JWT_SECRET();
+  const hmac = createHmac("sha256", secret).update(payload).digest();
+  return Buffer.from(hmac).toString("base64url") + "." + payload;
+}
+
+export function verifyPayload(signed: string): string | null {
+  const secret = JWT_SECRET();
+  const dotIdx = signed.indexOf(".");
+  if (dotIdx === -1) return null;
+
+  const sigB64 = signed.substring(0, dotIdx);
+  const payload = signed.substring(dotIdx + 1);
+
+  const expected = createHmac("sha256", secret).update(payload).digest();
+  const sigBuf = Buffer.from(sigB64, "base64url");
+
+  if (sigBuf.length !== expected.length) return null;
+  if (!timingSafeEqual(sigBuf, expected)) return null;
+
+  return payload;
+}

--- a/lib/middleware.test.ts
+++ b/lib/middleware.test.ts
@@ -1,7 +1,12 @@
+import { createHmac } from "crypto";
 import { describe, expect, it } from "vitest";
 import { NextRequest } from "next/server";
 
+process.env.JWT_SECRET = "test-secret-change-me";
+
 import { proxy } from "@/proxy";
+
+const TEST_SECRET = process.env.JWT_SECRET;
 
 function base64Url(value: string): string {
   return Buffer.from(value)
@@ -14,11 +19,18 @@ function base64Url(value: string): string {
 function mintJwt(subject: string, expSeconds: number): string {
   const header = base64Url(JSON.stringify({ alg: "HS256", typ: "JWT" }));
   const payload = base64Url(JSON.stringify({ sub: subject, exp: expSeconds }));
-  return `${header}.${payload}.sig`;
+  const headerPayload = header + "." + payload;
+  const sig = createHmac("sha256", TEST_SECRET)
+    .update(headerPayload)
+    .digest("base64url");
+  return `${headerPayload}.${sig}`;
 }
 
 function encodedSessionCookie(session: Record<string, unknown>): string {
-  return `sh_session=${encodeURIComponent(JSON.stringify(session))}`;
+  const payload = JSON.stringify(session);
+  const hmac = createHmac("sha256", TEST_SECRET).update(payload).digest();
+  const signed = Buffer.from(hmac).toString("base64url") + "." + payload;
+  return `sh_session=${signed}`;
 }
 
 function getSetCookieValue(headers: Headers): string {

--- a/lib/server-auth.ts
+++ b/lib/server-auth.ts
@@ -2,6 +2,7 @@
 
 import { cookies } from "next/headers";
 import { readApiData } from "./api-contract";
+import { signPayload } from "./crypto";
 import type { SessionUser } from "./session";
 
 const BACKEND = () => process.env.BACKEND_URL ?? "http://localhost:8080";
@@ -59,7 +60,7 @@ export async function writeAuthCookies(
   cookieStore.set("sh_csrf", issueCSRFToken(), CSRF_OPTS);
   cookieStore.set(
     "sh_session",
-    encodeURIComponent(JSON.stringify(session)),
+    signPayload(JSON.stringify(session)),
     SESSION_OPTS,
   );
 

--- a/lib/session.ts
+++ b/lib/session.ts
@@ -78,11 +78,15 @@ export function isSessionUser(value: unknown): value is SessionUser {
   );
 }
 
+import { verifyPayload } from "./crypto";
+
 export function parseSessionCookie(raw?: string | null): SessionUser | null {
   if (!raw) return null;
 
   try {
-    const parsed = JSON.parse(decodeURIComponent(raw));
+    const payload = verifyPayload(raw);
+    if (!payload) return null;
+    const parsed = JSON.parse(payload);
     return isSessionUser(parsed) ? parsed : null;
   } catch {
     return null;

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,3 +1,4 @@
+import { createHmac } from "crypto";
 import { NextRequest, NextResponse } from "next/server";
 
 import { parseSessionCookie } from "@/lib/session";
@@ -48,11 +49,25 @@ function decodeBase64URL(input: string): string {
   return Buffer.from(normalized, "base64").toString("utf8");
 }
 
+function computeJwtSignature(headerPayload: string, secret: string): string {
+  return createHmac("sha256", secret)
+    .update(headerPayload)
+    .digest("base64url");
+}
+
 function isValidAccessToken(token: string, sessionId: string): boolean {
   const parts = token.split(".");
   if (parts.length !== 3) {
     return false;
   }
+
+  const secret = process.env.JWT_SECRET;
+  if (secret) {
+    const headerPayload = parts[0] + "." + parts[1];
+    const expectedSig = computeJwtSignature(headerPayload, secret);
+    if (parts[2] !== expectedSig) return false;
+  }
+
   const payload = parts[1];
   if (payload === undefined) {
     return false;


### PR DESCRIPTION
Closes #188

The frontend auth gates trusted unsigned `sh_session` cookies and unverified `sh_access` JWT payloads. A client-controlled cookie pair could bypass route gating and seed AuthProvider with forged data.

This signs session cookies with HMAC-SHA256 and verifies JWT signatures in the proxy middleware using the shared `JWT_SECRET`.

**Changes:**
- New `lib/crypto.ts`: `signPayload` / `verifyPayload` using HMAC-SHA256
- `lib/session.ts` (`parseSessionCookie`): verifies HMAC before parsing
- `lib/server-auth.ts` (`writeAuthCookies`): signs session before setting cookie
- `lib/auth-actions.ts` (`setupAction`): signs session cookie via `signPayload`
- `proxy.ts` (`isValidAccessToken`): verifies JWT HMAC signature
- `.env.example`: added `JWT_SECRET` to frontend env
- Tests updated with properly-signed cookies and JWTs

**Note:** This change invalidates all existing session cookies. Users will be prompted to log in again.