### PR TITLE
fix: block path traversal via ../ in login redirect validation

### DIFF
--- a/app/auth/login/page.tsx
+++ b/app/auth/login/page.tsx
@@ -14,6 +14,7 @@ function LoginForm() {
     redirectParam &&
     redirectParam.startsWith("/") &&
     !redirectParam.startsWith("//") &&
+    !redirectParam.includes("../") &&
     // eslint-disable-next-line no-control-regex
     !/[\x00-\x1F\x7F]/.test(redirectParam);
 


### PR DESCRIPTION
Closes #550

Adds `../` detection to the `isSafeRedirect` check in the login form to prevent malicious redirect URLs from path-traversing outside the expected app paths.