### PR TITLE
fix: validate session JSON with isSessionUser runtime guard

### DIFF
--- a/lib/auth.tsx
+++ b/lib/auth.tsx
@@ -3,7 +3,7 @@
 import React, { createContext, useContext, useEffect, useState } from "react";
 import { logoutAction } from "./auth-actions";
 import { readBrowserCSRFToken } from "./csrf";
-import type { SessionUser } from "./session";
+import { isSessionUser, type SessionUser } from "./session";
 
 interface AuthContextValue {
   user: SessionUser | null;
@@ -47,7 +47,8 @@ export function AuthProvider({ children, initialUser }: AuthProviderProps) {
           return null;
         }
 
-        return (await refreshResponse.json()) as SessionUser | null;
+        const raw = await refreshResponse.json();
+        return isSessionUser(raw) ? raw : null;
       } catch {
         if (controller.signal.aborted) {
           return null;
@@ -64,7 +65,8 @@ export function AuthProvider({ children, initialUser }: AuthProviderProps) {
         const sessionResponse = await fetch("/api/session", {
           signal: controller.signal,
         });
-        const session = (await sessionResponse.json()) as SessionUser | null;
+        const raw = await sessionResponse.json();
+        const session = isSessionUser(raw) ? raw : null;
         if (session) {
           if (active) setUser(session);
           return;


### PR DESCRIPTION
Closes #545

Replaces unsafe `as SessionUser | null` type casts in `loadSession()` and `tryRefreshSession()` with the existing `isSessionUser()` runtime type guard. This prevents crashes when the API returns malformed or unexpected data.