### PR TITLE
fix: add unmount guards to async effects in settings and early-access pages

### DIFF
--- a/app/admin/early-access/page.tsx
+++ b/app/admin/early-access/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import {
   listEarlyAccessRequests,
   approveEarlyAccessRequest,
@@ -19,21 +19,30 @@ export default function AdminEarlyAccessPage() {
   const [loading, setLoading] = useState(true)
   const [working, setWorking] = useState<string | null>(null)
   const [error, setError] = useState('')
+  const mountedRef = useRef(true)
 
   async function load() {
     setLoading(true)
     try {
       const data = await listEarlyAccessRequests()
+      if (!mountedRef.current) return
       setRequests(data)
     } catch (err) {
+      if (!mountedRef.current) return
       setError(err instanceof Error ? err.message : 'Failed to load early access requests')
       setRequests([])
     } finally {
-      setLoading(false)
+      if (mountedRef.current) setLoading(false)
     }
   }
 
-  useEffect(() => { load() }, [])
+  useEffect(() => {
+    mountedRef.current = true
+    load()
+    return () => {
+      mountedRef.current = false
+    }
+  }, [])
 
   async function handleApprove(id: string) {
     setError('')

--- a/app/app/[schemeId]/settings/page.tsx
+++ b/app/app/[schemeId]/settings/page.tsx
@@ -65,9 +65,12 @@ export default function SchemeSettingsPage() {
   const canEdit = user?.role === 'admin'
 
   useEffect(() => {
+    let cancelled = false
+
     async function load() {
       try {
         const detail = await getScheme(schemeId)
+        if (cancelled) return
         setScheme(detail)
         setSchemeForm({
           name: detail.name,
@@ -75,16 +78,21 @@ export default function SchemeSettingsPage() {
           unit_count: String(detail.unit_count),
         })
       } catch (error) {
+        if (cancelled) return
         addToast(
           error instanceof Error ? error.message : 'Failed to load scheme',
           'error',
         )
       } finally {
-        setLoading(false)
+        if (!cancelled) setLoading(false)
       }
     }
 
     load()
+
+    return () => {
+      cancelled = true
+    }
   }, [addToast, schemeId])
 
   async function handleSchemeSave() {


### PR DESCRIPTION
Closes #549

Adds `cancelled`/`mountedRef` flags to async `useEffect` load functions in:
- `app/app/[schemeId]/settings/page.tsx` — scheme settings loader
- `app/admin/early-access/page.tsx` — early access requests loader

Prevents React warnings and state update races when components unmount mid-fetch.