### PR TITLE
fix: save and restore original body overflow value in AppShell

### DIFF
--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -29,8 +29,9 @@ export default function AppShell({ sidebar, children, headerLabel }: AppShellPro
 
   // Prevent body scroll when mobile sidebar is open
   useEffect(() => {
+    const original = document.body.style.overflow
     document.body.style.overflow = sidebarOpen ? 'hidden' : ''
-    return () => { document.body.style.overflow = '' }
+    return () => { document.body.style.overflow = original }
   }, [sidebarOpen])
 
   return (


### PR DESCRIPTION
Closes #551

Saves the original `document.body.style.overflow` value before overriding it for the sidebar state, then restores it on cleanup instead of blindly resetting to `"""`. Preserves any overflow value set by other scripts or components.