### PR TITLE
fix: display actual error message in portfolio error boundary

### DIFF
--- a/app/agent/error.tsx
+++ b/app/agent/error.tsx
@@ -3,6 +3,7 @@
 import RetryState from "@/components/RetryState";
 
 export default function Error({
+  error,
   reset,
 }: {
   error: Error;
@@ -11,7 +12,7 @@ export default function Error({
   return (
     <RetryState
       title="Could not load portfolio overview"
-      message="Temporary service issue. Try again."
+      message={error.message || "Temporary service issue. Try again."}
       onRetry={() => reset()}
     />
   );


### PR DESCRIPTION
Closes #548

The error boundary component in `app/agent/error.tsx` was ignoring the `error: Error` prop and always showing a hardcoded "Temporary service issue" message. This fix surfaces the actual error message so users get actionable feedback.